### PR TITLE
feat(0.16.0): wire @opena2a/telemetry — anonymous usage telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-04-27
+
+### Added
+- Tier-1 anonymous usage telemetry via `@opena2a/telemetry@0.1.2` and `@opena2a/cli-ui@0.4.0`. `secretless-ai --version` now prints the disclosure line; `secretless-ai telemetry [on|off|status]` inspects/toggles. Disable per-invocation with `OPENA2A_TELEMETRY=off`, persistently with `secretless-ai telemetry off`, audit payloads with `OPENA2A_TELEMETRY_DEBUG=print`. README §Telemetry documents the schema and links to [opena2a.org/telemetry](https://opena2a.org/telemetry). Default ON; opt-out is one env var or one subcommand.
+- `docs/testing/release-smoke.md` — first release-smoke for this repo, covering build/help/version + the seven telemetry checks.
+
+### Changed
+- `src/cli.ts` `main()` is now async to support `await tele.flush()` before `process.exit()` (prevents subcommand telemetry events from being lost on exit). The dispatcher logic moved into a sync `dispatch()` helper to keep the case statement compact.
+- First runtime dependency: `@opena2a/telemetry` + `@opena2a/cli-ui`. Previously the package had only devDependencies.
+
 ## [0.15.1] - 2026-04-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -157,6 +157,18 @@ opena2a secrets init    # Initialize secretless protection
 npm run build && npm test    # 809 tests
 ```
 
+## Telemetry
+
+Secretless sends anonymous tier-1 usage data to the OpenA2A Registry: tool name (`secretless-ai`), version, command name (`scan`, `protect`, etc.), success, duration, platform, Node major version, and a stable per-machine `install_id`. **No content is collected** — no scanned secrets, no file paths, no env-var values, no rule contents, no IPs.
+
+- **Policy:** [opena2a.org/telemetry](https://opena2a.org/telemetry).
+- **Status:** `secretless-ai telemetry status`.
+- **Disable per-invocation:** `OPENA2A_TELEMETRY=off secretless-ai <anything>`.
+- **Disable persistently:** `secretless-ai telemetry off`.
+- **Audit every payload:** `OPENA2A_TELEMETRY_DEBUG=print secretless-ai <anything>` echoes each event to stderr in JSON.
+
+Fire-and-forget with a 2-second timeout — telemetry never blocks Secretless.
+
 ## License
 
 Apache-2.0

--- a/docs/testing/release-smoke.md
+++ b/docs/testing/release-smoke.md
@@ -1,0 +1,80 @@
+# secretless-ai release smoke test
+
+**Run before every tag push to `v*`. ~10 minutes by hand.**
+
+Every item came from a real bug or regression. Don't skip without writing down why.
+
+## 0. Build + tests
+
+```bash
+cd secretless-ai
+git status                 # clean, or only the branch you intend to ship
+npm ci                     # lockfile valid
+npm run build              # zero output, zero errors
+npm test                   # all green (current baseline: ~809 tests)
+```
+
+Fail the release if any step is red.
+
+## 1. Help and version
+
+```bash
+node dist/cli.js --help     # prints the help block; no telemetry line here
+node dist/cli.js --version  # prints two lines: version + telemetry disclosure
+```
+
+The `--version` output must be exactly two lines:
+```
+secretless-ai 0.16.0
+Telemetry: on (opt-out: OPENA2A_TELEMETRY=off  •  details: opena2a.org/telemetry)
+```
+
+If the second line is missing, the `versionLine()` helper isn't wired or the SDK init failed silently.
+
+## 2. Core commands work end-to-end (3 min)
+
+```bash
+TMP=$(mktemp -d) && cd "$TMP"
+echo 'OPENAI_API_KEY=sk-fake-deadbeef' > .env
+node /path/to/secretless-ai/dist/cli.js init .         # creates .secretless/
+node /path/to/secretless-ai/dist/cli.js scan .         # detects fake credential
+node /path/to/secretless-ai/dist/cli.js status .       # reports Clean or N findings
+node /path/to/secretless-ai/dist/cli.js verify .       # verify pass
+```
+
+Fail if any command panics or returns the wrong status.
+
+## 3. Telemetry disclosure surfaces and opt-out (2 min)
+
+**Do NOT point at the production endpoint while smoking** — set `OPENA2A_TELEMETRY_URL=http://127.0.0.1:1/never` so events go to a port that refuses connections (proves fire-and-forget tolerance) instead of polluting prod aggregates.
+
+```bash
+export OPENA2A_TELEMETRY_URL=http://127.0.0.1:1/never
+unset OPENA2A_TELEMETRY
+rm -f ~/.config/opena2a/telemetry.json   # start clean
+```
+
+| # | Command | Expected |
+|---|---------|----------|
+| 3.1 | `secretless-ai --version` | Two lines: `secretless-ai 0.16.0` then `Telemetry: on (opt-out: ...)` |
+| 3.2 | `secretless-ai telemetry status` | Prints `state: on`, install_id, config path, policy URL, toggle hint |
+| 3.3 | `secretless-ai telemetry off` | Prints `Telemetry disabled for secretless-ai.` Then `--version` shows `Telemetry: off`. `~/.config/opena2a/telemetry.json` has `"enabled": false`. |
+| 3.4 | `secretless-ai telemetry on` | Re-enables persistently. |
+| 3.5 | `OPENA2A_TELEMETRY=off secretless-ai telemetry status` | Shows `state: off` even though file says `on` (env wins). |
+| 3.6 | `OPENA2A_TELEMETRY_DEBUG=print secretless-ai status .` | Stderr contains a `[opena2a:telemetry]` line with the JSON payload (`tool: "secretless-ai"`, `event: "command"`, `name: "status"`, `success: true`, `duration_ms: <int>`, no PII fields). |
+| 3.7 | `secretless-ai status .` (with the unreachable URL) | Command completes normally. Telemetry endpoint unreachable must not slow the command perceptibly (≤2s timeout). |
+
+Fail the release if:
+- any disclosure line is omitted
+- the persisted config file leaks anything beyond `enabled` and `installId`
+- the debug-print payload contains scanned secrets, file paths, env-var values, rule contents, or any field outside the locked schema (tool, version, install_id, event, name, success, duration_ms, platform, node_major)
+- a command blocks more than 2 seconds when the telemetry endpoint is unreachable
+
+## 4. Cleanup
+
+```bash
+unset OPENA2A_TELEMETRY_URL
+rm -rf "$TMP"
+# Restore your real telemetry config if you had one — the tests above
+# overwrite ~/.config/opena2a/telemetry.json.
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "secretless-ai",
       "version": "0.15.1",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@opena2a/cli-ui": "0.4.0",
+        "@opena2a/telemetry": "0.1.2"
+      },
       "bin": {
         "secretless-ai": "dist/cli.js",
         "secretless-mcp": "dist/mcp-wrapper.js"
@@ -110,6 +114,24 @@
         "js-yaml": "^4.1.1",
         "tweetnacl": "^1.0.3"
       },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@opena2a/cli-ui": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@opena2a/cli-ui/-/cli-ui-0.4.0.tgz",
+      "integrity": "sha512-wro+mk1znr1PbEr9XvdI1jovP8qFpfuKoBYouf6XVkHTfLJ1z09Zpli6dEjB6bFz/HxLtZbJ9zg8aaurqFxTjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^5.3.0"
+      }
+    },
+    "node_modules/@opena2a/telemetry": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@opena2a/telemetry/-/telemetry-0.1.2.tgz",
+      "integrity": "sha512-lMbNtwDfrXvrPWyEMXBY3ttU/RXWhQ2/xzSfCaosVvujFbqxtWuyq8YY725IEpQ9owa7uJ+PCp4mkxZ8UKW3wA==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
       }
@@ -597,6 +619,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/convert-source-map": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secretless-ai",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "One command to keep secrets out of AI. Works with Claude Code, Cursor, Copilot, Windsurf, and any AI coding tool.",
   "license": "Apache-2.0",
   "type": "commonjs",
@@ -52,5 +52,9 @@
     "@nanomind/engine": "^0.1.1",
     "@nanomind/guard": "^0.1.1",
     "@opena2a/aim-core": ">=0.2.0"
+  },
+  "dependencies": {
+    "@opena2a/cli-ui": "0.4.0",
+    "@opena2a/telemetry": "0.1.2"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,10 @@
  */
 
 import * as path from 'path';
+import type { TelemetryAction } from '@opena2a/cli-ui' with { 'resolution-mode': 'import' };
 import { VERSION } from './commands/utils';
+// @opena2a/telemetry and @opena2a/cli-ui are pure ESM; this CLI is CommonJS,
+// so they're loaded via dynamic import() inside the async main().
 import { runInit, runScan, runStatus, runVerify, runDoctor } from './commands/core';
 import { runClean, runWatch, runScanHistory, runCleanHistory } from './commands/transcript';
 import { runSecret } from './commands/secrets';
@@ -21,9 +24,22 @@ import { runScope } from './commands/scope';
 import { runWarm, runInstall } from './commands/session';
 import { printHelp } from './commands/help';
 
-function main(): void {
+const TOOL = 'secretless-ai';
+// Subcommands we don't track: pure-help / pure-config calls don't represent
+// the user actually using the tool, and tracking 'telemetry' itself creates
+// confusing self-referential events.
+const NON_TRACKED = new Set<string>(['telemetry', '--version', '-v', '--help', '-h']);
+
+async function main(): Promise<number> {
   const args = process.argv.slice(2);
   const command = args[0];
+
+  // Tier-1 anonymous usage telemetry — default ON; opt-out via OPENA2A_TELEMETRY=off
+  // or `secretless-ai telemetry off`. See README §Telemetry. Disclosure surfaces:
+  // README, --version line, telemetry subcommand, opena2a.org/telemetry.
+  const tele = await import('@opena2a/telemetry');
+  const { versionLine, runTelemetryCommand } = await import('@opena2a/cli-ui');
+  await tele.init({ tool: TOOL, version: VERSION });
 
   // Intercept `--help` / `-h` anywhere in the args BEFORE dispatching. Subcommand
   // runners do not parse per-subcommand help, so without this guard `scan --help`
@@ -32,9 +48,43 @@ function main(): void {
   // help instead — a safe no-op. Regression: release-test 2026-04-14.
   if (command && (args.includes('--help') || args.includes('-h'))) {
     printHelp();
-    return;
+    return 0;
   }
 
+  // --version: cli-ui versionLine helper appends the standard telemetry line.
+  if (command === '--version' || command === '-v') {
+    console.log(versionLine({ tool: TOOL, version: VERSION, telemetry: tele.status() }));
+    return 0;
+  }
+
+  // telemetry subcommand
+  if (command === 'telemetry') {
+    console.log(runTelemetryCommand(args[1] as TelemetryAction, {
+      tool: TOOL,
+      getStatus: tele.status,
+      setOptOut: tele.setOptOut,
+    }));
+    return 0;
+  }
+
+  const startedAt = Date.now();
+  let exitCode = 0;
+  try {
+    exitCode = dispatch(args, command);
+  } catch (err) {
+    exitCode = 1;
+    if (command) tele.error(command, (err as { code?: string; name?: string })?.code || (err as { name?: string })?.name || 'UNKNOWN');
+    throw err;
+  } finally {
+    if (command && !NON_TRACKED.has(command)) {
+      await tele.track(command, { success: exitCode === 0, durationMs: Date.now() - startedAt });
+    }
+    await tele.flush();
+  }
+  return exitCode;
+}
+
+function dispatch(args: string[], command: string | undefined): number {
   switch (command) {
     case 'init': {
       const dirArg = args[1];
@@ -141,10 +191,6 @@ function main(): void {
     case 'install':
       runInstall(args.slice(1));
       break;
-    case '--version':
-    case '-v':
-      console.log(`secretless-ai ${VERSION} \u2014 credential protection for AI coding tools`);
-      break;
     case '--help':
     case '-h':
     case undefined:
@@ -153,8 +199,15 @@ function main(): void {
     default:
       console.error(`Unknown command: ${command}`);
       printHelp();
-      process.exit(1);
+      return 1;
   }
+  return 0;
 }
 
-main();
+main().then(
+  (code) => process.exit(code),
+  (err) => {
+    console.error(err);
+    process.exit(1);
+  },
+);


### PR DESCRIPTION
## Summary

Second per-tool integration of `@opena2a/telemetry` (after DVAA #37/#38). Same one-liner pattern: `tele.init` at startup, `versionLine()` for `--version`, `runTelemetryCommand` for the subcommand, `await tele.flush()` before `process.exit()`.

**Independent of the existing scan-submission / community-contribution flow.** Telemetry answers "is anyone using secretless-ai?" (install counts, command-use heatmap). Community page metrics (scans submitted, findings shared, contributors) come from a separate set of endpoints that secretless-ai doesn't currently call. No double-count risk.

## Wiring

- `main()` is now async — `await tele.init` at top, `await tele.flush()` before `process.exit()` to prevent subcommand event loss (the bug we caught and fixed in DVAA).
- `--version` uses `versionLine({ tool, version, telemetry })` from `@opena2a/cli-ui@0.4.0`.
- New `secretless-ai telemetry [on|off|status]` subcommand via `runTelemetryCommand`.
- Subcommands tracked: success/durationMs on success, `tele.error(name, code)` on throw before re-throw.
- Excluded from tracking: `telemetry` (self-referential), `--version`, `--help`.

## Deps (first runtime deps for this package)

- `@opena2a/telemetry@0.1.2` (includes flush() + beforeExit drain)
- `@opena2a/cli-ui@0.4.0` (versionLine + runTelemetryCommand)

CommonJS package + pure-ESM deps → dynamic `import()` inside the async main; type-only import uses `with { 'resolution-mode': 'import' }` for TS Node16.

## Test plan

- [x] `npm run build` clean
- [x] `--version`, `telemetry status`, `telemetry off`, `telemetry on`, `OPENA2A_TELEMETRY=off` override, `OPENA2A_TELEMETRY_DEBUG=print` debug all behave correctly against `OPENA2A_TELEMETRY_URL=http://127.0.0.1:1/never`
- [x] `release-smoke.md` §3 (seven checks) added
- [ ] Reviewer sanity check before tag

## Not in this PR

- No npm publish (publish budget exceeded today; PR is draft).
- No prod tag — schedule for tomorrow alongside the other tools (opena2a-cli + a follow-up for hma + ai-trust once session 83 lands).
- No prior versions back-fill (0.15.x and earlier won't have telemetry — expected).