### PR TITLE
Document CLI integration and ecosystem references

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,6 @@ Secretless has zero runtime dependencies.
 | [**HackMyAgent**](https://github.com/opena2a-org/hackmyagent) | Security scanner -- 147 checks, attack mode, auto-fix | `npx hackmyagent secure` |
 | [**OASB**](https://github.com/opena2a-org/oasb) | Open Agent Security Benchmark -- 182 attack scenarios | `npm install @opena2a/oasb` |
 | [**ARP**](https://github.com/opena2a-org/arp) | Agent Runtime Protection -- process, network, filesystem monitoring | `npm install @opena2a/arp` |
-| [**Secretless AI**](https://github.com/opena2a-org/secretless-ai) | Keep credentials out of AI context windows | `npx secretless-ai init` |
 | [**DVAA**](https://github.com/opena2a-org/damn-vulnerable-ai-agent) | Damn Vulnerable AI Agent -- security training and red-teaming | `docker pull opena2a/dvaa` |
 
 ## License


### PR DESCRIPTION
## Summary
- Add CLI adapter documentation for Secretless AI integration with OpenA2A CLI
- Fix self-referencing ecosystem table entries

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm links to CLI docs resolve