### PR TITLE
fix(scan): isKnownExample precedence + known-example shadowing

### DIFF
--- a/src/scan-staged.test.ts
+++ b/src/scan-staged.test.ts
@@ -115,4 +115,32 @@ describe('scanStagedFiles', () => {
     const result = scanStagedFiles();
     expect(result.findings.length).toBeGreaterThan(0);
   });
+
+  it('issue #51: does NOT let a known-example key shadow a real credential of another pattern on the same line', () => {
+    mockExecFileSync.mockImplementation((cmd: string, args?: readonly string[]) => {
+      if (args && args.includes('--name-only')) {
+        return 'config.js\n';
+      }
+      // Same line: public AWS example + real GitHub PAT. Previously the AWS
+      // example match triggered a `break` and the real PAT was never checked.
+      return 'const old = "AKIAIOSFODNN7EXAMPLE"; const new_ = "ghp_abcdefghijklmnopqrstuvwxyz1234567890";\n';
+    });
+
+    const result = scanStagedFiles();
+    const names = result.findings.map(f => f.patternName);
+    expect(names).toContain('GitHub Token');
+  });
+
+  it('issue #51: does NOT let a known-example AWS key shadow a real AWS key later on the same line', () => {
+    mockExecFileSync.mockImplementation((cmd: string, args?: readonly string[]) => {
+      if (args && args.includes('--name-only')) {
+        return 'config.js\n';
+      }
+      return 'const keys = ["AKIAIOSFODNN7EXAMPLE", "AKIAREALKEY1234567890"];\n';
+    });
+
+    const result = scanStagedFiles();
+    expect(result.findings.length).toBeGreaterThan(0);
+    expect(result.findings[0].patternName).toBe('AWS Access Key');
+  });
 });

--- a/src/scan-staged.ts
+++ b/src/scan-staged.ts
@@ -7,7 +7,7 @@
 
 import { execFileSync } from 'child_process';
 import { CREDENTIAL_PATTERNS, SECRET_FILE_PATTERNS, CREDENTIAL_PREFIX_QUICK_CHECK } from './patterns';
-import { isKnownExample } from './scan';
+import { findRealMatch } from './scan';
 
 interface StagedFinding {
   file: string;
@@ -96,14 +96,8 @@ export function scanStagedFiles(): { findings: StagedFinding[]; blockedFiles: st
       }
 
       for (const pattern of CREDENTIAL_PATTERNS) {
-        // Reset lastIndex so /g regexes don't skip matches across lines
-        pattern.regex.lastIndex = 0;
-        const match = line.match(pattern.regex);
+        const match = findRealMatch(line, pattern);
         if (!match) continue;
-
-        // Skip public example keys (e.g. AWS AKIAIOSFODNN7EXAMPLE in docs)
-        // Parity with the non-staged scanner.
-        if (isKnownExample(line, match)) break;
 
         findings.push({
           file,

--- a/src/scan.test.ts
+++ b/src/scan.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { isKnownExample, findRealMatch } from './scan';
+import { CREDENTIAL_PATTERNS } from './patterns';
+
+function patternByName(name: string) {
+  const p = CREDENTIAL_PATTERNS.find(p => p.name === name);
+  if (!p) throw new Error(`pattern ${name} not found`);
+  return p;
+}
+
+describe('isKnownExample (issue #50 — comment-marker precedence)', () => {
+  it('does NOT treat a line with # but no "example" as a known example', () => {
+    // Python comment line with a credential-shaped value but no "example" marker.
+    // Previous buggy precedence `(A && B) || C` would enter the inner block on any
+    // line containing `#`. Regression guard: must return false here.
+    const line = '# TODO: rotate AKIAREALKEY1234567890 next sprint';
+    const match = line.match(/AKIA[0-9A-Z]{16}/)!;
+    expect(match).not.toBeNull();
+    expect(isKnownExample(line, match)).toBe(false);
+  });
+
+  it('DOES treat a line with "example //" as a known example', () => {
+    const line = 'const key = "AKIASOMEOTHERKEY12345"; // example placeholder';
+    const match = line.match(/AKIA[0-9A-Z]{16}/)!;
+    expect(match).not.toBeNull();
+    expect(isKnownExample(line, match)).toBe(true);
+  });
+
+  it('treats the AKIAIOSFODNN7EXAMPLE public example as a known example', () => {
+    const line = 'See AKIAIOSFODNN7EXAMPLE in the AWS docs.';
+    const match = line.match(/AKIA[0-9A-Z]{16}/)!;
+    expect(isKnownExample(line, match)).toBe(true);
+  });
+});
+
+describe('findRealMatch (issue #51 — known-example shadowing)', () => {
+  it('mixed-pattern line: AWS example + real GitHub PAT returns the PAT', () => {
+    // Intentionally NO `//` or `#` markers — we're testing that the KNOWN_EXAMPLE_KEYS
+    // match for AKIAIOSFODNN7EXAMPLE does not shadow the real GitHub PAT later on
+    // the same line. (Lines with comment+example context are an orthogonal case
+    // handled by isKnownExample directly.)
+    const line = 'const old = "AKIAIOSFODNN7EXAMPLE"; const new_ = "ghp_abcdefghijklmnopqrstuvwxyz1234567890";';
+    const awsPattern = patternByName('AWS Access Key');
+    const ghPattern = patternByName('GitHub Token');
+
+    // AWS pattern: only match is the public example -> no real match
+    expect(findRealMatch(line, awsPattern)).toBeNull();
+    // GitHub pattern: match is real
+    const ghMatch = findRealMatch(line, ghPattern);
+    expect(ghMatch).not.toBeNull();
+    expect(ghMatch![0]).toBe('ghp_abcdefghijklmnopqrstuvwxyz1234567890');
+  });
+
+  it('multi-match same-pattern line: example AKIAIOSFODNN7EXAMPLE before real AKIA key returns the real one', () => {
+    // AWS Access Key pattern ships without /g; findRealMatch must still iterate
+    // every match on the line and skip the example to find the real key.
+    const line = 'const keys = ["AKIAIOSFODNN7EXAMPLE", "AKIAREALKEY1234567890"];';
+    const awsPattern = patternByName('AWS Access Key');
+    const match = findRealMatch(line, awsPattern);
+    expect(match).not.toBeNull();
+    // AWS regex is AKIA[0-9A-Z]{16} — match is exactly 20 chars, trailing digits truncated.
+    expect(match![0]).toBe('AKIAREALKEY123456789');
+  });
+
+  it('returns null when every match on the line is a known example', () => {
+    const line = '// examples: AKIAIOSFODNN7EXAMPLE';
+    const awsPattern = patternByName('AWS Access Key');
+    expect(findRealMatch(line, awsPattern)).toBeNull();
+  });
+});

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -5,7 +5,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { CREDENTIAL_PATTERNS, CONFIG_FILES, CREDENTIAL_PREFIX_QUICK_CHECK, SOURCE_FILE_EXTENSIONS, SOURCE_SKIP_DIRS, KNOWN_EXAMPLE_KEYS, PLACEHOLDER_INDICATORS } from './patterns';
+import { CREDENTIAL_PATTERNS, CONFIG_FILES, CREDENTIAL_PREFIX_QUICK_CHECK, SOURCE_FILE_EXTENSIONS, SOURCE_SKIP_DIRS, KNOWN_EXAMPLE_KEYS, PLACEHOLDER_INDICATORS, type CredentialPattern } from './patterns';
 
 export interface ScanFinding {
   file: string;
@@ -65,10 +65,35 @@ export function isKnownExample(line: string, match: RegExpMatchArray): boolean {
   if (PLACEHOLDER_INDICATORS.some(p => lower.includes(p))) return true;
   // Check if the line contains a comment marking it as an example
   const lineLC = line.toLowerCase();
-  if (lineLC.includes('example') && lineLC.includes('//') || lineLC.includes('#')) {
+  if (lineLC.includes('example') && (lineLC.includes('//') || lineLC.includes('#'))) {
     if (lineLC.includes('example') || lineLC.includes('placeholder') || lineLC.includes('fake')) return true;
   }
   return false;
+}
+
+/**
+ * Return the first match in `line` for `pattern.regex` that is NOT a known
+ * example, or null if every match is an example (or there are no matches).
+ *
+ * For /g regexes this iterates all matches via matchAll so that a known
+ * example of a given pattern on a line does not shadow a real credential
+ * of the same pattern later on that line. Non-global regexes fall back to
+ * a single match check.
+ *
+ * Exported so scan-staged and any other scanner stays in lockstep.
+ */
+export function findRealMatch(line: string, pattern: CredentialPattern): RegExpMatchArray | null {
+  // matchAll requires /g. Promote non-/g patterns so we iterate EVERY match on
+  // the line — otherwise a known-example match at position 0 would shadow a
+  // real credential of the same pattern later on the same line.
+  const globalRegex = pattern.regex.flags.includes('g')
+    ? pattern.regex
+    : new RegExp(pattern.regex.source, pattern.regex.flags + 'g');
+  globalRegex.lastIndex = 0;
+  for (const m of line.matchAll(globalRegex)) {
+    if (!isKnownExample(line, m)) return m;
+  }
+  return null;
 }
 
 /** Global config files that may contain secrets (outside project dir) */
@@ -100,9 +125,8 @@ export function scan(projectDir: string, options?: ScanOptions): ScanFinding[] {
         if (line.length > 4096) continue;
         if (/\$\{[A-Z_]+\}/.test(line) && !CREDENTIAL_PREFIX_QUICK_CHECK.test(line)) continue;
         for (const pattern of CREDENTIAL_PATTERNS) {
-          const match = line.match(pattern.regex);
+          const match = findRealMatch(line, pattern);
           if (match) {
-            if (isKnownExample(line, match)) break;
             const globalRegex = new RegExp(pattern.regex.source, pattern.regex.flags.includes('g') ? pattern.regex.flags : pattern.regex.flags + 'g');
             const masked = line.replace(globalRegex, `[${pattern.name} REDACTED]`);
             findings.push({
@@ -144,9 +168,8 @@ export function scan(projectDir: string, options?: ScanOptions): ScanFinding[] {
         }
 
         for (const pattern of CREDENTIAL_PATTERNS) {
-          const match = line.match(pattern.regex);
+          const match = findRealMatch(line, pattern);
           if (match) {
-            if (isKnownExample(line, match)) break;
             // Mask the actual secret in the preview (replace ALL occurrences)
             const globalRegex = new RegExp(pattern.regex.source, pattern.regex.flags.includes('g') ? pattern.regex.flags : pattern.regex.flags + 'g');
             const masked = line.replace(globalRegex, `[${pattern.name} REDACTED]`);
@@ -202,9 +225,8 @@ export function scan(projectDir: string, options?: ScanOptions): ScanFinding[] {
           if (/os\.environ/.test(line) && !CREDENTIAL_PREFIX_QUICK_CHECK.test(line)) continue;
 
           for (const pattern of CREDENTIAL_PATTERNS) {
-            const match = line.match(pattern.regex);
+            const match = findRealMatch(line, pattern);
             if (match) {
-              if (isKnownExample(line, match)) break;
               const globalRegex = new RegExp(pattern.regex.source, pattern.regex.flags.includes('g') ? pattern.regex.flags : pattern.regex.flags + 'g');
               const masked = line.replace(globalRegex, `[${pattern.name} REDACTED]`);
 


### PR DESCRIPTION
## Summary

- **#50** (precedence): `isKnownExample`'s comment-marker check used `A && B || C`, which binds as `(A && B) || C`. Any line containing `#` entered the inner block regardless of whether it contained 'example'. Fixed to `A && (B || C)`.
- **#51** (shadowing): Both `scan.ts` and `scan-staged.ts` broke out of the pattern loop when the first match on a line was a known example, so a known-example key (e.g. `AKIAIOSFODNN7EXAMPLE`) shadowed real credentials of either the same or different patterns on the same line.

## Approach

Extracted a shared `findRealMatch(line, pattern)` helper in `scan.ts` that:
- promotes non-`/g` regexes to `/g` internally so `matchAll` iterates every match on the line
- returns the first non-example `RegExpMatchArray`, or `null` if every match is an example

`scan.ts` (3 call sites) and `scan-staged.ts` both call this helper — parity by construction.

## Test plan

- [x] New `src/scan.test.ts` with 6 tests:
  - precedence: line with `#` but no 'example' → not an example (regression guard)
  - precedence: line with `example //` context → is an example
  - `AKIAIOSFODNN7EXAMPLE` in prose → is a known example
  - mixed-pattern shadowing: AWS example + real GitHub PAT on same line → PAT returned
  - same-pattern multi-match shadowing: two AWS keys, first example second real → real returned
  - all-examples line → returns null
- [x] 2 new cases added to `src/scan-staged.test.ts` covering the same two shadowing scenarios end-to-end
- [x] 869/869 existing tests still pass
- [x] `npm run build` clean

Closes #50
Closes #51