### PR TITLE
fix(cli): intercept --help/-h before subcommand dispatch

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+/**
+ * Integration tests for the CLI dispatcher. Spawns the built entry point
+ * (`dist/cli.js`) so behavior matches what a real user sees — relevant because
+ * `secretless-ai scan --help` used to actually run `scan`, `init --help` used
+ * to create a `--help/` directory, and `broker start --help` used to start the
+ * daemon.
+ */
+
+const CLI_PATH = path.resolve(__dirname, '..', 'dist', 'cli.js');
+
+function runCli(args: string[], opts: { cwd?: string } = {}): string {
+  return execFileSync(process.execPath, [CLI_PATH, ...args], {
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    cwd: opts.cwd,
+  });
+}
+
+describe('cli --help handling', () => {
+  // Skip the whole suite if the build artifact is missing (CI order guard).
+  const hasBuild = fs.existsSync(CLI_PATH);
+  const itIfBuilt = hasBuild ? it : it.skip;
+
+  itIfBuilt('prints top-level help for `--help`', () => {
+    const out = runCli(['--help']);
+    expect(out).toMatch(/Secretless v/);
+    expect(out).toMatch(/Quick start:/);
+  });
+
+  itIfBuilt('subcommand `--help` does NOT execute the subcommand (regression guard)', () => {
+    // init without the guard would scaffold files into cwd. Run from a fresh
+    // temp dir and assert nothing was written.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-cli-help-'));
+    try {
+      const before = fs.readdirSync(tmp);
+      const out = runCli(['init', '--help'], { cwd: tmp });
+      const after = fs.readdirSync(tmp);
+      expect(after).toEqual(before); // nothing created
+      expect(out).toMatch(/Secretless v/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  itIfBuilt('`scan --help` prints help instead of scanning', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-cli-help-'));
+    try {
+      const out = runCli(['scan', '--help'], { cwd: tmp });
+      expect(out).toMatch(/Secretless v/);
+      expect(out).not.toMatch(/Secretless Scanner/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  itIfBuilt('`-h` short flag also intercepts', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-cli-help-'));
+    try {
+      const out = runCli(['scan', '-h'], { cwd: tmp });
+      expect(out).toMatch(/Secretless v/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,16 @@ function main(): void {
   const args = process.argv.slice(2);
   const command = args[0];
 
+  // Intercept `--help` / `-h` anywhere in the args BEFORE dispatching. Subcommand
+  // runners do not parse per-subcommand help, so without this guard `scan --help`
+  // would actually run the scanner, `init --help` would create a literal `--help/`
+  // directory, and `broker start --help` would launch the daemon. Print top-level
+  // help instead — a safe no-op. Regression: release-test 2026-04-14.
+  if (command && (args.includes('--help') || args.includes('-h'))) {
+    printHelp();
+    return;
+  }
+
   switch (command) {
     case 'init': {
       const dirArg = args[1];


### PR DESCRIPTION
## Summary

Pre-0.15.0 release testing caught that subcommand runners don't parse help flags, so:
- `secretless-ai scan --help` actually runs the scanner
- `secretless-ai init --help` creates a literal \`--help/\` directory + .claude/ in the user's cwd
- `secretless-ai broker start --help` launches the broker daemon

Guard at the dispatcher in \`src/cli.ts\`: any \`--help\`/\`-h\` anywhere in the args prints top-level help and returns. Safe no-op for every subcommand — the pre-existing top-level \`--help\` path is preserved for the \`undefined\` command case.

## Test plan

- [x] 4 new integration tests in \`src/cli.test.ts\` that spawn the built \`dist/cli.js\` and assert no side effects for \`--help\`, \`-h\`, \`init --help\`, \`scan --help\`
- [x] Manual repro + verification on the published 0.14.1 tarball (bug reproduces) and on this branch (fixed)
- [x] 873/873 tests pass
- [x] Blocks 0.15.0 publish per release-test P1 policy