### PR TITLE
Fix security findings: complete redaction, tighten Azure pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ npx secretless-ai init
 Output:
 
 ```
-  Secretless v0.2.0
+  Secretless v0.3.0
   Keeping secrets out of AI
 
   Detected:
@@ -173,6 +173,15 @@ For Claude Code, Secretless installs a PreToolUse hook that intercepts every `Re
 ```
 
 Additionally, Secretless adds `permissions.deny` rules to `.claude/settings.json` as a second layer of defense, and adds instructions to `CLAUDE.md` so Claude understands why certain files are blocked.
+
+## Development
+
+```bash
+npm run build      # Compile TypeScript to dist/
+npm test           # Run tests (vitest)
+npm run dev        # Watch mode — recompile on file changes
+npm run clean      # Remove dist/ directory
+```
 
 ## Requirements
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,8 @@ import { status } from './status';
 import { verify } from './verify';
 import { toolDisplayName } from './detect';
 
-const VERSION = '0.3.0';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { version: VERSION } = require('../package.json');
 
 function main(): void {
   const args = process.argv.slice(2);

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -22,7 +22,7 @@ export const CREDENTIAL_PATTERNS: CredentialPattern[] = [
   { id: 'stripe', name: 'Stripe Live Key', regex: /sk_live_[0-9a-zA-Z]{24,}/, envPrefix: 'STRIPE_SECRET_KEY' },
   { id: 'sendgrid', name: 'SendGrid Key', regex: /SG\.[a-zA-Z0-9_-]{22}\.[a-zA-Z0-9_-]{43}/, envPrefix: 'SENDGRID_API_KEY' },
   { id: 'supabase', name: 'Supabase Service Key', regex: /eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\.[a-zA-Z0-9_-]{50,}/, envPrefix: 'SUPABASE_SERVICE_ROLE_KEY' },
-  { id: 'azure', name: 'Azure Key', regex: /[a-zA-Z0-9+/]{43}=/, envPrefix: 'AZURE_API_KEY' },
+  { id: 'azure', name: 'Azure Key', regex: /(?:AccountKey|SharedAccessKey|azure[_-]?(?:storage|key|account))\s*[=:]\s*[a-zA-Z0-9+/]{43}=/i, envPrefix: 'AZURE_API_KEY' },
 ];
 
 /** File patterns that should never be read by AI tools */

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -51,7 +51,8 @@ export function scan(projectDir: string, options?: ScanOptions): ScanFinding[] {
         if (/\$\{[A-Z_]+\}/.test(line) && !/sk-ant|sk-proj|AKIA|ghp_|xox[baprs]/.test(line)) continue;
         for (const pattern of CREDENTIAL_PATTERNS) {
           if (pattern.regex.test(line)) {
-            const masked = line.replace(pattern.regex, `[${pattern.name} REDACTED]`);
+            const globalRegex = new RegExp(pattern.regex.source, pattern.regex.flags.includes('g') ? pattern.regex.flags : pattern.regex.flags + 'g');
+            const masked = line.replace(globalRegex, `[${pattern.name} REDACTED]`);
             findings.push({
               file: global.label,
               line: i + 1,
@@ -91,8 +92,9 @@ export function scan(projectDir: string, options?: ScanOptions): ScanFinding[] {
 
         for (const pattern of CREDENTIAL_PATTERNS) {
           if (pattern.regex.test(line)) {
-            // Mask the actual secret in the preview
-            const masked = line.replace(pattern.regex, `[${pattern.name} REDACTED]`);
+            // Mask the actual secret in the preview (replace ALL occurrences)
+            const globalRegex = new RegExp(pattern.regex.source, pattern.regex.flags.includes('g') ? pattern.regex.flags : pattern.regex.flags + 'g');
+            const masked = line.replace(globalRegex, `[${pattern.name} REDACTED]`);
 
             findings.push({
               file: configFile,

--- a/src/status.ts
+++ b/src/status.ts
@@ -49,7 +49,7 @@ export function status(projectDir: string): StatusResult {
     if (fs.existsSync(filePath)) {
       try {
         const content = fs.readFileSync(filePath, 'utf-8');
-        if (content.includes('secretless-ai:managed') || content.includes('Secretless AI')) {
+        if (content.includes('secretless:managed') || content.includes('Secretless AI')) {
           result.configuredTools.push(tool.tool);
         }
       } catch {
@@ -63,7 +63,7 @@ export function status(projectDir: string): StatusResult {
   if (fs.existsSync(claudeMd)) {
     try {
       const content = fs.readFileSync(claudeMd, 'utf-8');
-      if (content.includes('secretless-ai:managed') && !result.configuredTools.includes('claude-code')) {
+      if (content.includes('secretless:managed') && !result.configuredTools.includes('claude-code')) {
         result.configuredTools.push('claude-code');
       }
     } catch {


### PR DESCRIPTION
## Summary
- **[HIGH]** Fix incomplete redaction: secrets appearing multiple times on one line are now fully redacted by creating a global-flag regex for the replacement step
- **[HIGH]** Tighten Azure key pattern to require contextual prefix (`AccountKey`, `SharedAccessKey`, `azure_storage`, etc.), eliminating false positives on generic base64 strings
- **[MEDIUM]** Fix status marker mismatch — `status.ts` now looks for `secretless:managed` to match what `init.ts` writes
- **[MEDIUM]** Add Development section to README with `clean` and `dev` (watch) command documentation; fix version from v0.2.0 to v0.3.0
- **[LOW]** Replace hardcoded VERSION constant in `cli.ts` with dynamic import from `package.json`

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (27 tests)
- [x] Verify: string with duplicate secrets is fully redacted (global regex in scan.ts)
- [x] Verify: generic base64 strings are NOT matched by the updated Azure pattern
- [x] Verify: `status()` correctly detects protection after `init()` (marker alignment)