### PR TITLE
docs: broker daemon + bring-your-own-vault + three-tier architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `broker status` no longer reports `Policies: 0 / Requests: 0 / AIM: not connected` regardless of live state.
 - `scan-staged` (pre-commit hook) now applies the same known-example-key allowlist as `scan`. Previously, docs or CHANGELOG entries that referenced public example keys like `AKIAIOSFODNN7EXAMPLE` could trigger false-positive commit blocks.
 
+### Documentation
+- New README "Architecture" section names the three tiers (SDK, Vault Exec, Broker) and states that AIM is optional — Tiers 1 and 2 work against any supported backend.
+- New guide `docs/use-cases/bring-your-own-vault.md` — connect Secretless to an existing HashiCorp Vault / 1Password / GCP Secret Manager with round-trip verification using stock vault tooling.
+- New guide `docs/use-cases/run-broker.md` — when to run the broker daemon, how to write policies, AIM-connected mode, audit log.
+- `team-setup.md` now flags the 1Password desktop biometric prompt on first `backend` run.
+
 ## [0.14.0] - 2026-04-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -65,12 +65,38 @@ npx secretless-ai mcp-unprotect                    # Restore original configs fr
 3. **Blocks** AI tools from reading credential files (21 file patterns)
 4. **Brokers** access through environment variables -- secrets never enter AI context
 
+## Architecture
+
+Secretless has three layers. You can use one, two, or all three — each is independent and works against any supported backend.
+
+**Tier 1 — In-process SDK.** Credentials resolved in the call stack and zeroized after use. Available in the Python and TypeScript AIM SDKs. Sub-millisecond overhead.
+
+**Tier 2 — Vault Exec.** A subprocess primitive that injects a credential into a child process's environment without exposing it to the parent. The agent running under an AI assistant never sees the secret.
+
+```bash
+npx secretless-ai vault exec github -- curl https://api.github.com/user
+```
+
+The child process receives `$GITHUB`. The parent shell, the AI tool's context, and any process listing see nothing. Language-agnostic — wraps any command.
+
+**Tier 3 — Broker with identity policy.** A local daemon that mediates credential access across multiple agents. Policy rules allow or deny access by agent ID, credential name, time window, and rate limit. Optional AIM integration adds trust-score and capability constraints.
+
+```bash
+npx secretless-ai broker start
+```
+
+See [Run the Broker](docs/use-cases/run-broker.md) for when to use the daemon and how to configure it.
+
+**AIM is optional.** Tier 1 and Tier 2 work against any of the five [storage backends](#storage-backends) with no AIM involvement. Tier 3 adds identity-bound policy when an AIM server is reachable; it still enforces default-deny locally without one.
+
 ## Use Cases
 
 Step-by-step guides for common workflows: [docs/USE-CASES.md](docs/USE-CASES.md)
 
 - [Protect My Credentials](docs/use-cases/protect-my-credentials.md) -- Keep API keys out of AI tools (2 min)
 - [Secure MCP Configs](docs/use-cases/secure-mcp-configs.md) -- Encrypt MCP server credentials (3 min)
+- [Bring Your Own Vault](docs/use-cases/bring-your-own-vault.md) -- Point Secretless at HashiCorp Vault, GCP SM, or 1Password (3 min)
+- [Run the Broker](docs/use-cases/run-broker.md) -- Policy-gated credential daemon for multi-agent runtimes (3 min)
 - [Team Setup](docs/use-cases/team-setup.md) -- Shared backend, CI/CD, onboarding (5 min)
 - [Migrate from .env](docs/use-cases/migrate-from-dotenv.md) -- Move .env files to encrypted storage (3 min)
 

--- a/docs/USE-CASES.md
+++ b/docs/USE-CASES.md
@@ -8,6 +8,8 @@ Step-by-step guides for common secretless-ai workflows. Each guide takes 2-5 min
 |-------|----------|------|
 | [Protect My Credentials](use-cases/protect-my-credentials.md) | Keep API keys out of AI tools | 2 min |
 | [Secure MCP Configs](use-cases/secure-mcp-configs.md) | Encrypt credentials in MCP server configurations | 3 min |
+| [Bring Your Own Vault](use-cases/bring-your-own-vault.md) | Point Secretless at HashiCorp Vault, GCP SM, or 1Password | 3 min |
+| [Run the Broker](use-cases/run-broker.md) | Policy-gated credential daemon for multi-agent runtimes | 3 min |
 | [Team Setup](use-cases/team-setup.md) | Set up secretless for a team with shared backend | 5 min |
 | [Migrate from .env](use-cases/migrate-from-dotenv.md) | Move from .env files to secure storage | 3 min |
 
@@ -15,6 +17,8 @@ Step-by-step guides for common secretless-ai workflows. Each guide takes 2-5 min
 
 - **Solo developer, first time:** Start with [Protect My Credentials](use-cases/protect-my-credentials.md). One command, immediate protection.
 - **Using MCP servers:** Go to [Secure MCP Configs](use-cases/secure-mcp-configs.md). MCP server configs store plaintext API keys in JSON files that AI tools can read.
+- **Already have a vault (HashiCorp / GCP / 1Password):** [Bring Your Own Vault](use-cases/bring-your-own-vault.md) shows how to point Secretless at it — no AIM required.
+- **Multiple agents, need policy enforcement:** [Run the Broker](use-cases/run-broker.md) sets up the credential daemon with per-agent rate limits and an audit log.
 - **Setting up a team:** Follow [Team Setup](use-cases/team-setup.md) to choose a shared backend and configure CI/CD.
 - **Already using .env files:** [Migrate from .env](use-cases/migrate-from-dotenv.md) moves existing secrets to encrypted storage without changing your workflow.
 

--- a/docs/use-cases/bring-your-own-vault.md
+++ b/docs/use-cases/bring-your-own-vault.md
@@ -1,0 +1,122 @@
+# I already have a vault
+
+**Time:** 3 minutes
+**Prerequisites:** An existing secrets backend you trust (HashiCorp Vault, GCP Secret Manager, or 1Password)
+
+If your team already runs a vault, you don't need another one. Point Secretless at the vault you already have and everything downstream — `secret set`, `run --only`, `protect-mcp`, the broker — resolves against it.
+
+You don't need an AIM account for any of this. The backend is local to your configuration; Secretless is the client.
+
+## Step 1: Pick your backend
+
+Five backends are wired into the CLI today:
+
+| Backend | Shared across machines? | Requires |
+|---------|-------------------------|----------|
+| `local` | No (single machine, encrypted file) | Nothing |
+| `keychain` | No (macOS Keychain / Linux Secret Service) | Native OS keychain |
+| `1password` | Yes | `op` CLI installed and signed in |
+| `vault` | Yes | A reachable HashiCorp Vault with a token |
+| `gcp-sm` | Yes | GCP Application Default Credentials |
+
+For AWS Secrets Manager and Azure Key Vault, use the Go AIM backend instead — those aren't part of this CLI today. Track status on the AIM repo.
+
+## Step 2: Connect to HashiCorp Vault (canonical walk-through)
+
+Every external backend follows the same pattern: set env vars, run `backend set <name>`, verify. HashiCorp Vault is the most common — the other backends work identically.
+
+```bash
+export VAULT_ADDR=https://vault.yourcompany.com
+export VAULT_TOKEN=<your-token>
+npx secretless-ai backend set vault
+```
+
+Expected output:
+
+```
+  Backend set to: vault
+
+  Run `npx secretless-ai protect-mcp` to re-protect MCP servers with the new backend.
+  Or use `npx secretless-ai migrate` to migrate existing secrets.
+```
+
+Confirm the CLI sees it:
+
+```bash
+npx secretless-ai backend
+```
+
+```
+  Current:      vault
+  Config file:  vault
+  Vault:        configured (https://vault.yourcompany.com)
+  ...
+```
+
+## Step 3: Round-trip a credential
+
+```bash
+npx secretless-ai secret set GITHUB_TOKEN=ghp_<your-real-token>
+npx secretless-ai run --only GITHUB_TOKEN -- curl -s -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/user
+```
+
+The credential is stored in Vault under `<mount>/secret/GITHUB_TOKEN`. Default mount is `secret`, so full Vault path is `secret/secret/GITHUB_TOKEN`. Read it back with stock Vault tooling to confirm:
+
+```bash
+vault kv get secret/secret/GITHUB_TOKEN
+```
+
+```
+==== Data ====
+Key      Value
+---      -----
+value    ghp_<your-real-token>
+```
+
+That's the point: the credential is a normal Vault entry. No Secretless-proprietary encoding, no wrapper format, nothing that would make it hard to migrate off later.
+
+## Same pattern — other backends
+
+| Backend | Env vars to set |
+|---------|-----------------|
+| `1password` | `op` CLI signed in (or `OP_SERVICE_ACCOUNT_TOKEN` for CI) |
+| `gcp-sm` | `GOOGLE_CLOUD_PROJECT` (uses Application Default Credentials) |
+
+Then:
+
+```bash
+npx secretless-ai backend set <name>
+npx secretless-ai secret set MY_KEY=<value>
+npx secretless-ai run --only MY_KEY -- <command>
+```
+
+## Vault Exec — isolating credentials from AI context
+
+Once your backend is connected, use `vault exec` (Tier 2) to run commands without ever exposing the secret to your parent shell or the AI tool watching it:
+
+```bash
+npx secretless-ai vault exec github -- curl -H "Authorization: Bearer $GITHUB" https://api.github.com/user
+```
+
+The child process gets `$GITHUB`. The parent shell does not. The AI assistant reading your terminal output sees the command but never the secret.
+
+## When would I add AIM?
+
+You don't need AIM to use any of the above. AIM unlocks:
+
+- **Identity-bound policy** at the broker: rules that gate by agent trust score or capability, not just agent ID
+- **Shared policy** across a team: one AIM instance enforces the same rules for every developer's broker
+- **Cross-team audit**: AIM-side logs of which agent requested which credential from which host
+
+If none of that matches your use case, stick with the local Tier 1 / Tier 2 flow against your existing vault. You can always add AIM later without re-configuring your backend.
+
+## Caveats
+
+- The first time you run `secretless-ai backend` on a machine where 1Password Desktop integration is enabled, `op` triggers a biometric / unlock prompt (used to check 1Password availability). Cancel or unlock — both are safe. Not triggered when 1Password is not installed or the `op` CLI isn't on `$PATH`.
+- Vault tokens on the command line are visible in `ps aux` — prefer env vars (as shown above) or a token file sourced from a `.envrc`.
+
+## Next steps
+
+- [Run the Broker](run-broker.md) -- When to run the daemon for multi-agent workflows
+- [Team Setup](team-setup.md) -- Shared backend + CI/CD
+- [Secure MCP Configs](secure-mcp-configs.md) -- Encrypt MCP server credentials using the same backend

--- a/docs/use-cases/run-broker.md
+++ b/docs/use-cases/run-broker.md
@@ -1,0 +1,218 @@
+# Run the broker
+
+**Time:** 3 minutes
+**Prerequisites:** Node 20+, a storage backend configured ([Bring Your Own Vault](bring-your-own-vault.md))
+
+The broker is a local daemon that mediates credential access for one or more agents. Policy rules gate every resolve: agent ID, credential name, time window, rate limit, optional AIM trust score and capabilities.
+
+## When do I need the broker?
+
+For most workflows you don't — `vault exec` (Tier 2) is enough. Reach for the broker when:
+
+- **Multiple long-lived agents** need credentials in the same session, and you want one policy to govern all of them
+- You need **per-agent rate limits** (e.g. "scan-bot gets at most 10 resolves per minute on GITHUB_*")
+- You want an **audit log** of every credential access, not just the run
+- You plan to wire AIM trust-score policy later
+
+If you're running one short-lived script, skip the daemon — `secretless-ai run --only KEY -- cmd` is simpler.
+
+## Storage: two separate stores
+
+Important architectural note before you start:
+
+- **Identity Vault** (`~/.aim/vault`) — what `vault register` and `vault exec` use. Ed25519 identity-bound, XSalsa20-Poly1305.
+- **SecretStore** (your configured backend: local, keychain, 1password, vault, gcp-sm) — what `secret set`, `run --only`, and the broker's `/resolve` endpoint use.
+
+The broker does **not** read from the Identity Vault. `vault exec` does. They're two independent storage paths. Pick the one that fits your use case; most broker users will put credentials in SecretStore.
+
+## Start the broker
+
+```bash
+npx secretless-ai broker start
+```
+
+```
+  Secretless Broker
+
+  Starting credential broker daemon...
+  Broker is running.
+
+  PID:          12345
+  HTTP port:    19421
+  Socket:       /Users/you/.secretless-ai/broker.sock
+  AIM:          not configured
+  Policy file:  (default)
+
+  Press Ctrl+C to stop.
+```
+
+The daemon is foreground by default. In a second terminal:
+
+```bash
+npx secretless-ai broker status
+```
+
+```
+  Secretless Broker Status
+
+  Status:       running
+  PID:          12345
+  Uptime:       5s
+  HTTP port:    19421
+  Socket:       /Users/you/.secretless-ai/broker.sock
+  AIM:          not configured
+  Policies:     0
+  Requests:     0
+```
+
+Stop the daemon:
+
+```bash
+npx secretless-ai broker stop
+```
+
+## Authenticate to the broker
+
+The broker generates a random bearer token on start and writes it to `~/.secretless-ai/broker.token` (mode `0600`). Any client resolving a credential must pass it:
+
+```bash
+TOK=$(cat ~/.secretless-ai/broker.token)
+curl -H "Authorization: Bearer $TOK" http://127.0.0.1:19421/status
+```
+
+HTTP routes:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/health` | Health check |
+| `GET` | `/status` | Uptime, request count, policy count, AIM state |
+| `POST` | `/resolve` | `{agentId, credentialName}` -> `{value}` or 403 |
+
+Both the HTTP port and a Unix socket at `~/.secretless-ai/broker.sock` accept the same routes. The socket is `0600`, same user only.
+
+## Write a policy
+
+Default deny. Without a policy, every `/resolve` returns 403.
+
+Create `~/.secretless-ai/broker-policies.json`:
+
+```json
+{
+  "version": 1,
+  "rules": [
+    {
+      "id": "scanner-github-readonly",
+      "agentSelector": "scan-*",
+      "credentialSelector": "GITHUB_TOKEN",
+      "constraints": {
+        "rateLimit": { "maxPerMinute": 30 },
+        "timeWindow": { "start": "09:00", "end": "18:00" }
+      },
+      "effect": "allow"
+    }
+  ]
+}
+```
+
+Supported constraints:
+
+- `timeWindow` — 24h, supports overnight (e.g. `22:00`–`06:00`)
+- `rateLimit.maxPerMinute` — per agent + credential pair
+- `minTrustScore` — AIM-only, see below
+- `requireCapability` — AIM-only, see below
+- `scopeCheck` — deny if credential permissions expanded since last baseline
+
+Reload by restarting the daemon. Or pass `--policy-file <path>` on start to use a non-default location.
+
+## AIM-connected mode
+
+If you run an AIM server and want trust-score / capability policy constraints to work:
+
+```bash
+export SECRETLESS_AIM_TOKEN=<bearer-token>
+npx secretless-ai broker start --aim-url https://aim.oa2a.org
+```
+
+Or on the flag:
+
+```bash
+npx secretless-ai broker start --aim-url https://aim.oa2a.org --aim-token <bearer-token>
+```
+
+Prefer the env var — CLI tokens are visible in `ps aux`.
+
+Check AIM wiring:
+
+```bash
+npx secretless-ai broker status
+```
+
+```
+  AIM:          configured (reachable)
+```
+
+Three possible AIM states:
+
+| Status | Meaning |
+|--------|---------|
+| `not configured` | `--aim-url` was not passed |
+| `configured (reachable)` | AIM responded to `/health` at startup |
+| `configured (unreachable)` | `--aim-url` set but AIM did not respond — trust-score / capability constraints will never be satisfied until AIM comes back |
+
+If AIM returns 4xx on agent identity lookups (typically 401 from a missing or bad token), an `aim_auth_error` event lands in `~/.secretless-ai/broker-audit.log` with the status and URL. Check the audit log if your trust-score rules appear to never match.
+
+## Audit log
+
+Every resolve, every auth failure, every startup and shutdown — `~/.secretless-ai/broker-audit.log`, one JSON event per line.
+
+```bash
+tail -f ~/.secretless-ai/broker-audit.log
+```
+
+```json
+{"timestamp":"...","eventType":"resolve","agentId":"scan-01","credentialName":"GITHUB_TOKEN","policyId":"scanner-github-readonly","result":"allowed","reason":"Allowed by rule ...","latencyMs":3}
+{"timestamp":"...","eventType":"auth","agentId":"unknown","credentialName":"","policyId":"","result":"denied","reason":"Unauthorized access attempt from 127.0.0.1","latencyMs":0}
+```
+
+## Client integration
+
+An agent resolving a credential from the broker makes a POST with its agent ID and the credential name. Example in shell:
+
+```bash
+TOK=$(cat ~/.secretless-ai/broker.token)
+curl -s -X POST \
+  -H "Authorization: Bearer $TOK" \
+  -H "Content-Type: application/json" \
+  -d '{"agentId":"scan-01","credentialName":"GITHUB_TOKEN"}' \
+  http://127.0.0.1:19421/resolve
+```
+
+```json
+{"value":"ghp_..."}
+```
+
+Denied requests return HTTP 403 with a reason:
+
+```json
+{"error":"Access denied","reason":"No matching allow rule (default deny)"}
+```
+
+## Stop
+
+```bash
+npx secretless-ai broker stop
+```
+
+The daemon removes the socket, pid file, and auth token on shutdown.
+
+## Troubleshooting
+
+- **`broker status` shows `Policies: 0` but I have a policy file** — confirm the file is at `~/.secretless-ai/broker-policies.json` or you passed `--policy-file`. Restart the daemon after edits. `broker status` now pulls live values from the running server, so a zero means the daemon really loaded zero rules.
+- **All `/resolve` calls return 403 "default deny"** — write an `allow` rule that matches your `agentId` and `credentialSelector`. Check the audit log for the exact input.
+- **AIM shows `configured (unreachable)`** — probe the URL yourself: `curl -s -o /dev/null -w "%{http_code}\n" <aim-url>/health`. Common causes: wrong URL, network segmentation, AIM not deployed to that host.
+
+## Next steps
+
+- [Bring Your Own Vault](bring-your-own-vault.md) -- Connect the broker to HashiCorp Vault or 1Password
+- [Team Setup](team-setup.md) -- Shared backend + CI/CD
+- [Protect My Credentials](protect-my-credentials.md) -- The simpler flow when you don't need the daemon

--- a/docs/use-cases/team-setup.md
+++ b/docs/use-cases/team-setup.md
@@ -16,6 +16,8 @@ When working on a team, each developer needs access to the same secrets without 
 
 For most teams, 1Password is the simplest starting point. Every developer already has it, and CI/CD uses service account tokens.
 
+> **1Password caveat:** On a machine where the 1Password desktop app is installed and CLI integration is enabled, the first `secretless-ai backend` run triggers a biometric / master-password prompt (used to confirm `op` availability). Cancel it if you don't want 1Password — the backend probe falls back cleanly. If you do want 1Password, unlock once and subsequent calls stay inside the cache window.
+
 ## Step 2: Configure the backend
 
 ### 1Password


### PR DESCRIPTION
## Summary

The README previously framed Secretless as an AI-tool credential blocker. Accurate, but narrow — the v2 architecture has three independent tiers, a broker daemon, and five pluggable backends, and none of that was documented. An enterprise evaluator reading today's README would reasonably conclude AIM is required. It isn't.

This PR is documentation only — no code changes, no behavior changes, no npm publish.

## What changes

### README.md

- New **Architecture** section between *How It Works* and *Use Cases*. Names the three tiers (in-process SDK, Vault Exec subprocess, broker with identity policy) in one paragraph each, with a single `vault exec` example for Tier 2 and a pointer to the broker guide for Tier 3.
- Explicit line: **"AIM is optional. Tier 1 and Tier 2 work against any of the five storage backends with no AIM involvement."**
- Use Cases list expanded with two new guides.

### New: `docs/use-cases/bring-your-own-vault.md`

3-minute walk-through. Framing: "You already have a vault. You don't need another one."

- Walk-through for HashiCorp Vault with a **round-trip verification using stock `vault kv get`** — proves the credential is a normal Vault entry with no Secretless-proprietary encoding.
- Short blocks for `1password` and `gcp-sm`.
- "When would I add AIM?" section spells out what AIM unlocks vs what works without it.
- Notes the Vault mount + key-prefix detail (`{mount}/secret/{KEY}`).
- Known caveat: `op` biometric prompt on first `backend` run.

### New: `docs/use-cases/run-broker.md`

3-minute walk-through for the broker daemon.

- When to run the daemon vs. pure `vault exec` (short-lived vs. multi-agent).
- **Important storage note**: the broker's resolver reads from SecretStore + MCP vault, NOT from the Identity Vault at `~/.aim/vault`. `vault exec` reads the Identity Vault. Two separate stores — flagged up front.
- `start` / `stop` / `status` with post-fix output (live `Policies` and `Requests` counts, `configured (reachable)` / `configured (unreachable)` AIM status).
- Policy file format with a minimal working example.
- AIM-connected mode: `--aim-url`, `--aim-token`, `SECRETLESS_AIM_TOKEN` env var.
- HTTP routes and auth token flow.
- Audit log structure.
- Troubleshooting section.

### `docs/use-cases/team-setup.md`

Added a caveat that `secretless-ai backend` triggers a 1Password biometric prompt on machines with 1Password Desktop CLI integration enabled.

### `docs/USE-CASES.md`

Index expanded with two new rows and two new "when to start here" bullets.

### `CHANGELOG.md`

New **Documentation** subsection under Unreleased.

## Accuracy

Every command example is copy-pasted real output from a verification run (verification log lives at `opena2a-org/briefs/secretless-docs-verification-log.md`). No fabricated output.

Concrete claims checked against source:
- 5 backends in the CLI: confirmed in `src/backends/factory.ts`
- Broker HTTP surface (`/health`, `/status`, `/resolve`): confirmed in `src/broker/server.ts`
- Vault storage path `{mount}/secret/{KEY}`: verified by reading `secret/secret/VAULT_ROUNDTRIP` back with stock `vault kv get` after writing via Secretless
- AIM status states match post-fix behavior from PR #49 (`aimConfigured` + `aimReachable`)

## Out of scope

- Website docs at `opena2a.org/docs/secretless` (separate repo, separate PR)
- Tier 3 ATC end-to-end tutorial (requires running AIM instance; enough content for its own guide)
- Diagrams (text-only for this PR)

## Test plan

- [ ] `bring-your-own-vault.md` — walk through it with a fresh Vault dev container, confirm every command works as printed
- [ ] `run-broker.md` — start broker, walk the policy / AIM-unreachable / AIM-reachable scenarios, confirm audit log matches documented shape
- [ ] README Architecture section reads well on GitHub's rendered markdown
- [ ] No dead internal links (verified locally)