### PR TITLE
ci(release): add npm Trusted Publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+
+      - name: Publish to npm with provenance
+        run: npm publish --provenance --access public
+
+      - name: Verify provenance on npm
+        run: |
+          deadline=$((SECONDS + 300))
+          while [ $SECONDS -lt $deadline ]; do
+            attestations=$(npm view "secretless-ai" dist.attestations --json 2>&1 || true)
+            if [ -n "$attestations" ] && [ "$attestations" != "null" ] && [ "$attestations" != "{}" ]; then
+              echo "Provenance verified for secretless-ai"
+              exit 0
+            fi
+            echo "Attestations not yet visible, retrying in 15s... (elapsed ${SECONDS}s)"
+            sleep 15
+          done
+          echo "::error::Provenance attestations missing from npm for secretless-ai after 5 minutes"
+          exit 1
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
New `.github/workflows/release.yml` publishes `secretless-ai` on tag push (`v*`) via npm Trusted Publishing (OIDC). Node 24, `id-token: write`, no `NPM_TOKEN` / `NODE_AUTH_TOKEN`. Matches the Stage 1 pattern shipped in opena2a #87 and oasb #11.

- `--provenance --access public` on `npm publish`.
- Post-publish `npm view dist.attestations` poll (5-min deadline) asserts SLSA v1 attestations are visible before the job exits green.
- GitHub Release auto-generated via `softprops/action-gh-release@v2`.

Before the first real tag ships, the `secretless-ai` Trusted Publisher must be configured on npmjs.com: organization `opena2a-org`, repository `secretless-ai`, workflow `release.yml`, env blank. This PR does not tag; next session will bump + tag once TP is clicked.

## Pre-push quality gate

8-phase `/pre-push-review` ran. Build (tsc clean) + tests (54 files / 873 pass) green. AI code review: no CRITICAL/HIGH. Phases 4.5 / 5 / 6 skipped (no detection logic touched, CLI-only, CI-only diff).

### Known HMA false positives (not introduced by this PR, tracked for 0.18 batch)

HMA `secure --ci` reports two findings on files this PR does not touch. Both are scanner bugs logged to the HMA per-finding bug list for the pending 0.18 release:

1. **CRITICAL `eval()` at `src/env.ts:13` — FP.** Line 13 is a JSDoc comment (`* - Only outputs to TTY or when stdout is piped to eval (no AI tool capture)`). All six `eval` occurrences in the file are in comments or a single-quoted string literal returning a shell install snippet (`'eval "\$(secretless-ai env 2>/dev/null)"'`). No actual `eval()` call exists. Same bug class as HMA bug #8 (PyTorch `model.eval()`) but needs a comment + string-literal token gate, not just the `(?<!\.)\beval\(` lookbehind.

2. **MEDIUM credentials on `.claude/settings.json` — FP + scanner UX bug.** This file is user-local Claude Code config, listed in `.git/info/exclude`, and never committed. The Verify command also renders as \`Verify: grep -in "key\|token\|secret\|password" '--help/.claude/settings.json'\` — the \`'--help/'\` prefix is a path-corruption bug in HMA's finding renderer (looks like a CLI arg parser leaking \`--help\` into the scanned-path string).

Precedent: opena2a Stage 1 PR #87 shipped with a known HMA FP disclosed in the body and merged after dismiss-cycle; oasb PR #11 shipped clean. Per the 2026-04-22 strategic frame, HMA fixes are on HOLD and batched into 0.18 — both FPs above join HMA bug list items #9 and #10 in that batch.

## Test plan
- [ ] Merge with no tag pushed — confirm release workflow does not run (tag-only trigger).
- [ ] After TP is configured on npmjs.com, bump patch + push `v0.15.1` in a future session.
- [ ] Confirm `npm view secretless-ai dist.attestations --json` returns a non-empty SLSA v1 object after the first real publish.