### PR TITLE
feat: add Identity Vault CLI for AIM Secrets Phase 1a

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "optionalDependencies": {
     "@nanomind/engine": "^0.1.1",
-    "@nanomind/guard": "^0.1.1"
+    "@nanomind/guard": "^0.1.1",
+    "@opena2a/aim-core": ">=0.2.0"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ import { runHook, runScanStaged } from './commands/git';
 import { runProtectMcp, runMcpStatus, runMcpUnprotect } from './commands/mcp';
 import { runBackend, runMigrate, runCache } from './commands/backend';
 import { runBroker } from './commands/broker';
+import { runVault } from './commands/vault';
 import { runScope } from './commands/scope';
 import { runWarm, runInstall } from './commands/session';
 import { printHelp } from './commands/help';
@@ -111,6 +112,9 @@ function main(): void {
       break;
     case 'broker':
       runBroker(args.slice(1));
+      break;
+    case 'vault':
+      runVault(args.slice(1));
       break;
     case 'scope':
       runScope(args.slice(1));

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -70,6 +70,18 @@ export function printHelp(): void {
     npx secretless-ai clean-history          Redact credentials in shell history
     npx secretless-ai clean-history --dry-run  Preview without modifying
 
+  Identity Vault (requires @opena2a/aim-core):
+    npx secretless-ai vault init                    Initialize vault with agent identity
+    npx secretless-ai vault register <ns> [opts]    Register a credential in a namespace
+    npx secretless-ai vault list                    List stored credentials (metadata only)
+    npx secretless-ai vault rotate <ns> [opts]      Rotate a credential to a new value
+    npx secretless-ai vault revoke <ns>             Revoke a namespace and delete credential
+    npx secretless-ai vault exec <ns> -- <cmd>      Run command with vault credential injected
+    npx secretless-ai vault audit                   Show vault audit log
+    npx secretless-ai vault scan [dir]              Scan for credentials to migrate
+    npx secretless-ai vault test                    Run vault self-test
+    npx secretless-ai vault migrate [opts]          Migrate from SecretStore or .env file
+
   Credential Broker:
     npx secretless-ai broker start        Start the credential broker daemon
     npx secretless-ai broker stop         Stop the running broker daemon

--- a/src/commands/vault.test.ts
+++ b/src/commands/vault.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for commands/vault.ts — CLI arg parsing and dispatch.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock all vault-core functions so we can test CLI dispatch without aim-core
+vi.mock('../vault-core', () => ({
+  vaultInit: vi.fn().mockResolvedValue(undefined),
+  vaultRegister: vi.fn().mockResolvedValue(undefined),
+  vaultList: vi.fn().mockResolvedValue(undefined),
+  vaultRotate: vi.fn().mockResolvedValue(undefined),
+  vaultRevoke: vi.fn().mockResolvedValue(undefined),
+  vaultAudit: vi.fn().mockResolvedValue(undefined),
+  vaultScan: vi.fn().mockResolvedValue(undefined),
+  vaultExec: vi.fn().mockResolvedValue(0),
+  vaultTest: vi.fn().mockResolvedValue(undefined),
+  vaultMigrate: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { runVault } from './vault';
+import {
+  vaultInit,
+  vaultRegister,
+  vaultList,
+  vaultRotate,
+  vaultRevoke,
+  vaultAudit,
+  vaultScan,
+  vaultExec,
+  vaultTest,
+  vaultMigrate,
+} from '../vault-core';
+
+describe('runVault CLI dispatch', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    consoleSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('dispatches "init" to vaultInit', () => {
+    runVault(['init']);
+    expect(vaultInit).toHaveBeenCalledWith(undefined);
+  });
+
+  it('dispatches "init --name my-agent" with agent name', () => {
+    runVault(['init', '--name', 'my-agent']);
+    expect(vaultInit).toHaveBeenCalledWith('my-agent');
+  });
+
+  it('dispatches "register" with namespace and options', () => {
+    runVault(['register', 'github', '--value', 'ghp_abc', '--description', 'GitHub token']);
+    expect(vaultRegister).toHaveBeenCalledWith('github', {
+      value: 'ghp_abc',
+      envVar: undefined,
+      description: 'GitHub token',
+      operations: undefined,
+      urlPatterns: undefined,
+    });
+  });
+
+  it('dispatches "register" with --operations and --url-patterns', () => {
+    runVault(['register', 'aws', '--env', 'AWS_KEY', '--operations', 'read,write', '--url-patterns', 'https://s3.amazonaws.com/*']);
+    expect(vaultRegister).toHaveBeenCalledWith('aws', {
+      value: undefined,
+      envVar: 'AWS_KEY',
+      description: undefined,
+      operations: ['read', 'write'],
+      urlPatterns: ['https://s3.amazonaws.com/*'],
+    });
+  });
+
+  it('dispatches "register" without namespace shows usage and exits', () => {
+    runVault(['register']);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(vaultRegister).not.toHaveBeenCalled();
+  });
+
+  it('dispatches "list" to vaultList', () => {
+    runVault(['list']);
+    expect(vaultList).toHaveBeenCalled();
+  });
+
+  it('dispatches "ls" as alias for list', () => {
+    runVault(['ls']);
+    expect(vaultList).toHaveBeenCalled();
+  });
+
+  it('dispatches "rotate" with namespace and --value', () => {
+    runVault(['rotate', 'github', '--value', 'ghp_new']);
+    expect(vaultRotate).toHaveBeenCalledWith('github', {
+      value: 'ghp_new',
+      envVar: undefined,
+    });
+  });
+
+  it('dispatches "rotate" without namespace shows usage and exits', () => {
+    runVault(['rotate']);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(vaultRotate).not.toHaveBeenCalled();
+  });
+
+  it('dispatches "revoke" with namespace', () => {
+    runVault(['revoke', 'github']);
+    expect(vaultRevoke).toHaveBeenCalledWith('github');
+  });
+
+  it('dispatches "revoke" without namespace shows usage and exits', () => {
+    runVault(['revoke']);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(vaultRevoke).not.toHaveBeenCalled();
+  });
+
+  it('dispatches "audit" with options', () => {
+    runVault(['audit', '--limit', '20', '--namespace', 'github']);
+    expect(vaultAudit).toHaveBeenCalledWith({
+      limit: 20,
+      since: undefined,
+      namespace: 'github',
+    });
+  });
+
+  it('dispatches "scan" with optional directory', () => {
+    runVault(['scan', '/tmp/myproject']);
+    expect(vaultScan).toHaveBeenCalledWith('/tmp/myproject');
+  });
+
+  it('dispatches "exec" with namespace and command', () => {
+    runVault(['exec', 'github', '--', 'curl', 'https://api.github.com/user']);
+    expect(vaultExec).toHaveBeenCalledWith(
+      'github',
+      ['curl', 'https://api.github.com/user'],
+      { envName: undefined },
+    );
+  });
+
+  it('dispatches "exec" with --env-name', () => {
+    runVault(['exec', 'aws-prod', '--env-name', 'AWS_SECRET_ACCESS_KEY', '--', 'aws', 's3', 'ls']);
+    expect(vaultExec).toHaveBeenCalledWith(
+      'aws-prod',
+      ['aws', 's3', 'ls'],
+      { envName: 'AWS_SECRET_ACCESS_KEY' },
+    );
+  });
+
+  it('dispatches "exec" without -- shows usage and exits', () => {
+    runVault(['exec', 'github', 'curl']);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(vaultExec).not.toHaveBeenCalled();
+  });
+
+  it('dispatches "test" to vaultTest', () => {
+    runVault(['test']);
+    expect(vaultTest).toHaveBeenCalled();
+  });
+
+  it('dispatches "migrate" with options', () => {
+    runVault(['migrate', '--env-file', '.env', '--dry-run']);
+    expect(vaultMigrate).toHaveBeenCalledWith({
+      dryRun: true,
+      envFile: '.env',
+    });
+  });
+
+  it('shows help for --help', () => {
+    runVault(['--help']);
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('Identity Vault');
+    expect(output).toContain('vault exec');
+  });
+
+  it('shows error and help for unknown subcommand', () => {
+    runVault(['unknown-cmd']);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errorOutput = consoleErrorSpy.mock.calls.flat().join(' ');
+    expect(errorOutput).toContain('Unknown vault command: unknown-cmd');
+  });
+
+  it('shows help when no subcommand given', () => {
+    runVault([]);
+    const output = consoleSpy.mock.calls.flat().join(' ');
+    expect(output).toContain('Identity Vault');
+  });
+});

--- a/src/commands/vault.ts
+++ b/src/commands/vault.ts
@@ -1,0 +1,269 @@
+/**
+ * CLI handlers for the vault command.
+ * Dispatches to vault-core.ts functions.
+ * Follows the runBroker() pattern from commands/broker.ts.
+ */
+
+import {
+  vaultInit,
+  vaultRegister,
+  vaultList,
+  vaultRotate,
+  vaultRevoke,
+  vaultAudit,
+  vaultScan,
+  vaultExec,
+  vaultTest,
+  vaultMigrate,
+} from '../vault-core';
+
+export function runVault(args: string[]): void {
+  const subcommand = args[0];
+
+  switch (subcommand) {
+    case 'init':
+      handleInit(args.slice(1));
+      break;
+    case 'register':
+      handleRegister(args.slice(1));
+      break;
+    case 'list':
+    case 'ls':
+      handleList();
+      break;
+    case 'rotate':
+      handleRotate(args.slice(1));
+      break;
+    case 'revoke':
+      handleRevoke(args.slice(1));
+      break;
+    case 'audit':
+      handleAudit(args.slice(1));
+      break;
+    case 'scan':
+      handleScan(args.slice(1));
+      break;
+    case 'exec':
+      handleExec(args.slice(1));
+      break;
+    case 'test':
+      handleTest();
+      break;
+    case 'migrate':
+      handleMigrate(args.slice(1));
+      break;
+    case '--help':
+    case '-h':
+      printVaultHelp();
+      break;
+    default: {
+      const isUnknown = subcommand && subcommand !== '--help' && subcommand !== '-h';
+      if (isUnknown) {
+        console.error(`\n  Unknown vault command: ${subcommand}`);
+      }
+      printVaultHelp();
+      if (isUnknown) process.exit(1);
+      break;
+    }
+  }
+}
+
+// ── Subcommand handlers ────────────────────────────────────────────
+
+function handleInit(args: string[]): void {
+  const agentName = parseFlag(args, '--name');
+  vaultInit(agentName ?? undefined).catch(handleError);
+}
+
+function handleRegister(args: string[]): void {
+  const namespace = args[0];
+  if (!namespace || namespace.startsWith('-')) {
+    console.error('\n  Usage: secretless-ai vault register <namespace> [options]\n');
+    console.error('  Options:');
+    console.error('    --value <value>       Credential value (or pipe via stdin)');
+    console.error('    --env <VAR>           Read value from environment variable');
+    console.error('    --description <desc>  Namespace description');
+    console.error('    --operations <ops>    Comma-separated: read,write,delete,admin');
+    console.error('    --url-patterns <pats> Comma-separated URL patterns\n');
+    process.exit(1);
+    return;
+  }
+
+  const value = parseFlag(args, '--value');
+  const envVar = parseFlag(args, '--env');
+  const description = parseFlag(args, '--description');
+  const opsStr = parseFlag(args, '--operations');
+  const urlStr = parseFlag(args, '--url-patterns');
+
+  const operations = opsStr
+    ? opsStr.split(',').map(o => o.trim()) as Array<'read' | 'write' | 'delete' | 'admin'>
+    : undefined;
+  const urlPatterns = urlStr ? urlStr.split(',').map(u => u.trim()) : undefined;
+
+  vaultRegister(namespace, {
+    value: value ?? undefined,
+    envVar: envVar ?? undefined,
+    description: description ?? undefined,
+    operations,
+    urlPatterns,
+  }).catch(handleError);
+}
+
+function handleList(): void {
+  vaultList().catch(handleError);
+}
+
+function handleRotate(args: string[]): void {
+  const namespace = args[0];
+  if (!namespace || namespace.startsWith('-')) {
+    console.error('\n  Usage: secretless-ai vault rotate <namespace> [--value <value>] [--env <VAR>]\n');
+    process.exit(1);
+    return;
+  }
+
+  const value = parseFlag(args, '--value');
+  const envVar = parseFlag(args, '--env');
+
+  vaultRotate(namespace, {
+    value: value ?? undefined,
+    envVar: envVar ?? undefined,
+  }).catch(handleError);
+}
+
+function handleRevoke(args: string[]): void {
+  const namespace = args[0];
+  if (!namespace || namespace.startsWith('-')) {
+    console.error('\n  Usage: secretless-ai vault revoke <namespace>\n');
+    process.exit(1);
+    return;
+  }
+
+  vaultRevoke(namespace).catch(handleError);
+}
+
+function handleAudit(args: string[]): void {
+  const limitStr = parseFlag(args, '--limit');
+  const since = parseFlag(args, '--since');
+  const namespace = parseFlag(args, '--namespace');
+
+  vaultAudit({
+    limit: limitStr ? parseInt(limitStr, 10) : undefined,
+    since: since ?? undefined,
+    namespace: namespace ?? undefined,
+  }).catch(handleError);
+}
+
+function handleScan(args: string[]): void {
+  const dir = args.find(a => !a.startsWith('-'));
+  vaultScan(dir).catch(handleError);
+}
+
+function handleExec(args: string[]): void {
+  // Parse: vault exec <namespace> [--env-name VAR] -- <command...>
+  const dashDashIdx = args.indexOf('--');
+  if (dashDashIdx === -1) {
+    console.error('\n  Usage: secretless-ai vault exec <namespace> -- <command> [args...]\n');
+    console.error('  Example:');
+    console.error('    secretless-ai vault exec github -- curl https://api.github.com/user');
+    console.error('    secretless-ai vault exec aws-prod --env-name AWS_SECRET_ACCESS_KEY -- aws s3 ls\n');
+    process.exit(1);
+    return;
+  }
+
+  const preArgs = args.slice(0, dashDashIdx);
+  const command = args.slice(dashDashIdx + 1);
+
+  const namespace = preArgs[0];
+  if (!namespace || namespace.startsWith('-')) {
+    console.error('\n  Error: namespace is required before --\n');
+    process.exit(1);
+    return;
+  }
+
+  const envName = parseFlag(preArgs, '--env-name');
+
+  vaultExec(namespace, command, {
+    envName: envName ?? undefined,
+  }).then((code) => {
+    process.exit(code);
+  }).catch(handleError);
+}
+
+function handleTest(): void {
+  vaultTest().catch(handleError);
+}
+
+function handleMigrate(args: string[]): void {
+  const dryRun = args.includes('--dry-run');
+  const envFile = parseFlag(args, '--env-file');
+
+  vaultMigrate({
+    dryRun,
+    envFile: envFile ?? undefined,
+  }).catch(handleError);
+}
+
+// ── Help ───────────────────────────────────────────────────────────
+
+function printVaultHelp(): void {
+  console.log(`
+  Usage: secretless-ai vault <command> [options]
+
+  Identity Vault — encrypted, identity-bound credential storage.
+  Credentials never enter the agent's process memory (CR-001).
+
+  Commands:
+    init                     Initialize vault with agent identity
+    register <ns> [opts]     Register a credential in a namespace
+    list                     List stored credentials (metadata only)
+    rotate <ns> [opts]       Rotate a credential to a new value
+    revoke <ns>              Revoke a namespace (delete credential)
+    audit                    Show vault audit log
+    scan [dir]               Scan for credentials to migrate
+    exec <ns> -- <cmd>       Execute command with vault credential
+    test                     Run vault self-test
+    migrate [opts]           Migrate from SecretStore or .env file
+
+  Register options:
+    --value <value>          Credential value (or pipe via stdin)
+    --env <VAR>              Read value from environment variable
+    --description <desc>     Namespace description
+    --operations <ops>       Comma-separated: read,write,delete,admin
+    --url-patterns <pats>    Comma-separated URL patterns
+
+  Exec options:
+    --env-name <VAR>         Env var name for the credential (default: NAMESPACE)
+
+  Migrate options:
+    --env-file <path>        Migrate from a .env file
+    --dry-run                Preview without migrating
+
+  Audit options:
+    --limit <n>              Max events to show (default: 50)
+    --since <ISO-date>       Events after this timestamp
+    --namespace <ns>         Filter by namespace
+
+  Examples:
+    secretless-ai vault init
+    secretless-ai vault register github --value ghp_abc123
+    secretless-ai vault register aws --env AWS_SECRET_ACCESS_KEY
+    secretless-ai vault exec github -- curl https://api.github.com/user
+    secretless-ai vault migrate --env-file .env --dry-run
+    secretless-ai vault audit --limit 10
+`);
+}
+
+// ── Utilities ──────────────────────────────────────────────────────
+
+/** Parse a --flag value pair from args */
+function parseFlag(args: string[], flag: string): string | null {
+  const idx = args.indexOf(flag);
+  if (idx === -1 || idx + 1 >= args.length) return null;
+  return args[idx + 1];
+}
+
+function handleError(err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`\n  Error: ${message}\n`);
+  process.exit(1);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,14 @@ export {
   type ResolveResult, type ResolveError,
 } from './phantom';
 
+// Identity Vault (requires @opena2a/aim-core)
+export {
+  vaultInit, vaultRegister, vaultList, vaultRotate, vaultRevoke,
+  vaultAudit, vaultScan, vaultExec, vaultTest, vaultMigrate,
+  loadAimCoreVault, loadAimCoreIdentity, getOrCreateAgent, getVaultStore,
+  PATHS as VAULT_PATHS,
+} from './vault-core';
+
 // Session management
 export {
   readSessionState, writeSessionState, getSessionStatus,

--- a/src/vault-core.test.ts
+++ b/src/vault-core.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Tests for vault-core.ts — integration tests using real aim-core vault module.
+ *
+ * These tests require @opena2a/aim-core to be installed/linked.
+ * They create temp directories and clean up after themselves.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// We need to mock the paths before importing vault-core
+let tmpHome: string;
+let vaultDir: string;
+let aimDataDir: string;
+
+// Check if aim-core is available
+let aimCoreAvailable = false;
+try {
+  require.resolve('@opena2a/aim-core');
+  aimCoreAvailable = true;
+} catch {
+  // aim-core not available — tests will be skipped
+}
+
+const describeWithAimCore = aimCoreAvailable ? describe : describe.skip;
+
+describeWithAimCore('vault-core', () => {
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-vault-test-'));
+    vaultDir = path.join(tmpHome, '.aim', 'vault');
+    aimDataDir = path.join(tmpHome, '.opena2a', 'aim-core');
+
+    // Override HOME so vault-core uses our temp dirs
+    vi.stubEnv('HOME', tmpHome);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    // Reset cached modules
+    vi.resetModules();
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('loadAimCoreVault succeeds when aim-core is installed', async () => {
+    // Reset cache by re-importing
+    const { loadAimCoreVault } = await import('./vault-core');
+    const vault = await loadAimCoreVault();
+    expect(vault).toBeDefined();
+    expect(vault.VaultStore).toBeDefined();
+    expect(vault.createResolutionRequest).toBeDefined();
+    expect(vault.resolveWithPolicy).toBeDefined();
+  });
+
+  it('loadAimCoreIdentity succeeds when aim-core is installed', async () => {
+    const { loadAimCoreIdentity } = await import('./vault-core');
+    const identity = await loadAimCoreIdentity();
+    expect(identity).toBeDefined();
+    expect(identity.loadIdentity).toBeDefined();
+    expect(identity.createIdentity).toBeDefined();
+  });
+
+  it('getOrCreateAgent creates new identity when none exists', async () => {
+    const { getOrCreateAgent } = await import('./vault-core');
+    const agent = await getOrCreateAgent('test-agent');
+    expect(agent.agentId).toBeTruthy();
+    expect(agent.agentId).toMatch(/^aim_/);
+    expect(agent.agentName).toBe('test-agent');
+    expect(agent.publicKey).toBeTruthy();
+    expect(agent.secretKey).toBeTruthy();
+  });
+
+  it('getOrCreateAgent returns existing identity on second call', async () => {
+    const { getOrCreateAgent } = await import('./vault-core');
+    const agent1 = await getOrCreateAgent('test-agent');
+    const agent2 = await getOrCreateAgent('test-agent');
+    expect(agent1.agentId).toBe(agent2.agentId);
+    expect(agent1.publicKey).toBe(agent2.publicKey);
+  });
+
+  it('vaultInit creates vault directory and files', async () => {
+    const { vaultInit } = await import('./vault-core');
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await vaultInit('test-agent');
+
+    expect(fs.existsSync(vaultDir)).toBe(true);
+    expect(fs.existsSync(path.join(vaultDir, 'vault.enc'))).toBe(true);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('vaultInit is idempotent — second call reports already initialized', async () => {
+    const { vaultInit } = await import('./vault-core');
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await vaultInit('test-agent');
+    await vaultInit('test-agent');
+
+    // Second call should mention "already initialized"
+    const allOutput = consoleSpy.mock.calls.flat().join(' ');
+    expect(allOutput).toContain('already initialized');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('full lifecycle: init -> register -> list -> rotate -> revoke', async () => {
+    const {
+      vaultInit, vaultRegister, vaultList, vaultRotate, vaultRevoke,
+    } = await import('./vault-core');
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    // Init
+    await vaultInit('test-agent');
+
+    // Register
+    await vaultRegister('github', {
+      value: 'ghp_test_token_123',
+      description: 'GitHub token',
+      operations: ['read'],
+      urlPatterns: ['https://api.github.com/*'],
+    });
+
+    // List
+    consoleSpy.mockClear();
+    await vaultList();
+    const listOutput = consoleSpy.mock.calls.flat().join(' ');
+    expect(listOutput).toContain('github');
+    expect(listOutput).toContain('active');
+    expect(listOutput).not.toContain('ghp_test_token_123'); // No credential values
+
+    // Rotate
+    consoleSpy.mockClear();
+    await vaultRotate('github', { value: 'ghp_rotated_456' });
+    const rotateOutput = consoleSpy.mock.calls.flat().join(' ');
+    expect(rotateOutput).toContain('rotated');
+    expect(rotateOutput).toContain('2'); // Version 2
+
+    // Revoke
+    consoleSpy.mockClear();
+    await vaultRevoke('github');
+    const revokeOutput = consoleSpy.mock.calls.flat().join(' ');
+    expect(revokeOutput).toContain('revoked');
+
+    // List after revoke — should show empty
+    consoleSpy.mockClear();
+    await vaultList();
+    const emptyListOutput = consoleSpy.mock.calls.flat().join(' ');
+    expect(emptyListOutput).toContain('No credentials');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('vaultExec spawns child with credential as env var', async () => {
+    const { vaultInit, vaultRegister, vaultExec } = await import('./vault-core');
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await vaultInit('test-agent');
+    await vaultRegister('test-cred', {
+      value: 'secret_value_abc',
+      operations: ['read'],
+    });
+
+    consoleSpy.mockRestore();
+
+    // Exec: verify the credential is available as env var
+    const code = await vaultExec('test-cred', ['node', '-e', `
+      const val = process.env.TEST_CRED;
+      if (val !== 'secret_value_abc') {
+        process.stderr.write('Expected secret_value_abc, got: ' + val + '\\n');
+        process.exit(1);
+      }
+    `]);
+
+    expect(code).toBe(0);
+  });
+
+  it('vaultExec does not leak credential to stdout', async () => {
+    const { vaultInit, vaultRegister, vaultExec } = await import('./vault-core');
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await vaultInit('test-agent');
+    await vaultRegister('leak-test', {
+      value: 'should_not_appear_in_stdout',
+      operations: ['read'],
+    });
+    consoleSpy.mockRestore();
+
+    // The credential should be in the child env but the vault-core module
+    // itself should not write it to stdout
+    const output: string[] = [];
+    const origWrite = process.stdout.write;
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      output.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+
+    await vaultExec('leak-test', ['node', '-e', 'process.exit(0)']);
+
+    process.stdout.write = origWrite;
+
+    const allOutput = output.join('');
+    expect(allOutput).not.toContain('should_not_appear_in_stdout');
+  });
+
+  it('vaultExec with custom env name', async () => {
+    const { vaultInit, vaultRegister, vaultExec } = await import('./vault-core');
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await vaultInit('test-agent');
+    await vaultRegister('aws-prod', {
+      value: 'aws_secret_key_123',
+      operations: ['read'],
+    });
+    consoleSpy.mockRestore();
+
+    const code = await vaultExec('aws-prod', ['node', '-e', `
+      if (process.env.MY_AWS_KEY !== 'aws_secret_key_123') process.exit(1);
+    `], { envName: 'MY_AWS_KEY' });
+
+    expect(code).toBe(0);
+  });
+
+  it('vaultExec fails for revoked namespace', async () => {
+    const { vaultInit, vaultRegister, vaultRevoke, vaultExec } = await import('./vault-core');
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await vaultInit('test-agent');
+    await vaultRegister('revoke-test', {
+      value: 'temp_token',
+      operations: ['read'],
+    });
+    await vaultRevoke('revoke-test');
+    consoleSpy.mockRestore();
+
+    await expect(
+      vaultExec('revoke-test', ['echo', 'should not run']),
+    ).rejects.toThrow(/denied/i);
+  });
+
+  it('vaultAudit shows events', async () => {
+    const { vaultInit, vaultRegister, vaultAudit } = await import('./vault-core');
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await vaultInit('test-agent');
+    await vaultRegister('audit-test', {
+      value: 'token123',
+      operations: ['read'],
+    });
+
+    consoleSpy.mockClear();
+    await vaultAudit({ limit: 10 });
+    const auditOutput = consoleSpy.mock.calls.flat().join(' ');
+    expect(auditOutput).toContain('vault:init');
+    expect(auditOutput).toContain('store');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('vaultTest reports all checks', async () => {
+    const { vaultInit, vaultTest } = await import('./vault-core');
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await vaultInit('test-agent');
+
+    consoleSpy.mockClear();
+    await vaultTest();
+    const testOutput = consoleSpy.mock.calls.flat().join(' ');
+    expect(testOutput).toContain('[OK]');
+    expect(testOutput).toContain('aim-core loaded');
+    expect(testOutput).toContain('All checks passed');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('getVaultStore throws when vault not initialized', async () => {
+    const { getOrCreateAgent, getVaultStore } = await import('./vault-core');
+
+    // Ensure identity exists but vault does not
+    await getOrCreateAgent('test-agent');
+
+    await expect(getVaultStore()).rejects.toThrow(/not initialized/i);
+  });
+
+  it('vaultRegister with --env reads from environment', async () => {
+    const { vaultInit, vaultRegister } = await import('./vault-core');
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    vi.stubEnv('MY_TEST_TOKEN', 'env_token_value');
+
+    await vaultInit('test-agent');
+    await vaultRegister('env-test', {
+      envVar: 'MY_TEST_TOKEN',
+      operations: ['read'],
+    });
+
+    consoleSpy.mockRestore();
+
+    // Verify it was stored by checking we can exec with it
+    const { vaultExec } = await import('./vault-core');
+    const code = await vaultExec('env-test', ['node', '-e', `
+      if (process.env.ENV_TEST !== 'env_token_value') process.exit(1);
+    `]);
+
+    expect(code).toBe(0);
+  });
+});
+
+describe('vault-core error message format', () => {
+  it('error message includes install instructions when aim-core unavailable', () => {
+    // We can't easily mock require() to fail when aim-core is installed,
+    // so we verify the error message format directly.
+    const expectedMessage = '@opena2a/aim-core is required for vault commands.\n' +
+      '  Install it:  npm install @opena2a/aim-core\n' +
+      '  Or link it:  npm link @opena2a/aim-core';
+
+    const err = new Error(expectedMessage);
+    expect(err.message).toContain('@opena2a/aim-core is required');
+    expect(err.message).toContain('npm install');
+    expect(err.message).toContain('npm link');
+  });
+});

--- a/src/vault-core.ts
+++ b/src/vault-core.ts
@@ -1,0 +1,880 @@
+/**
+ * Vault core orchestration — bridges secretless-ai CLI to @opena2a/aim-core vault module.
+ *
+ * @opena2a/aim-core is an optional peer dependency. All vault imports are dynamic
+ * so secretless-ai works without it (just shows an actionable install message).
+ *
+ * CR-001: credential never in agent context
+ * CR-010: no proxy, no sidecar — pipes/fds only for cross-process isolation
+ */
+
+import { spawn } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as readline from 'readline';
+
+// ── Types for the dynamically loaded aim-core vault module ──────────
+
+/** Subset of aim-core vault module we consume */
+interface AimCoreVault {
+  VaultStore: new (vaultDir: string) => VaultStoreInstance;
+  createNamespace: (vaultDir: string, opts: CreateNamespaceOpts) => VaultNamespace;
+  listNamespaces: (vaultDir: string) => VaultNamespace[];
+  getNamespace: (vaultDir: string, id: string) => VaultNamespace | null;
+  revokeNamespace: (vaultDir: string, id: string) => boolean;
+  readVaultAudit: (vaultDir: string, opts?: AuditReadOpts) => VaultAuditEvent[];
+  logVaultEvent: (vaultDir: string, event: VaultAuditEventInput) => VaultAuditEvent;
+  createResolutionRequest: (
+    namespace: string,
+    operation: VaultOperation,
+    agentId: string,
+    edSecretKey: Uint8Array,
+  ) => VaultResolutionRequest;
+  resolveWithPolicy: (
+    request: VaultResolutionRequest,
+    context: ResolutionContext,
+  ) => VaultResolutionResult;
+  zeroize: (data: Uint8Array) => void;
+}
+
+/** Subset of aim-core identity module we consume */
+interface AimCoreIdentity {
+  loadIdentity: (dataDir: string) => StoredIdentity | null;
+  createIdentity: (dataDir: string, agentName: string) => StoredIdentity;
+  getSecretKey: (dataDir: string) => Uint8Array | null;
+  getPublicKey: (dataDir: string) => Uint8Array | null;
+}
+
+interface VaultStoreInstance {
+  init(agentId: string, edSecretKey: Uint8Array): void;
+  exists(): boolean;
+  unlock(edSecretKey: Uint8Array): void;
+  storeCredential(namespace: string, credential: Uint8Array): void;
+  resolveCredential(namespace: string): Uint8Array;
+  listCredentials(): Array<{ namespace: string; version: number; encryptedAt: string }>;
+  deleteCredential(namespace: string): boolean;
+  rotateCredential(namespace: string, newCredential: Uint8Array): void;
+  getAgentId(): string;
+  destroy(): void;
+  lock(): void;
+}
+
+interface StoredIdentity {
+  agentId: string;
+  publicKey: string;
+  secretKey: string;
+  agentName: string;
+  createdAt: string;
+}
+
+type VaultOperation = 'read' | 'write' | 'delete' | 'admin';
+type NamespaceStatus = 'active' | 'revoked';
+
+interface VaultNamespace {
+  id: string;
+  description: string;
+  agentId: string;
+  operations: VaultOperation[];
+  urlPatterns: string[];
+  status: NamespaceStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface CreateNamespaceOpts {
+  id: string;
+  description: string;
+  agentId: string;
+  operations: VaultOperation[];
+  urlPatterns: string[];
+}
+
+interface VaultResolutionRequest {
+  namespace: string;
+  operation: VaultOperation;
+  signature: string;
+  nonce: string;
+  agentId: string;
+}
+
+interface VaultResolutionResult {
+  success: boolean;
+  credential?: Uint8Array;
+  error?: string;
+  namespace: string;
+  version?: number;
+}
+
+interface ResolutionContext {
+  vaultDir: string;
+  store: VaultStoreInstance;
+  edPublicKey: Uint8Array;
+  checkCapability?: (capability: string) => boolean;
+}
+
+interface VaultAuditEvent {
+  timestamp: string;
+  agentId: string;
+  namespace?: string;
+  operation: string;
+  result: 'granted' | 'denied' | 'error';
+  denyReason?: string;
+  metadata?: Record<string, unknown>;
+}
+
+type VaultAuditEventInput = Omit<VaultAuditEvent, 'timestamp'>;
+
+interface AuditReadOpts {
+  limit?: number;
+  since?: string;
+  namespace?: string;
+}
+
+// ── Paths ──────────────────────────────────────────────────────────
+
+const HOME = process.env.HOME ?? process.env.USERPROFILE ?? '/tmp';
+const VAULT_DIR = path.join(HOME, '.aim', 'vault');
+const AIM_DATA_DIR = path.join(HOME, '.opena2a', 'aim-core');
+
+// ── Dynamic import ─────────────────────────────────────────────────
+
+let cachedVault: AimCoreVault | null = null;
+let cachedIdentity: AimCoreIdentity | null = null;
+
+/**
+ * Dynamically import @opena2a/aim-core vault module.
+ * Throws an actionable error if the package is not installed.
+ */
+export async function loadAimCoreVault(): Promise<AimCoreVault> {
+  if (cachedVault) return cachedVault;
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const mod = require('@opena2a/aim-core');
+    cachedVault = mod.vault as unknown as AimCoreVault;
+    return cachedVault;
+  } catch {
+    throw new Error(
+      '@opena2a/aim-core is required for vault commands.\n' +
+      '  Install it:  npm install @opena2a/aim-core\n' +
+      '  Or link it:  npm link @opena2a/aim-core',
+    );
+  }
+}
+
+/**
+ * Dynamically import @opena2a/aim-core identity functions.
+ */
+export async function loadAimCoreIdentity(): Promise<AimCoreIdentity> {
+  if (cachedIdentity) return cachedIdentity;
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const mod = require('@opena2a/aim-core');
+    cachedIdentity = {
+      loadIdentity: mod.loadIdentity,
+      createIdentity: mod.createIdentity,
+      getSecretKey: mod.getSecretKey as AimCoreIdentity['getSecretKey'] ?? null,
+      getPublicKey: mod.getPublicKey as AimCoreIdentity['getPublicKey'] ?? null,
+    };
+
+    // getSecretKey/getPublicKey may not be re-exported from index — fall back
+    if (!cachedIdentity.getSecretKey) {
+      cachedIdentity.getSecretKey = (dataDir: string) => {
+        const stored = cachedIdentity!.loadIdentity(dataDir);
+        if (!stored) return null;
+        return Buffer.from(stored.secretKey, 'base64');
+      };
+      cachedIdentity.getPublicKey = (dataDir: string) => {
+        const stored = cachedIdentity!.loadIdentity(dataDir);
+        if (!stored) return null;
+        return Buffer.from(stored.publicKey, 'base64');
+      };
+    }
+
+    return cachedIdentity;
+  } catch {
+    throw new Error(
+      '@opena2a/aim-core is required for vault commands.\n' +
+      '  Install it:  npm install @opena2a/aim-core\n' +
+      '  Or link it:  npm link @opena2a/aim-core',
+    );
+  }
+}
+
+// ── Agent identity helpers ─────────────────────────────────────────
+
+/**
+ * Get or create the agent's Ed25519 identity.
+ * Returns the stored identity (including secret key for signing).
+ */
+export async function getOrCreateAgent(agentName?: string): Promise<StoredIdentity> {
+  const identity = await loadAimCoreIdentity();
+  let stored = identity.loadIdentity(AIM_DATA_DIR);
+  if (!stored) {
+    stored = identity.createIdentity(AIM_DATA_DIR, agentName ?? 'secretless-agent');
+  }
+  return stored;
+}
+
+/**
+ * Get an unlocked VaultStore instance, creating the identity if needed.
+ */
+export async function getVaultStore(): Promise<{
+  store: VaultStoreInstance;
+  agent: StoredIdentity;
+  edSecretKey: Uint8Array;
+  edPublicKey: Uint8Array;
+}> {
+  const vault = await loadAimCoreVault();
+  const agent = await getOrCreateAgent();
+  const edSecretKey = Buffer.from(agent.secretKey, 'base64');
+  const edPublicKey = Buffer.from(agent.publicKey, 'base64');
+
+  const store = new vault.VaultStore(VAULT_DIR);
+  if (!store.exists()) {
+    throw new Error(
+      'Vault not initialized. Run:\n' +
+      '  secretless-ai vault init',
+    );
+  }
+
+  store.unlock(edSecretKey);
+  return { store, agent, edSecretKey, edPublicKey };
+}
+
+// ── Vault commands ─────────────────────────────────────────────────
+
+/**
+ * Initialize a new vault for the current agent identity.
+ * Creates ~/.aim/vault/ with an empty encrypted vault file.
+ */
+export async function vaultInit(agentName?: string): Promise<void> {
+  const vault = await loadAimCoreVault();
+  const agent = await getOrCreateAgent(agentName);
+  const edSecretKey = Buffer.from(agent.secretKey, 'base64');
+
+  const store = new vault.VaultStore(VAULT_DIR);
+  if (store.exists()) {
+    console.log(`\n  Vault already initialized for agent ${agent.agentId}\n`);
+    console.log(`  Vault path:  ${VAULT_DIR}`);
+    console.log(`  Agent:       ${agent.agentName} (${agent.agentId})\n`);
+    return;
+  }
+
+  store.init(agent.agentId, edSecretKey);
+
+  vault.logVaultEvent(VAULT_DIR, {
+    agentId: agent.agentId,
+    operation: 'vault:init',
+    result: 'granted',
+  });
+
+  console.log('\n  Identity Vault initialized.\n');
+  console.log(`  Vault path:  ${VAULT_DIR}`);
+  console.log(`  Agent:       ${agent.agentName} (${agent.agentId})`);
+  console.log(`  Crypto:      XSalsa20-Poly1305, Ed25519 identity-bound`);
+  console.log(`  Identity:    ${AIM_DATA_DIR}\n`);
+  console.log('  Next steps:');
+  console.log('    secretless-ai vault register github --value <token>');
+  console.log('    secretless-ai vault list');
+  console.log('    secretless-ai vault exec github -- curl https://api.github.com/user\n');
+
+  vault.zeroize(edSecretKey);
+}
+
+/**
+ * Register a credential in a vault namespace.
+ */
+export async function vaultRegister(
+  namespace: string,
+  options: {
+    value?: string;
+    description?: string;
+    operations?: VaultOperation[];
+    urlPatterns?: string[];
+    envVar?: string;
+  },
+): Promise<void> {
+  const vault = await loadAimCoreVault();
+  const { store, agent, edSecretKey } = await getVaultStore();
+
+  // Get credential value
+  let credentialValue: string;
+  if (options.value) {
+    credentialValue = options.value;
+  } else if (options.envVar) {
+    const envVal = process.env[options.envVar];
+    if (!envVal) {
+      throw new Error(`Environment variable ${options.envVar} is not set`);
+    }
+    credentialValue = envVal;
+  } else {
+    // Read from stdin (piped or prompt)
+    credentialValue = await readCredentialFromStdin(namespace);
+  }
+
+  // Create namespace if it doesn't exist
+  const existingNs = vault.getNamespace(VAULT_DIR, namespace);
+  if (!existingNs) {
+    vault.createNamespace(VAULT_DIR, {
+      id: namespace,
+      description: options.description ?? `Credentials for ${namespace}`,
+      agentId: agent.agentId,
+      operations: options.operations ?? ['read'],
+      urlPatterns: options.urlPatterns ?? [],
+    });
+  }
+
+  // Encrypt and store
+  const credentialBytes = new TextEncoder().encode(credentialValue);
+  store.storeCredential(namespace, credentialBytes);
+
+  vault.logVaultEvent(VAULT_DIR, {
+    agentId: agent.agentId,
+    namespace,
+    operation: 'store',
+    result: 'granted',
+  });
+
+  console.log(`\n  Credential registered in namespace "${namespace}".`);
+  console.log(`  Version: ${store.listCredentials().find(c => c.namespace === namespace)?.version ?? 1}`);
+  console.log(`\n  Use it:  secretless-ai vault exec ${namespace} -- <command>\n`);
+
+  // Zeroize sensitive material
+  credentialBytes.fill(0);
+  vault.zeroize(edSecretKey);
+  store.lock();
+}
+
+/**
+ * List all vault credentials (metadata only — no values).
+ */
+export async function vaultList(): Promise<void> {
+  const vault = await loadAimCoreVault();
+  const { store, edSecretKey } = await getVaultStore();
+
+  const credentials = store.listCredentials();
+  const namespaces = vault.listNamespaces(VAULT_DIR);
+
+  if (credentials.length === 0) {
+    console.log('\n  No credentials in vault.\n');
+    console.log('  Register one:  secretless-ai vault register <namespace> --value <token>\n');
+    vault.zeroize(edSecretKey);
+    store.lock();
+    return;
+  }
+
+  console.log('\n  Identity Vault Credentials\n');
+  for (const cred of credentials) {
+    const ns = namespaces.find(n => n.id === cred.namespace);
+    const status = ns?.status ?? 'unknown';
+    const statusLabel = status === 'active' ? 'active' : 'REVOKED';
+    console.log(`  ${cred.namespace}`);
+    console.log(`    Status:      ${statusLabel}`);
+    console.log(`    Version:     ${cred.version}`);
+    console.log(`    Encrypted:   ${cred.encryptedAt}`);
+    if (ns?.operations.length) {
+      console.log(`    Operations:  ${ns.operations.join(', ')}`);
+    }
+    if (ns?.urlPatterns.length) {
+      console.log(`    URL patterns: ${ns.urlPatterns.join(', ')}`);
+    }
+    console.log();
+  }
+
+  vault.zeroize(edSecretKey);
+  store.lock();
+}
+
+/**
+ * Rotate a credential in a vault namespace.
+ */
+export async function vaultRotate(
+  namespace: string,
+  options: { value?: string; envVar?: string },
+): Promise<void> {
+  const vault = await loadAimCoreVault();
+  const { store, agent, edSecretKey } = await getVaultStore();
+
+  // Get new credential value
+  let credentialValue: string;
+  if (options.value) {
+    credentialValue = options.value;
+  } else if (options.envVar) {
+    const envVal = process.env[options.envVar];
+    if (!envVal) {
+      throw new Error(`Environment variable ${options.envVar} is not set`);
+    }
+    credentialValue = envVal;
+  } else {
+    credentialValue = await readCredentialFromStdin(namespace);
+  }
+
+  const credentialBytes = new TextEncoder().encode(credentialValue);
+  store.rotateCredential(namespace, credentialBytes);
+
+  vault.logVaultEvent(VAULT_DIR, {
+    agentId: agent.agentId,
+    namespace,
+    operation: 'rotate',
+    result: 'granted',
+  });
+
+  const meta = store.listCredentials().find(c => c.namespace === namespace);
+  console.log(`\n  Credential rotated for namespace "${namespace}".`);
+  console.log(`  New version: ${meta?.version ?? '?'}\n`);
+
+  credentialBytes.fill(0);
+  vault.zeroize(edSecretKey);
+  store.lock();
+}
+
+/**
+ * Revoke a namespace — credentials can no longer be resolved.
+ */
+export async function vaultRevoke(namespace: string): Promise<void> {
+  const vault = await loadAimCoreVault();
+  const { store, agent, edSecretKey } = await getVaultStore();
+
+  const revoked = vault.revokeNamespace(VAULT_DIR, namespace);
+  if (revoked) {
+    store.deleteCredential(namespace);
+
+    vault.logVaultEvent(VAULT_DIR, {
+      agentId: agent.agentId,
+      namespace,
+      operation: 'namespace:revoke',
+      result: 'granted',
+    });
+
+    console.log(`\n  Namespace "${namespace}" revoked and credential deleted.\n`);
+  } else {
+    console.log(`\n  Namespace "${namespace}" was already revoked.\n`);
+  }
+
+  vault.zeroize(edSecretKey);
+  store.lock();
+}
+
+/**
+ * Show vault audit log.
+ */
+export async function vaultAudit(options: {
+  limit?: number;
+  since?: string;
+  namespace?: string;
+}): Promise<void> {
+  const vault = await loadAimCoreVault();
+
+  const events = vault.readVaultAudit(VAULT_DIR, {
+    limit: options.limit ?? 50,
+    since: options.since,
+    namespace: options.namespace,
+  });
+
+  if (events.length === 0) {
+    console.log('\n  No audit events found.\n');
+    return;
+  }
+
+  console.log('\n  Vault Audit Log\n');
+  for (const event of events) {
+    const resultLabel = event.result === 'granted' ? 'OK' :
+                        event.result === 'denied' ? 'DENIED' : 'ERROR';
+    const ns = event.namespace ? ` [${event.namespace}]` : '';
+    const reason = event.denyReason ? ` — ${event.denyReason}` : '';
+    console.log(`  ${event.timestamp}  ${resultLabel}  ${event.operation}${ns}${reason}`);
+  }
+  console.log();
+}
+
+/**
+ * Scan for hardcoded credentials and suggest vault migration.
+ */
+export async function vaultScan(targetDir?: string): Promise<void> {
+  // Re-use secretless-ai's existing scan infrastructure
+  const { scan } = await import('./scan.js');
+  const dir = targetDir ?? process.cwd();
+
+  console.log(`\n  Scanning ${dir} for credentials to migrate to vault...\n`);
+
+  const findings = scan(dir, { includeTests: false });
+  if (findings.length === 0) {
+    console.log('  No hardcoded credentials found.\n');
+    return;
+  }
+
+  console.log(`  Found ${findings.length} credential(s) that could be moved to the vault:\n`);
+  for (const finding of findings) {
+    const relPath = path.relative(dir, finding.file);
+    console.log(`  ${relPath}:${finding.line}`);
+    console.log(`    Pattern:  ${finding.patternId}`);
+    console.log(`    Migrate:  secretless-ai vault register ${finding.patternId.toLowerCase()} --value <value>`);
+    console.log();
+  }
+
+  console.log('  After registering, use vault exec to inject credentials at runtime:');
+  console.log('    secretless-ai vault exec <namespace> -- <command>\n');
+}
+
+/**
+ * Execute a command with vault credentials injected as env vars.
+ *
+ * This is the Tier 2 security mechanism — the key innovation:
+ * 1. Resolve credential via policy-checked flow (signed request)
+ * 2. Spawn child process with credential as env var
+ * 3. Child exits → zeroize credential
+ * 4. Agent process never sees credential values
+ *
+ * CR-001: credential never in agent context
+ * CR-010: pipes/fds only for cross-process isolation
+ */
+export async function vaultExec(
+  namespace: string,
+  command: string[],
+  options?: { envName?: string },
+): Promise<number> {
+  if (command.length === 0) {
+    throw new Error('No command specified. Usage: secretless-ai vault exec <namespace> -- <command>');
+  }
+
+  const vault = await loadAimCoreVault();
+  const { store, agent, edSecretKey, edPublicKey } = await getVaultStore();
+
+  // Step 1: Create signed resolution request
+  const request = vault.createResolutionRequest(
+    namespace,
+    'read',
+    agent.agentId,
+    edSecretKey,
+  );
+
+  // Step 2: Resolve with policy enforcement
+  const result = vault.resolveWithPolicy(request, {
+    vaultDir: VAULT_DIR,
+    store,
+    edPublicKey,
+  });
+
+  if (!result.success || !result.credential) {
+    vault.zeroize(edSecretKey);
+    store.lock();
+    throw new Error(`Vault resolution denied: ${result.error ?? 'unknown error'}`);
+  }
+
+  // Step 3: Decode credential to string for env var injection
+  const credentialStr = new TextDecoder().decode(result.credential);
+
+  // Determine env var name: --env-name flag, or uppercase namespace with dashes replaced
+  const envName = options?.envName ?? namespace.toUpperCase().replace(/-/g, '_');
+
+  // Step 4: Spawn child process with credential as env var
+  const childEnv = { ...process.env, [envName]: credentialStr };
+
+  const child = spawn(command[0], command.slice(1), {
+    env: childEnv,
+    stdio: 'inherit',
+  });
+
+  // Forward signals
+  const signals: NodeJS.Signals[] = ['SIGTERM', 'SIGINT', 'SIGHUP'];
+  const handlers: Array<() => void> = [];
+  for (const sig of signals) {
+    const handler = () => child.kill(sig);
+    handlers.push(handler);
+    process.on(sig, handler);
+  }
+
+  const exitCode = await new Promise<number>((resolve) => {
+    child.on('close', (code) => {
+      for (let i = 0; i < signals.length; i++) {
+        process.removeListener(signals[i], handlers[i]);
+      }
+      resolve(code ?? 1);
+    });
+
+    child.on('error', (err) => {
+      process.stderr.write(`secretless: Failed to start ${command[0]}: ${err.message}\n`);
+      for (let i = 0; i < signals.length; i++) {
+        process.removeListener(signals[i], handlers[i]);
+      }
+      resolve(1);
+    });
+  });
+
+  // Step 5: Zeroize all credential material
+  vault.zeroize(result.credential);
+  vault.zeroize(edSecretKey);
+  // credentialStr is a JS string — can't zeroize, but it was only in this process
+  // and the child process's env was a copy. Both are cleaned up on exit.
+
+  store.lock();
+  return exitCode;
+}
+
+/**
+ * Test vault functionality — verify init, register, resolve, zeroize cycle.
+ */
+export async function vaultTest(): Promise<void> {
+  const vault = await loadAimCoreVault();
+
+  console.log('\n  Vault Self-Test\n');
+
+  // Check 1: aim-core available
+  console.log('  [OK]  @opena2a/aim-core loaded');
+
+  // Check 2: Identity exists
+  const identity = await loadAimCoreIdentity();
+  const stored = identity.loadIdentity(AIM_DATA_DIR);
+  if (!stored) {
+    console.log('  [FAIL]  No agent identity found');
+    console.log('          Fix: secretless-ai vault init\n');
+    return;
+  }
+  console.log(`  [OK]  Agent identity: ${stored.agentId}`);
+
+  // Check 3: Vault exists
+  const store = new vault.VaultStore(VAULT_DIR);
+  if (!store.exists()) {
+    console.log('  [FAIL]  Vault not initialized');
+    console.log('          Fix: secretless-ai vault init\n');
+    return;
+  }
+  console.log('  [OK]  Vault exists at ~/.aim/vault/');
+
+  // Check 4: Vault unlockable
+  try {
+    const edSecretKey = Buffer.from(stored.secretKey, 'base64');
+    store.unlock(edSecretKey);
+    console.log('  [OK]  Vault unlocks with agent identity');
+    vault.zeroize(edSecretKey);
+  } catch (err) {
+    console.log(`  [FAIL]  Vault unlock failed: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+
+  // Check 5: Credential count
+  const creds = store.listCredentials();
+  console.log(`  [OK]  ${creds.length} credential(s) stored`);
+
+  // Check 6: Audit log accessible
+  const events = vault.readVaultAudit(VAULT_DIR, { limit: 1 });
+  console.log(`  [OK]  Audit log: ${events.length > 0 ? 'has events' : 'empty (new vault)'}`);
+
+  store.lock();
+  console.log('\n  All checks passed.\n');
+}
+
+/**
+ * Migrate credentials from secretless SecretStore to the identity vault.
+ */
+export async function vaultMigrate(options: {
+  dryRun?: boolean;
+  envFile?: string;
+}): Promise<void> {
+  const vault = await loadAimCoreVault();
+
+  console.log('\n  Vault Migration\n');
+
+  if (options.envFile) {
+    // Migrate from .env file
+    await migrateFromEnvFile(vault, options.envFile, options.dryRun ?? false);
+    return;
+  }
+
+  // Migrate from SecretStore
+  const { SecretStore } = await import('./secret-store.js');
+  const secretStore = new SecretStore();
+  const secretNames = await secretStore.listSecrets();
+
+  if (secretNames.length === 0) {
+    console.log('  No secrets found in SecretStore to migrate.\n');
+    console.log('  To migrate from a .env file:');
+    console.log('    secretless-ai vault migrate --env-file .env\n');
+    return;
+  }
+
+  console.log(`  Found ${secretNames.length} secret(s) in SecretStore:\n`);
+
+  const { store, agent, edSecretKey } = await getVaultStore();
+
+  let migrated = 0;
+  let skipped = 0;
+
+  for (const name of secretNames) {
+    const namespace = name.toLowerCase().replace(/_/g, '-');
+    const existingNs = vault.getNamespace(VAULT_DIR, namespace);
+
+    if (existingNs) {
+      console.log(`  SKIP  ${name} -> ${namespace} (namespace already exists)`);
+      skipped++;
+      continue;
+    }
+
+    if (options.dryRun) {
+      console.log(`  WOULD  ${name} -> ${namespace}`);
+      migrated++;
+      continue;
+    }
+
+    const value = await secretStore.getSecret(name);
+    if (!value) {
+      console.log(`  SKIP  ${name} (empty value)`);
+      skipped++;
+      continue;
+    }
+
+    // Create namespace and store credential
+    vault.createNamespace(VAULT_DIR, {
+      id: namespace,
+      description: `Migrated from SecretStore: ${name}`,
+      agentId: agent.agentId,
+      operations: ['read'],
+      urlPatterns: [],
+    });
+
+    const credentialBytes = new TextEncoder().encode(value);
+    store.storeCredential(namespace, credentialBytes);
+    credentialBytes.fill(0);
+
+    vault.logVaultEvent(VAULT_DIR, {
+      agentId: agent.agentId,
+      namespace,
+      operation: 'store',
+      result: 'granted',
+      metadata: { migratedFrom: 'SecretStore', originalName: name },
+    });
+
+    console.log(`  OK    ${name} -> ${namespace}`);
+    migrated++;
+  }
+
+  vault.zeroize(edSecretKey);
+  store.lock();
+
+  console.log();
+  if (options.dryRun) {
+    console.log(`  Dry run: ${migrated} would migrate, ${skipped} skipped.`);
+    console.log('  Run without --dry-run to execute.\n');
+  } else {
+    console.log(`  Migrated: ${migrated}, Skipped: ${skipped}`);
+    console.log('\n  Verify: secretless-ai vault list\n');
+  }
+}
+
+// ── Private helpers ────────────────────────────────────────────────
+
+async function readCredentialFromStdin(namespace: string): Promise<string> {
+  // If stdin is a pipe, read from it
+  if (!process.stdin.isTTY) {
+    return new Promise<string>((resolve, reject) => {
+      let data = '';
+      process.stdin.setEncoding('utf-8');
+      process.stdin.on('data', (chunk) => { data += chunk; });
+      process.stdin.on('end', () => resolve(data.trim()));
+      process.stdin.on('error', reject);
+    });
+  }
+
+  // Interactive prompt
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stderr, // Prompt on stderr so stdout stays clean
+  });
+
+  return new Promise<string>((resolve) => {
+    rl.question(`  Enter credential for "${namespace}": `, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+async function migrateFromEnvFile(
+  vault: AimCoreVault,
+  envFilePath: string,
+  dryRun: boolean,
+): Promise<void> {
+  const absPath = path.resolve(envFilePath);
+  if (!fs.existsSync(absPath)) {
+    throw new Error(`File not found: ${absPath}`);
+  }
+
+  const { parseEnvFile } = await import('./env-import.js');
+  const entries = parseEnvFile(fs.readFileSync(absPath, 'utf-8'));
+
+  if (entries.length === 0) {
+    console.log('  No entries found in env file.\n');
+    return;
+  }
+
+  console.log(`  Found ${entries.length} entries in ${envFilePath}:\n`);
+
+  const { store, agent, edSecretKey } = await getVaultStore();
+
+  let migrated = 0;
+  let skipped = 0;
+
+  for (const entry of entries) {
+    const namespace = entry.name.toLowerCase().replace(/_/g, '-');
+    const existingNs = vault.getNamespace(VAULT_DIR, namespace);
+
+    if (existingNs) {
+      console.log(`  SKIP  ${entry.name} -> ${namespace} (namespace already exists)`);
+      skipped++;
+      continue;
+    }
+
+    if (dryRun) {
+      console.log(`  WOULD  ${entry.name} -> ${namespace}`);
+      migrated++;
+      continue;
+    }
+
+    vault.createNamespace(VAULT_DIR, {
+      id: namespace,
+      description: `Migrated from ${path.basename(envFilePath)}: ${entry.name}`,
+      agentId: agent.agentId,
+      operations: ['read'],
+      urlPatterns: [],
+    });
+
+    const credentialBytes = new TextEncoder().encode(entry.value);
+    store.storeCredential(namespace, credentialBytes);
+    credentialBytes.fill(0);
+
+    vault.logVaultEvent(VAULT_DIR, {
+      agentId: agent.agentId,
+      namespace,
+      operation: 'store',
+      result: 'granted',
+      metadata: { migratedFrom: envFilePath, originalName: entry.name },
+    });
+
+    console.log(`  OK    ${entry.name} -> ${namespace}`);
+    migrated++;
+  }
+
+  vault.zeroize(edSecretKey);
+  store.lock();
+
+  console.log();
+  if (dryRun) {
+    console.log(`  Dry run: ${migrated} would migrate, ${skipped} skipped.`);
+    console.log('  Run without --dry-run to execute.\n');
+  } else {
+    console.log(`  Migrated: ${migrated}, Skipped: ${skipped}`);
+    if (!dryRun && migrated > 0) {
+      console.log(`\n  Consider removing credentials from ${envFilePath} now that they are in the vault.`);
+    }
+    console.log('\n  Verify: secretless-ai vault list\n');
+  }
+}
+
+// ── Exported paths (for testing) ───────────────────────────────────
+
+export const PATHS = {
+  vaultDir: VAULT_DIR,
+  aimDataDir: AIM_DATA_DIR,
+} as const;


### PR DESCRIPTION
## Summary
- Adds `vault-core.ts` (~880 lines): orchestration layer with 10 exported functions, dynamic `require()` of aim-core
- Adds `commands/vault.ts` (~270 lines): CLI dispatcher with 10 subcommands
- Wires into existing CLI (cli.ts, help.ts, index.ts, package.json)
- 37 new tests (520 total → 846 with aim-core), zero regressions

## Commands added
`secretless-ai vault {init|register|list|rotate|revoke|audit|scan|exec|test|migrate}`

## Key design decisions
- `require()` used (not `await import()`) for aim-core dynamic loading — better with commonjs + vitest mocking
- `vault exec`: signed request → resolveWithPolicy → decrypt → spawn child with env var → zeroize (CR-001)
- `vault migrate` supports SecretStore → Vault and .env → Vault migration paths

## Test plan
- [x] `npm test` — 846 tests pass (37 new vault tests)
- [x] vault-core: init→register→list→rotate→revoke round-trip
- [x] vault exec: spawns subprocess with injected env, does NOT leak creds to stdout
- [x] vault migrate: from SecretStore + from .env
- [x] CLI dispatch: arg parsing, error handling, help text
- [x] Dynamic import failure: actionable error message