### PR TITLE
Harden against adversarial bypass attempts

### DIFF
--- a/src/backends/local.ts
+++ b/src/backends/local.ts
@@ -82,7 +82,9 @@ export class LocalBackend implements WritableSecretBackend {
 
     store[key] = value;
     const encrypted = this.encrypt(JSON.stringify(store));
-    fs.writeFileSync(storePath, encrypted, { mode: 0o600 });
+    const tmpStorePath = storePath + '.tmp';
+    fs.writeFileSync(tmpStorePath, encrypted, { mode: 0o600 });
+    fs.renameSync(tmpStorePath, storePath);
 
     // Update metadata
     const metaPath = path.join(this.storeDir, META_FILE);
@@ -94,7 +96,9 @@ export class LocalBackend implements WritableSecretBackend {
     } catch { /* ignore */ }
 
     meta.entries[key] = { createdAt: new Date().toISOString() };
-    fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2), { mode: 0o600 });
+    const tmpMetaPath = metaPath + '.tmp';
+    fs.writeFileSync(tmpMetaPath, JSON.stringify(meta, null, 2), { mode: 0o600 });
+    fs.renameSync(tmpMetaPath, metaPath);
   }
 
   /** Delete a secret by key. Returns true if the key existed, false otherwise. */
@@ -114,7 +118,9 @@ export class LocalBackend implements WritableSecretBackend {
 
     delete store[key];
     const encrypted = this.encrypt(JSON.stringify(store));
-    fs.writeFileSync(storePath, encrypted, { mode: 0o600 });
+    const tmpStorePath = storePath + '.tmp';
+    fs.writeFileSync(tmpStorePath, encrypted, { mode: 0o600 });
+    fs.renameSync(tmpStorePath, storePath);
 
     // Update metadata
     const metaPath = path.join(this.storeDir, META_FILE);
@@ -122,7 +128,9 @@ export class LocalBackend implements WritableSecretBackend {
       if (fs.existsSync(metaPath)) {
         const meta: StoreMeta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
         delete meta.entries[key];
-        fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2), { mode: 0o600 });
+        const tmpMetaPath = metaPath + '.tmp';
+        fs.writeFileSync(tmpMetaPath, JSON.stringify(meta, null, 2), { mode: 0o600 });
+        fs.renameSync(tmpMetaPath, metaPath);
       }
     } catch { /* ignore */ }
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -178,6 +178,7 @@ function configureClaudeCode(projectDir: string, result: InitResult): void {
   if (!settings.permissions.deny) settings.permissions.deny = [];
 
   const denyRules = [
+    // Block Read access to secret files
     'Read(.env*)',
     'Read(*.key)',
     'Read(*.pem)',
@@ -187,11 +188,59 @@ function configureClaudeCode(projectDir: string, result: InitResult): void {
     'Read(*.tfvars)',
     'Read(.aws/credentials)',
     'Read(.ssh/*)',
+    // Block Read access to secretless data directory
+    'Read(~/.secretless-ai/*)',
+    // Block Grep from searching secret files (Issue #1)
+    'Grep(*.env*)',
+    'Grep(*.key)',
+    'Grep(*.pem)',
+    'Grep(*.p12)',
+    'Grep(*.pfx)',
+    'Grep(credentials*)',
+    'Grep(*.tfstate)',
+    'Grep(*.tfvars)',
+    // Block Bash commands that read secret files (Issue #2 - expanded)
     'Bash(cat .env*)',
     'Bash(cat *.key)',
+    'Bash(cat *.pem)',
+    'Bash(grep * .env*)',
+    'Bash(grep * *.key)',
+    'Bash(grep * *.pem)',
+    'Bash(awk * .env*)',
+    'Bash(awk * *.key)',
+    'Bash(sed * .env*)',
+    'Bash(sed * *.key)',
+    'Bash(strings .env*)',
+    'Bash(strings *.key)',
+    'Bash(strings *.pem)',
+    'Bash(xxd .env*)',
+    'Bash(xxd *.key)',
+    'Bash(xxd *.pem)',
+    'Bash(python3 -c*open*.env*)',
+    'Bash(python3 -c*open*.key*)',
+    'Bash(python3 -c*open*.pem*)',
+    'Bash(node -e*readFile*.env*)',
+    'Bash(node -e*readFile*.key*)',
+    'Bash(node -e*readFile*.pem*)',
+    // Block echoing/printing secret env vars (Issue #4 - expanded)
     'Bash(echo $*SECRET*)',
     'Bash(echo $*PASSWORD*)',
     'Bash(echo $*API_KEY*)',
+    'Bash(echo $*TOKEN*)',
+    'Bash(echo $*VAULT*)',
+    'Bash(echo $*CREDENTIAL*)',
+    'Bash(printenv *TOKEN*)',
+    'Bash(printenv *SECRET*)',
+    'Bash(printenv *KEY*)',
+    // Block secretless-ai secret extraction (Issue #3)
+    'Bash(*secretless-ai secret get*--force*)',
+    // Block secretless-ai run with env dumping (Issue #6)
+    'Bash(*secretless-ai run*-- env*)',
+    'Bash(*secretless-ai run*-- printenv*)',
+    // Block access to secretless data directory (Issue #5)
+    'Bash(cat *secretless-ai*)',
+    'Bash(*secretless-ai/store*)',
+    'Bash(*secretless-ai/mcp-backups*)',
   ];
 
   for (const rule of denyRules) {
@@ -363,6 +412,7 @@ function generateClaudeHookScript(): string {
     '.npmrc', '.pypirc',
     '.tfstate', '.tfvars',
     'secrets/', '.opena2a/secretless-ai/',
+    '.secretless-ai/',
   ];
 
   return `#!/bin/bash
@@ -384,14 +434,34 @@ fi
 # For Bash tool, check the command for secret access patterns
 if [ "$TOOL_NAME" = "Bash" ]; then
   COMMAND=$(echo "$INPUT" | grep -o '"command":"[^"]*"' | head -1 | cut -d'"' -f4)
-  # Block commands that dump secret files
-  if echo "$COMMAND" | grep -qiE '(cat|head|tail|less|more|type)\\s+.*\\.(env|key|pem|p12|pfx)'; then
+  # Block commands that dump secret files (expanded to cover grep, awk, sed, strings, xxd)
+  if echo "$COMMAND" | grep -qiE '(cat|head|tail|less|more|type|grep|awk|sed|strings|xxd)\\s+.*\\.(env|key|pem|p12|pfx)'; then
     echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Secretless: blocked command that reads secret files"}}'
     exit 0
   fi
-  # Block commands that echo secret env vars
-  if echo "$COMMAND" | grep -qiE 'echo\\s+.*\\$(SECRET|PASSWORD|API_KEY|TOKEN|PRIVATE_KEY)'; then
+  # Block python/node one-liners that read secret files
+  if echo "$COMMAND" | grep -qiE '(python3?|node)\\s+-(c|e).*\\.(env|key|pem|p12|pfx)'; then
+    echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Secretless: blocked script command that reads secret files"}}'
+    exit 0
+  fi
+  # Block commands that echo secret env vars (expanded with TOKEN, VAULT, CREDENTIAL)
+  if echo "$COMMAND" | grep -qiE '(echo|printenv)\\s+.*\\$(SECRET|PASSWORD|API_KEY|TOKEN|PRIVATE_KEY|VAULT|CREDENTIAL)'; then
     echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Secretless: blocked command that exposes secret environment variables"}}'
+    exit 0
+  fi
+  # Block secretless-ai secret extraction with --force
+  if echo "$COMMAND" | grep -qiE 'secretless-ai\\s+secret\\s+get.*--force'; then
+    echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Secretless: blocked forced secret extraction"}}'
+    exit 0
+  fi
+  # Block secretless-ai run with env/printenv to dump injected secrets
+  if echo "$COMMAND" | grep -qiE 'secretless-ai\\s+run.*--\\s*(env|printenv)'; then
+    echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Secretless: blocked secret dump via secretless-ai run"}}'
+    exit 0
+  fi
+  # Block direct access to secretless data directory
+  if echo "$COMMAND" | grep -qiE '(cat|head|tail|less|more|grep|awk|sed|strings|xxd|ls)\\s+.*\\.secretless-ai'; then
+    echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Secretless: blocked access to secretless data directory"}}'
     exit 0
   fi
   exit 0

--- a/src/mcp-wrapper.ts
+++ b/src/mcp-wrapper.ts
@@ -42,8 +42,8 @@ function parseArgs(argv: string[]): {
     if (argv[i] === '--vault-key' && argv[i + 1]) { vaultKey = argv[++i]; continue; }
     if (argv[i] === '--backend' && argv[i + 1]) {
       const val = argv[++i];
-      if (val !== 'local' && val !== 'keychain' && val !== '1password') {
-        process.stderr.write(`secretless-mcp: Unknown backend: ${val}. Use 'local', 'keychain', or '1password'.\n`);
+      if (val !== 'local' && val !== 'keychain' && val !== '1password' && val !== 'vault' && val !== 'gcp-sm') {
+        process.stderr.write(`secretless-mcp: Unknown backend: ${val}. Use 'local', 'keychain', '1password', 'vault', or 'gcp-sm'.\n`);
         process.exit(1);
       }
       backend = val;

--- a/src/mcp/discover.ts
+++ b/src/mcp/discover.ts
@@ -20,7 +20,7 @@ export interface McpServerEntry {
   command: string;
   args: string[];
   env: Record<string, string>;
-  /** true if command is 'secretless-mcp' or ends with '/secretless-mcp' */
+  /** true if command is the secretless-mcp binary or the mcp-wrapper.js script */
   alreadyProtected: boolean;
 }
 
@@ -102,6 +102,13 @@ function getClientConfigPaths(): ClientConfigPath[] {
 function isProtectedCommand(command: string): boolean {
   if (command === 'secretless-mcp') return true;
   if (command.endsWith('/secretless-mcp')) return true;
+
+  // The protect-mcp command rewrites configs to use the full path to mcp-wrapper.js
+  // (e.g., /Users/.../dist/mcp-wrapper.js). Detect that as protected too.
+  const wrapperPath = path.resolve(__dirname, '..', 'dist', 'mcp-wrapper.js');
+  if (command === wrapperPath) return true;
+  if (command.endsWith('/mcp-wrapper.js') && command.includes('secretless')) return true;
+
   return false;
 }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -29,6 +29,15 @@ export async function runWithSecrets(
 
   const secretCount = Object.keys(secrets).length;
   if (secretCount === 0) {
+    // Check if the store actually has secrets (backend may have failed to load them)
+    const allSecrets = await store.listSecrets();
+    if (allSecrets.length > 0) {
+      process.stderr.write(
+        `secretless: Backend returned 0 secrets but the store contains ${allSecrets.length} entries. ` +
+        'This may indicate a backend failure. Aborting to prevent running without secrets.\n',
+      );
+      return 1;
+    }
     process.stderr.write(
       'secretless: No secrets found. Use `secretless-ai secret set <NAME>` to store secrets.\n',
     );


### PR DESCRIPTION
## Summary
- Expand Claude Code deny rules from ~15 to ~45 covering Grep, Bash filter gaps (awk/sed/strings/xxd/python3/node), TOKEN/VAULT/CREDENTIAL env vars, secretless data directory, --force flag bypass, and run -- env dump
- Fix mcp-wrapper to accept vault and gcp-sm backends
- Fix isProtectedCommand() to detect mcp-wrapper.js path (mcp-status now correctly shows "protected")
- Atomic writes (tmp+rename) in local backend to prevent store corruption
- Backend failure safety: run command aborts if backend returns 0 secrets but store is non-empty

## Test plan
- [x] All 758 tests pass
- [x] Build clean
- [x] Manually verified all 5 changed files