### PR TITLE
fix(telemetry): convert command handlers to return exit codes (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-04-28
+
+### Fixed
+- **Telemetry exit-path coverage** (#61). Every command now emits exactly one telemetry event regardless of which exit path it takes. Previously, ~50 `process.exit()` calls in `src/commands/*.ts` bypassed the `try/finally` in `src/cli.ts`, so failure paths (`scan` with findings, `verify` FAIL/WARN, `doctor` unhealthy, every command's error branch) emitted no telemetry. Adoption metrics were biased toward "everything always works." All command handlers now return their exit code; `process.exit()` lives only in `main().then()` at `src/cli.ts:178`. Exit codes preserved across the surface (including `vault exec` upstream-process exit, `run` child-process exit). The `hook --check-only` fast path retains its silent-and-fast contract intentionally and is excluded from telemetry by design.
+
 ## [0.16.0] - 2026-04-27
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "secretless-ai",
-  "version": "0.15.1",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "secretless-ai",
-      "version": "0.15.1",
+      "version": "0.16.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@opena2a/cli-ui": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secretless-ai",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "One command to keep secrets out of AI. Works with Claude Code, Cursor, Copilot, Windsurf, and any AI coding tool.",
   "license": "Apache-2.0",
   "type": "commonjs",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,7 +70,7 @@ async function main(): Promise<number> {
   const startedAt = Date.now();
   let exitCode = 0;
   try {
-    exitCode = dispatch(args, command);
+    exitCode = await dispatch(args, command);
   } catch (err) {
     exitCode = 1;
     if (command) tele.error(command, (err as { code?: string; name?: string })?.code || (err as { name?: string })?.name || 'UNKNOWN');
@@ -84,124 +84,94 @@ async function main(): Promise<number> {
   return exitCode;
 }
 
-function dispatch(args: string[], command: string | undefined): number {
+async function dispatch(args: string[], command: string | undefined): Promise<number> {
   switch (command) {
     case 'init': {
       const dirArg = args[1];
       const projectDir = dirArg ? path.resolve(dirArg) : process.cwd();
-      runInit(projectDir);
-      break;
+      return runInit(projectDir);
     }
     case 'scan': {
       if (args.includes('--history')) {
-        runScanHistory();
-        break;
+        return runScanHistory();
       }
       const includeTests = args.includes('--include-tests');
       const explain = args.includes('--explain');
       const positionalArgs = args.slice(1).filter(a => !a.startsWith('--'));
       const dirArg = positionalArgs[0];
       const projectDir = dirArg ? path.resolve(dirArg) : process.cwd();
-      runScan(projectDir, { includeTests, explain });
-      break;
+      return runScan(projectDir, { includeTests, explain });
     }
     case 'status': {
       const dirArg = args[1];
       const projectDir = dirArg ? path.resolve(dirArg) : process.cwd();
-      runStatus(projectDir);
-      break;
+      return runStatus(projectDir);
     }
     case 'verify': {
       const showAll = args.includes('--all');
       const positional = args.slice(1).filter(a => a !== '--all');
       const dirArg = positional[0];
       const projectDir = dirArg ? path.resolve(dirArg) : process.cwd();
-      runVerify(projectDir, showAll);
-      break;
+      return runVerify(projectDir, showAll);
     }
     case 'doctor':
-      runDoctor(args.includes('--fix'));
-      break;
+      return runDoctor(args.includes('--fix'));
     case 'clean':
-      runClean(args.slice(1));
-      break;
+      return runClean(args.slice(1));
     case 'watch':
-      runWatch(args.slice(1));
-      break;
+      return runWatch(args.slice(1));
     case 'rules':
-      runRules(args.slice(1));
-      break;
+      return runRules(args.slice(1));
     case 'protect-mcp':
-      runProtectMcp(args.slice(1));
-      break;
+      return runProtectMcp(args.slice(1));
     case 'mcp-status':
-      runMcpStatus();
-      break;
+      return runMcpStatus();
     case 'mcp-unprotect':
-      runMcpUnprotect();
-      break;
+      return runMcpUnprotect();
     case 'backend':
-      runBackend(args.slice(1));
-      break;
+      return runBackend(args.slice(1));
     case 'migrate':
-      runMigrate(args.slice(1));
-      break;
+      return runMigrate(args.slice(1));
     case 'secret':
-      runSecret(args.slice(1));
-      break;
+      return runSecret(args.slice(1));
     case 'run':
-      runRun(args.slice(1));
-      break;
+      return runRun(args.slice(1));
     case 'env':
-      runEnv(args.slice(1));
-      break;
+      return runEnv(args.slice(1));
     case 'import':
-      runImport(args.slice(1));
-      break;
+      return runImport(args.slice(1));
     case 'setup':
-      runSetupCommand(args.slice(1));
-      break;
+      return runSetupCommand(args.slice(1));
     case 'hook':
-      runHook(args.slice(1));
-      break;
+      return runHook(args.slice(1));
     case 'scan-staged':
-      runScanStaged();
-      break;
+      return runScanStaged();
     case 'cache':
-      runCache(args.slice(1));
-      break;
+      return runCache(args.slice(1));
     case 'broker':
-      runBroker(args.slice(1));
-      break;
+      return runBroker(args.slice(1));
     case 'vault':
-      runVault(args.slice(1));
-      break;
+      return runVault(args.slice(1));
     case 'scope':
-      runScope(args.slice(1));
-      break;
+      return runScope(args.slice(1));
     case 'scan-history':
-      runScanHistory();
-      break;
+      return runScanHistory();
     case 'clean-history':
-      runCleanHistory(args.includes('--dry-run'));
-      break;
+      return runCleanHistory(args.includes('--dry-run'));
     case 'warm':
-      runWarm(args.slice(1));
-      break;
+      return runWarm(args.slice(1));
     case 'install':
-      runInstall(args.slice(1));
-      break;
+      return runInstall(args.slice(1));
     case '--help':
     case '-h':
     case undefined:
       printHelp();
-      break;
+      return 0;
     default:
       console.error(`Unknown command: ${command}`);
       printHelp();
       return 1;
   }
-  return 0;
 }
 
 main().then(

--- a/src/commands/backend.ts
+++ b/src/commands/backend.ts
@@ -6,17 +6,18 @@ import { clearCacheFile } from '../backends/cache';
 import { migrateSecrets } from '../backends/migrate';
 import type { SelectableBackendType } from '../backends/config';
 
-export function runBackend(args: string[]): void {
+export async function runBackend(args: string[]): Promise<number> {
   const subcommand = args[0];
 
   if (subcommand === 'list') {
     const backendType = resolveBackendType();
     const backend = createBackend(backendType);
 
-    Promise.all([
-      backend.resolve('mcp'),
-      backend.resolve('secret'),
-    ]).then(([mcpEntries, secretEntries]) => {
+    try {
+      const [mcpEntries, secretEntries] = await Promise.all([
+        backend.resolve('mcp'),
+        backend.resolve('secret'),
+      ]);
       const mcpKeys = Object.keys(mcpEntries).sort();
       const secretKeys = Object.keys(secretEntries).sort();
       const total = mcpKeys.length + secretKeys.length;
@@ -25,7 +26,7 @@ export function runBackend(args: string[]): void {
 
       if (total === 0) {
         console.log('  No entries found.\n');
-        return;
+        return 0;
       }
 
       if (mcpKeys.length > 0) {
@@ -45,11 +46,11 @@ export function runBackend(args: string[]): void {
       }
 
       console.log(`  Total: ${total} ${total === 1 ? 'entry' : 'entries'}\n`);
-    }).catch((err) => {
+      return 0;
+    } catch (err) {
       console.error(`\n  Error: ${err instanceof Error ? err.message : String(err)}\n`);
-      process.exit(1);
-    });
-    return;
+      return 1;
+    }
   }
 
   if (subcommand === 'purge') {
@@ -60,7 +61,7 @@ export function runBackend(args: string[]): void {
       const val = args[prefixIdx + 1];
       if (val !== 'mcp' && val !== 'secret') {
         console.error(`\n  Unknown prefix: ${val}. Use 'mcp' or 'secret'.\n`);
-        process.exit(1);
+        return 1;
       }
       prefixFilter = val;
     }
@@ -69,7 +70,8 @@ export function runBackend(args: string[]): void {
     const backend = createBackend(backendType);
     const prefixes = prefixFilter ? [prefixFilter] : ['mcp', 'secret'];
 
-    Promise.all(prefixes.map(p => backend.resolve(p))).then(async (results) => {
+    try {
+      const results = await Promise.all(prefixes.map(p => backend.resolve(p)));
       const keysByPrefix: Record<string, string[]> = {};
       for (let i = 0; i < prefixes.length; i++) {
         const keys = Object.keys(results[i]);
@@ -81,7 +83,7 @@ export function runBackend(args: string[]): void {
       const allKeys = Object.values(keysByPrefix).flat();
       if (allKeys.length === 0) {
         console.log('\n  No entries to purge.\n');
-        return;
+        return 0;
       }
 
       if (!hasYes) {
@@ -90,7 +92,7 @@ export function runBackend(args: string[]): void {
           console.log(`  ${prefix}/:  ${keys.length}`);
         }
         console.log(`\n  To confirm, run: secretless-ai backend purge${prefixFilter ? ` --prefix ${prefixFilter}` : ''} --yes\n`);
-        return;
+        return 0;
       }
 
       let deleted = 0;
@@ -114,25 +116,25 @@ export function runBackend(args: string[]): void {
       }
       console.log('  Re-import secrets: npx secretless-ai import .env');
       console.log();
-    }).catch((err) => {
+      return 0;
+    } catch (err) {
       console.error(`\n  Error: ${err instanceof Error ? err.message : String(err)}\n`);
-      process.exit(1);
-    });
-    return;
+      return 1;
+    }
   }
 
   if (subcommand === 'set') {
     const type = args[1];
     if (type !== 'local' && type !== 'keychain' && type !== '1password' && type !== 'vault' && type !== 'gcp-sm') {
       console.error(`\n  Unknown backend type: ${type ?? '(none)'}. Use 'local', 'keychain', '1password', 'vault', or 'gcp-sm'.\n`);
-      process.exit(1);
+      return 1;
     }
 
     if (type === 'keychain') {
       const kc = isKeychainAvailable();
       if (!kc.available) {
         console.error(`\n  Cannot use keychain backend: ${kc.message}\n`);
-        process.exit(1);
+        return 1;
       }
     }
 
@@ -140,7 +142,7 @@ export function runBackend(args: string[]): void {
       const op = isOnePasswordAvailable();
       if (!op.available) {
         console.error(`\n  Cannot use 1Password backend: ${op.message}\n`);
-        process.exit(1);
+        return 1;
       }
     }
 
@@ -150,7 +152,7 @@ export function runBackend(args: string[]): void {
         console.error('  Set them in your shell profile:');
         console.error('    export VAULT_ADDR=http://127.0.0.1:8200');
         console.error('    export VAULT_TOKEN=<your-token>\n');
-        process.exit(1);
+        return 1;
       }
     }
 
@@ -158,7 +160,7 @@ export function runBackend(args: string[]): void {
       const gcp = isGCPAvailable();
       if (!gcp.available) {
         console.error(`\n  Cannot use GCP Secret Manager backend: ${gcp.message}\n`);
-        process.exit(1);
+        return 1;
       }
     }
 
@@ -166,7 +168,7 @@ export function runBackend(args: string[]): void {
     console.log(`\n  Backend set to: ${type}\n`);
     console.log('  Run `npx secretless-ai protect-mcp` to re-protect MCP servers with the new backend.');
     console.log('  Or use `npx secretless-ai migrate` to migrate existing secrets.\n');
-    return;
+    return 0;
   }
 
   // Default: show current backend status
@@ -196,9 +198,10 @@ export function runBackend(args: string[]): void {
   console.log('    npx secretless-ai backend list             List all stored entries');
   console.log('    npx secretless-ai backend purge            Delete all entries (--yes to confirm)');
   console.log();
+  return 0;
 }
 
-export function runMigrate(args: string[]): void {
+export async function runMigrate(args: string[]): Promise<number> {
   let fromType: SelectableBackendType | undefined;
   let toType: SelectableBackendType | undefined;
 
@@ -210,7 +213,7 @@ export function runMigrate(args: string[]): void {
         fromType = val as SelectableBackendType;
       } else {
         console.error(`\n  Unknown backend type: ${val}. Valid: ${validBackends.join(', ')}\n`);
-        process.exit(1);
+        return 1;
       }
     }
     if (args[i] === '--to' && args[i + 1]) {
@@ -219,19 +222,19 @@ export function runMigrate(args: string[]): void {
         toType = val as SelectableBackendType;
       } else {
         console.error(`\n  Unknown backend type: ${val}. Valid: ${validBackends.join(', ')}\n`);
-        process.exit(1);
+        return 1;
       }
     }
   }
 
   if (!fromType || !toType) {
     console.error('\n  Usage: npx secretless-ai migrate --from <local|keychain|1password|vault|gcp-sm> --to <local|keychain|1password|vault|gcp-sm>\n');
-    process.exit(1);
+    return 1;
   }
 
   if (fromType === toType) {
     console.error(`\n  Source and destination backends are the same: ${fromType}\n`);
-    process.exit(1);
+    return 1;
   }
 
   // Validate vault env vars before attempting migration
@@ -241,7 +244,7 @@ export function runMigrate(args: string[]): void {
     console.error('  Set them in your shell:');
     console.error('    export VAULT_ADDR=http://127.0.0.1:8200');
     console.error('    export VAULT_TOKEN=<your-token>\n');
-    process.exit(1);
+    return 1;
   }
 
   // Validate GCP credentials before attempting migration
@@ -250,7 +253,7 @@ export function runMigrate(args: string[]): void {
     const gcp = isGCPAvailable();
     if (!gcp.available) {
       console.error(`\n  GCP Secret Manager backend requires credentials: ${gcp.message}\n`);
-      process.exit(1);
+      return 1;
     }
   }
 
@@ -265,10 +268,11 @@ export function runMigrate(args: string[]): void {
   // for empty prefix -- we need to resolve each prefix explicitly.
   const PREFIXES = ['secret', 'mcp'];
 
-  Promise.all(
-    PREFIXES.map(p => migrateSecrets(source, destination, { deleteFromSource: false, prefix: p }))
-  ).then((results) => {
-    return results.reduce(
+  try {
+    const perPrefix = await Promise.all(
+      PREFIXES.map(p => migrateSecrets(source, destination, { deleteFromSource: false, prefix: p }))
+    );
+    const result = perPrefix.reduce(
       (acc, r) => ({
         migrated: acc.migrated + r.migrated,
         failed: acc.failed + r.failed,
@@ -276,10 +280,10 @@ export function runMigrate(args: string[]): void {
       }),
       { migrated: 0, failed: 0, errors: [] as Array<{ key: string; message: string }> },
     );
-  }).then((result) => {
+
     if (result.migrated === 0 && result.failed === 0) {
       console.log('  No secrets found to migrate.\n');
-      return;
+      return 0;
     }
 
     console.log(`  Migrated: ${result.migrated} secret(s)`);
@@ -295,13 +299,14 @@ export function runMigrate(args: string[]): void {
     writeBackendConfig(toType!);
     console.log(`  Backend config updated to: ${toType}`);
     console.log('  Run `npx secretless-ai protect-mcp` to update MCP wrapper configs.\n');
-  }).catch((err) => {
+    return result.failed > 0 ? 1 : 0;
+  } catch (err) {
     console.error(`\n  Error: ${err instanceof Error ? err.message : String(err)}\n`);
-    process.exit(1);
-  });
+    return 1;
+  }
 }
 
-export function runCache(args: string[]): void {
+export function runCache(args: string[]): number {
   const subcommand = args[0];
 
   if (subcommand === 'clear') {
@@ -311,7 +316,7 @@ export function runCache(args: string[]): void {
     } else {
       console.log('\n  No cache file found.\n');
     }
-    return;
+    return 0;
   }
 
   if (subcommand === 'ttl') {
@@ -321,13 +326,13 @@ export function runCache(args: string[]): void {
       // Show current TTL
       const current = readCacheTtl();
       console.log(`\n  Cache TTL: ${formatTtl(current)}${current <= 0 ? ' (disabled)' : ''}\n`);
-      return;
+      return 0;
     }
 
     const seconds = parseDuration(value);
     if (seconds < 0) {
       console.error(`\n  Invalid duration: "${value}". Use: 5m, 1h, 1d, 300, or off\n`);
-      process.exit(1);
+      return 1;
     }
 
     writeCacheTtl(seconds);
@@ -338,7 +343,7 @@ export function runCache(args: string[]): void {
     } else {
       console.log(`\n  Cache TTL set to ${formatTtl(seconds)}.\n`);
     }
-    return;
+    return 0;
   }
 
   // Default: show cache status
@@ -362,4 +367,5 @@ export function runCache(args: string[]): void {
   console.log('    secretless-ai cache ttl <duration>  Set cache TTL (5m, 1h, 1d, off)');
   console.log('    secretless-ai cache clear           Clear cached secrets');
   console.log();
+  return 0;
 }

--- a/src/commands/broker.ts
+++ b/src/commands/broker.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import { startDaemon, stopDaemon, getLiveDaemonStatus } from '../broker/daemon';
 import { formatUptime } from './utils';
 
-export function runBroker(args: string[]): void {
+export async function runBroker(args: string[]): Promise<number> {
   const subcommand = args[0];
 
   switch (subcommand) {
@@ -24,7 +24,7 @@ export function runBroker(args: string[]): void {
             port = parsed;
           } else {
             console.error(`\n  Invalid port: ${args[i]}. Must be 1-65535.\n`);
-            process.exit(1);
+            return 1;
           }
         } else if (args[i] === '--policy-file' && args[i + 1]) {
           policyFile = path.resolve(args[++i]);
@@ -34,7 +34,8 @@ export function runBroker(args: string[]): void {
       console.log('\n  Secretless Broker\n');
       console.log('  Starting credential broker daemon...');
 
-      startDaemon({ aimUrl, aimToken, httpPort: port, policyFile }).then((server) => {
+      try {
+        const server = await startDaemon({ aimUrl, aimToken, httpPort: port, policyFile });
         const info = server.getStatus();
         console.log('  Broker is running.\n');
         console.log(`  PID:          ${info.pid}`);
@@ -43,11 +44,11 @@ export function runBroker(args: string[]): void {
         console.log(`  AIM:          ${formatAimStatus(info.aimConfigured, info.aimReachable)}${aimUrl ? ` — ${aimUrl}` : ''}`);
         console.log(`  Policy file:  ${policyFile ?? '(default)'}`);
         console.log('\n  Press Ctrl+C to stop.\n');
-      }).catch((err) => {
+        return 0;
+      } catch (err) {
         console.error(`\n  Error: ${err instanceof Error ? err.message : String(err)}\n`);
-        process.exit(1);
-      });
-      break;
+        return 1;
+      }
     }
 
     case 'stop': {
@@ -57,31 +58,30 @@ export function runBroker(args: string[]): void {
       } else {
         console.log('\n  Broker daemon is not running.\n');
       }
-      break;
+      return 0;
     }
 
     case 'status': {
-      getLiveDaemonStatus().then((brokerStatus) => {
-        if (!brokerStatus) {
-          console.log('\n  Broker daemon is not running.\n');
-          return;
-        }
+      const brokerStatus = await getLiveDaemonStatus();
+      if (!brokerStatus) {
+        console.log('\n  Broker daemon is not running.\n');
+        return 0;
+      }
 
-        const uptime = formatUptime(brokerStatus.uptimeSeconds);
+      const uptime = formatUptime(brokerStatus.uptimeSeconds);
 
-        console.log('\n  Secretless Broker Status\n');
-        console.log(`  Status:       running`);
-        console.log(`  PID:          ${brokerStatus.pid}`);
-        console.log(`  Uptime:       ${uptime}`);
-        console.log(`  Started at:   ${brokerStatus.startedAt}`);
-        console.log(`  HTTP port:    ${brokerStatus.httpPort}`);
-        console.log(`  Socket:       ${brokerStatus.socketPath}`);
-        console.log(`  AIM:          ${formatAimStatus(brokerStatus.aimConfigured, brokerStatus.aimReachable)}`);
-        console.log(`  Policies:     ${brokerStatus.policyCount}`);
-        console.log(`  Requests:     ${brokerStatus.requestCount}`);
-        console.log();
-      });
-      break;
+      console.log('\n  Secretless Broker Status\n');
+      console.log(`  Status:       running`);
+      console.log(`  PID:          ${brokerStatus.pid}`);
+      console.log(`  Uptime:       ${uptime}`);
+      console.log(`  Started at:   ${brokerStatus.startedAt}`);
+      console.log(`  HTTP port:    ${brokerStatus.httpPort}`);
+      console.log(`  Socket:       ${brokerStatus.socketPath}`);
+      console.log(`  AIM:          ${formatAimStatus(brokerStatus.aimConfigured, brokerStatus.aimReachable)}`);
+      console.log(`  Policies:     ${brokerStatus.policyCount}`);
+      console.log(`  Requests:     ${brokerStatus.requestCount}`);
+      console.log();
+      return 0;
     }
 
     case '--help':
@@ -101,8 +101,7 @@ export function runBroker(args: string[]): void {
       console.log('    --aim-token <token>    Bearer token for AIM auth (or env SECRETLESS_AIM_TOKEN)');
       console.log('    --port <port>          HTTP port (default: 19421)');
       console.log('    --policy-file <path>   Policy file path\n');
-      if (isUnknown) process.exit(1);
-      break;
+      return isUnknown ? 1 : 0;
     }
   }
 }

--- a/src/commands/core.ts
+++ b/src/commands/core.ts
@@ -13,7 +13,7 @@ import { VERSION, formatUptime, formatRemainingTime } from './utils';
 import { explainFinding, isEngineAvailable } from '../nanomind';
 import { c, divider } from './colors';
 
-export function runInit(projectDir: string): void {
+export function runInit(projectDir: string): number {
   console.log('\n  Secretless v' + VERSION);
   console.log('  Keeping secrets out of AI\n');
 
@@ -87,16 +87,18 @@ export function runInit(projectDir: string): void {
   if (process.stdout.isTTY) {
     console.log('  Helpful? Star the project: https://github.com/opena2a-org/secretless-ai\n');
   }
+
+  return 0;
 }
 
-export function runScan(projectDir: string, options?: { includeTests?: boolean; explain?: boolean }): void {
+export async function runScan(projectDir: string, options?: { includeTests?: boolean; explain?: boolean }): Promise<number> {
   console.log('\n  Secretless Scanner\n');
 
   const nodeFs = require('fs') as typeof import('fs');
   if (!nodeFs.existsSync(projectDir)) {
     console.error(`  Directory not found: ${projectDir}`);
     console.error('  Check the path and try again.\n');
-    process.exit(1);
+    return 1;
   }
 
   const findings = scan(projectDir, { includeTests: options?.includeTests });
@@ -104,17 +106,16 @@ export function runScan(projectDir: string, options?: { includeTests?: boolean; 
   if (findings.length === 0) {
     console.log('  No hardcoded credentials found.');
     console.log('  Verify keys are working: npx secretless-ai verify\n');
-    return;
+    return 0;
   }
 
   // If --explain requested, use NanoMind engine for rich context
   if (options?.explain) {
-    runScanWithExplanations(findings).then((code) => process.exit(code));
-    return;
+    return runScanWithExplanations(findings);
   }
 
   printFindings(findings);
-  process.exit(findings.length > 0 ? 1 : 0);
+  return findings.length > 0 ? 1 : 0;
 }
 
 function printFindings(findings: ReturnType<typeof scan>): void {
@@ -187,7 +188,7 @@ async function runScanWithExplanations(findings: ReturnType<typeof scan>): Promi
   return findings.length > 0 ? 1 : 0;
 }
 
-export function runStatus(projectDir: string): void {
+export function runStatus(projectDir: string): number {
   console.log('\n  Secretless Status\n');
 
   const s = status(projectDir);
@@ -248,9 +249,10 @@ export function runStatus(projectDir: string): void {
   }
 
   console.log();
+  return 0;
 }
 
-export function runVerify(projectDir: string, showAll = false): void {
+export function runVerify(projectDir: string, showAll = false): number {
   console.log(`\n  ${c.boldWhite('Secretless Verify')}\n`);
 
   const result = verify(projectDir);
@@ -314,7 +316,7 @@ export function runVerify(projectDir: string, showAll = false): void {
       console.log(`  ${c.cyan('Redact transcripts:')} npx secretless-ai clean`);
     }
     console.log();
-    process.exit(1);
+    return 1;
   } else {
     console.log(`  ${c.boldYellow('WARN')} ${c.yellow('No API keys found in env vars.')}`);
 
@@ -328,12 +330,13 @@ export function runVerify(projectDir: string, showAll = false): void {
     console.log(divider('Next Steps'));
     console.log(`  ${c.cyan('Diagnose:')} npx secretless-ai doctor`);
     console.log();
-    process.exit(1);
+    return 1;
   }
   console.log();
+  return 0;
 }
 
-export function runDoctor(autoFix: boolean): void {
+export function runDoctor(autoFix: boolean): number {
   console.log('\n  Secretless Doctor\n');
 
   const result = doctor();
@@ -388,7 +391,7 @@ export function runDoctor(autoFix: boolean): void {
         console.log(`    Created ~/${fix.targetProfile}`);
       }
       console.log('    Restart your terminal for changes to take effect.\n');
-      return;
+      return 0;
     }
   }
 
@@ -402,6 +405,7 @@ export function runDoctor(autoFix: boolean): void {
 
   if (result.health !== 'healthy') {
     console.log('  Run `npx secretless-ai doctor --fix` to auto-fix.\n');
-    process.exit(1);
+    return 1;
   }
+  return 0;
 }

--- a/src/commands/env-run.ts
+++ b/src/commands/env-run.ts
@@ -4,7 +4,7 @@ import { importEnvFile, detectEnvFiles } from '../env-import';
 import { runSetup } from '../setup';
 import { generateEnvExports } from '../env';
 
-export function runRun(args: string[]): void {
+export async function runRun(args: string[]): Promise<number> {
   // Parse --only flag before --
   let only: string[] | undefined;
   const separatorIdx = args.indexOf('--');
@@ -21,28 +21,28 @@ export function runRun(args: string[]): void {
   // Everything after -- is the child command
   if (separatorIdx === -1 || separatorIdx >= args.length - 1) {
     console.error('\n  Usage: secretless-ai run [--only KEY1,KEY2] -- <command> [args...]\n');
-    process.exit(1);
+    return 1;
   }
 
   const childCommand = args[separatorIdx + 1];
   const childArgs = args.slice(separatorIdx + 2);
 
-  runWithSecrets(childCommand, childArgs, { only }).then((code) => {
-    process.exit(code);
-  }).catch((err) => {
+  try {
+    return await runWithSecrets(childCommand, childArgs, { only });
+  } catch (err) {
     console.error(`  Error: ${err instanceof Error ? err.message : String(err)}`);
-    process.exit(1);
-  });
+    return 1;
+  }
 }
 
-export function runEnv(args: string[]): void {
+export async function runEnv(args: string[]): Promise<number> {
   if (args.includes('--help') || args.includes('-h')) {
     console.log('\n  Usage: eval $(secretless-ai env [--only KEY1,KEY2])');
     console.log('\n  Export secrets as shell environment variables.');
     console.log('  Designed for use with eval in shell profiles.\n');
     console.log('  Options:');
     console.log('    --only KEY1,KEY2   Export only the specified secrets\n');
-    return;
+    return 0;
   }
 
   // Parse --only flag
@@ -60,18 +60,20 @@ export function runEnv(args: string[]): void {
     process.stderr.write('  Intended usage: eval $(secretless-ai env)\n\n');
   }
 
-  generateEnvExports({ only }).then((output) => {
+  try {
+    const output = await generateEnvExports({ only });
     if (output) {
       process.stdout.write(output + '\n');
     }
-  }).catch((err) => {
+    return 0;
+  } catch (err) {
     // Silently fail — this runs inside eval in shell profiles.
     process.stderr.write(`secretless: env: ${err instanceof Error ? err.message : String(err)}\n`);
-    process.exit(1);
-  });
+    return 1;
+  }
 }
 
-export function runImport(args: string[]): void {
+export async function runImport(args: string[]): Promise<number> {
   console.log('\n  Secretless Import\n');
 
   if (args.includes('--detect')) {
@@ -79,36 +81,30 @@ export function runImport(args: string[]): void {
     const files = detectEnvFiles(dir);
     if (files.length === 0) {
       console.log('  No .env files found in current directory.\n');
-      return;
+      return 0;
     }
 
     let totalImported = 0;
-    const importNext = (idx: number): void => {
-      if (idx >= files.length) {
-        console.log(`\n  Total: ${totalImported} secret(s) imported.\n`);
-        return;
-      }
-      const file = files[idx];
-      importEnvFile(file).then((result) => {
+    for (const file of files) {
+      try {
+        const result = await importEnvFile(file);
         console.log(`  ${path.basename(file)}: ${result.imported} imported`);
         if (result.skipped > 0) {
           console.log(`    (${result.skipped} skipped — invalid names)`);
         }
         totalImported += result.imported;
-        importNext(idx + 1);
-      }).catch((err) => {
+      } catch (err) {
         console.error(`  Error importing ${file}: ${err instanceof Error ? err.message : String(err)}`);
-        importNext(idx + 1);
-      });
-    };
-    importNext(0);
-    return;
+      }
+    }
+    console.log(`\n  Total: ${totalImported} secret(s) imported.\n`);
+    return 0;
   }
 
   const filePath = args[0];
   if (!filePath) {
     console.error('  Usage: secretless-ai import <file> or secretless-ai import --detect\n');
-    process.exit(1);
+    return 1;
   }
 
   const resolvedPath = path.resolve(filePath);
@@ -116,13 +112,14 @@ export function runImport(args: string[]): void {
   if (!nodeFs.existsSync(resolvedPath)) {
     console.error(`  File not found: ${filePath}`);
     console.error('  Check the path and try again.\n');
-    process.exit(1);
+    return 1;
   }
-  importEnvFile(resolvedPath).then((result) => {
+  try {
+    const result = await importEnvFile(resolvedPath);
     if (result.imported === 0) {
       console.log('  No secrets found in file.');
       console.log('  Expected format: KEY=value (one per line)\n');
-      return;
+      return 0;
     }
 
     console.log(`  Imported ${result.imported} secret(s) from ${path.basename(resolvedPath)}:\n`);
@@ -133,19 +130,21 @@ export function runImport(args: string[]): void {
       console.log(`\n  Skipped: ${result.skipped} (invalid names)`);
     }
     console.log();
-  }).catch((err) => {
+    return 0;
+  } catch (err) {
     console.error(`  Error: ${err instanceof Error ? err.message : String(err)}\n`);
-    process.exit(1);
-  });
+    return 1;
+  }
 }
 
-export function runSetupCommand(args: string[]): void {
+export async function runSetupCommand(args: string[]): Promise<number> {
   const checkOnly = args.includes('--check');
   const dir = process.cwd();
 
   console.log('\n  Secretless Setup\n');
 
-  runSetup(dir, { check: checkOnly }).then((result) => {
+  try {
+    const result = await runSetup(dir, { check: checkOnly });
     if (checkOnly) {
       console.log(`  Satisfied: ${result.existing} secret(s)`);
       console.log(`  Missing:   ${result.missing} required`);
@@ -158,11 +157,10 @@ export function runSetupCommand(args: string[]): void {
         }
         console.log();
         console.log('  FAIL: Run `secretless-ai setup` to configure missing secrets.\n');
-        process.exit(1);
-      } else {
-        console.log('  PASS: All required secrets are configured.\n');
+        return 1;
       }
-      return;
+      console.log('  PASS: All required secrets are configured.\n');
+      return 0;
     }
 
     if (result.set > 0 || result.existing > 0) {
@@ -170,8 +168,9 @@ export function runSetupCommand(args: string[]): void {
       console.log(`  Existing: ${result.existing}`);
       console.log(`  Skipped:  ${result.skipped} (optional)\n`);
     }
-  }).catch((err) => {
+    return 0;
+  } catch (err) {
     console.error(`  Error: ${err instanceof Error ? err.message : String(err)}\n`);
-    process.exit(1);
-  });
+    return 1;
+  }
 }

--- a/src/commands/git.ts
+++ b/src/commands/git.ts
@@ -2,33 +2,29 @@ import { installPreCommitHook, uninstallPreCommitHook, isHookInstalled } from '.
 import { scanStagedFiles } from '../scan-staged';
 import { runHookCheck } from '../session/hook';
 
-export function runHook(args: string[]): void {
+export function runHook(args: string[]): number {
   const subcommand = args[0];
   const projectDir = process.cwd();
 
-  // Fast path: --check-only for Claude Code PreToolUse hook (must be first arg)
+  // Fast path: --check-only for Claude Code PreToolUse hook (must be first arg).
+  // runHookCheck calls process.exit() internally — this path bypasses telemetry
+  // by design (it fires on every Claude Code tool call and would dominate the dataset).
   if (subcommand === '--check-only') {
     runHookCheck();
-    return; // runHookCheck calls process.exit()
+    return 0; // Unreachable: runHookCheck always exits.
   }
 
   switch (subcommand) {
     case 'install': {
       const result = installPreCommitHook(projectDir);
       console.log(`\n  ${result.message}\n`);
-      if (!result.installed) {
-        process.exit(1);
-      }
-      break;
+      return result.installed ? 0 : 1;
     }
 
     case 'uninstall': {
       const result = uninstallPreCommitHook(projectDir);
       console.log(`\n  ${result.message}\n`);
-      if (!result.removed) {
-        process.exit(1);
-      }
-      break;
+      return result.removed ? 0 : 1;
     }
 
     case 'status': {
@@ -38,7 +34,7 @@ export function runHook(args: string[]): void {
         console.log('  Install: npx secretless-ai hook install');
       }
       console.log();
-      break;
+      return 0;
     }
 
     default:
@@ -48,17 +44,17 @@ export function runHook(args: string[]): void {
       console.log('    secretless-ai hook uninstall     Remove pre-commit hook');
       console.log('    secretless-ai hook status        Check hook status');
       console.log('    secretless-ai hook --check-only  Session gate for Claude Code hooks (silent, fast)\n');
-      process.exit(1);
+      return 1;
   }
 }
 
-export function runScanStaged(): void {
+export function runScanStaged(): number {
   const { findings, blockedFiles } = scanStagedFiles();
   const total = findings.length + blockedFiles.length;
 
   if (total === 0) {
     // Clean — allow commit
-    process.exit(0);
+    return 0;
   }
 
   console.error('\n  secretless: Blocked commit — secrets detected\n');
@@ -81,5 +77,5 @@ export function runScanStaged(): void {
 
   console.error('  Remove the secrets and try again.');
   console.error('  To bypass: git commit --no-verify\n');
-  process.exit(1);
+  return 1;
 }

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -10,7 +10,7 @@ function getWrapperPath(): string {
   return path.resolve(__dirname, '..', 'mcp-wrapper.js');
 }
 
-export function runProtectMcp(args: string[]): void {
+export async function runProtectMcp(args: string[]): Promise<number> {
   console.log('\n  Secretless MCP Protection\n');
 
   const wrapperPath = getWrapperPath();
@@ -24,23 +24,24 @@ export function runProtectMcp(args: string[]): void {
       backendType = val;
     } else {
       console.error(`  Unknown backend type: ${val}. Use 'local', 'keychain', '1password', 'vault', or 'gcp-sm'.\n`);
-      process.exit(1);
+      return 1;
     }
   }
 
-  protectMcp({ wrapperPath, backendType }).then((result) => {
+  try {
+    const result = await protectMcp({ wrapperPath, backendType });
     if (result.clientsScanned === 0) {
       console.log('  No MCP configurations found.\n');
       console.log('  Looked for configs from: Claude Desktop, Cursor, Claude Code, VS Code, Windsurf');
       console.log('  Supported clients: Claude Desktop, Cursor, Claude Code, VS Code, Windsurf\n');
-      return;
+      return 0;
     }
 
     console.log(`  Scanned ${result.clientsScanned} client(s)\n`);
 
     if (result.secretsFound === 0) {
       console.log('  No plaintext secrets found in MCP configs. Already clean.\n');
-      return;
+      return 0;
     }
 
     for (const server of result.servers) {
@@ -71,13 +72,14 @@ export function runProtectMcp(args: string[]): void {
     console.log('  MCP servers will start normally — no workflow changes needed.');
     console.log('  Run `npx secretless-ai mcp-status` to check status anytime.');
     console.log('  Run `npx secretless-ai mcp-unprotect` to restore originals.\n');
-  }).catch((err) => {
+    return 0;
+  } catch (err) {
     console.error(`\n  Error: ${err instanceof Error ? err.message : String(err)}\n`);
-    process.exit(1);
-  });
+    return 1;
+  }
 }
 
-export function runMcpStatus(): void {
+export function runMcpStatus(): number {
   console.log('\n  Secretless MCP Status\n');
 
   const backend = resolveBackendType();
@@ -87,7 +89,7 @@ export function runMcpStatus(): void {
 
   if (configs.length === 0) {
     console.log('  No MCP configurations found.\n');
-    return;
+    return 0;
   }
 
   let protectedCount = 0;
@@ -117,9 +119,10 @@ export function runMcpStatus(): void {
   } else if (protectedCount > 0) {
     console.log(`  All protected servers use the ${backend} backend for secret storage.\n`);
   }
+  return 0;
 }
 
-export function runMcpUnprotect(): void {
+export function runMcpUnprotect(): number {
   console.log('\n  Secretless MCP Unprotect\n');
 
   const os = require('os');
@@ -141,4 +144,5 @@ export function runMcpUnprotect(): void {
   } else {
     console.log(`\n  Restored ${restored} config(s) to original state.\n`);
   }
+  return 0;
 }

--- a/src/commands/rules.ts
+++ b/src/commands/rules.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 
-export function runRules(args: string[]): void {
+export function runRules(args: string[]): number {
   const {
     loadCustomRulesDetailed,
     customRulesToDenyRules,
@@ -17,12 +17,12 @@ export function runRules(args: string[]): void {
       if (result.status === 'missing') {
         console.log(`\n  No ${RULES_FILENAME} found in this directory.`);
         console.log(`  Create one: npx secretless-ai rules init\n`);
-        return;
+        return 0;
       }
       if (result.status === 'empty') {
         console.log(`\n  ${RULES_FILENAME} exists but has no active rules.`);
         console.log('  Uncomment or add patterns, then run: npx secretless-ai init\n');
-        return;
+        return 0;
       }
       const rules = result.rules!;
 
@@ -50,7 +50,7 @@ export function runRules(args: string[]): void {
       const denyRules = customRulesToDenyRules(rules);
       console.log(`\n  Generates ${denyRules.length} deny rules.`);
       console.log('  Run: npx secretless-ai init  (to apply)\n');
-      break;
+      return 0;
     }
 
     case 'init': {
@@ -59,13 +59,13 @@ export function runRules(args: string[]): void {
       if (nodeFs.existsSync(rulesPath)) {
         console.log(`\n  ${RULES_FILENAME} already exists.`);
         console.log('  Edit it directly or use: npx secretless-ai rules list\n');
-        return;
+        return 0;
       }
       nodeFs.writeFileSync(rulesPath, generateTemplate());
       console.log(`\n  Created ${RULES_FILENAME}`);
       console.log('  Edit it to add your organization-specific patterns.');
       console.log('  Then run: npx secretless-ai init  (to apply)\n');
-      break;
+      return 0;
     }
 
     case 'test': {
@@ -79,7 +79,7 @@ export function runRules(args: string[]): void {
         console.error('    secretless-ai rules test "ACME_*"              (auto-detects env)');
         console.error('    secretless-ai rules test "*.corp-secret"       (auto-detects file)');
         console.error('    secretless-ai rules test "curl*corp*" --bash   (force bash type)\n');
-        process.exit(1);
+        return 1;
       }
 
       const { envPatternToDenyRules, filePatternToDenyRules, validatePattern, globToShellRegex } =
@@ -88,7 +88,7 @@ export function runRules(args: string[]): void {
       if (!validatePattern(pattern)) {
         console.error(`\n  Invalid pattern: ${pattern}`);
         console.error('  Only alphanumeric, *, ., -, _, / characters allowed.\n');
-        process.exit(1);
+        return 1;
       }
 
       console.log(`\n  Testing pattern: ${pattern}\n`);
@@ -131,12 +131,12 @@ export function runRules(args: string[]): void {
       }
       console.log(`  Shell regex: ${globToShellRegex(pattern)}`);
       console.log();
-      break;
+      return 0;
     }
 
     default:
       console.error(`\n  Unknown rules subcommand: ${subcommand}`);
       console.error('  Usage: secretless-ai rules <list|init|test>\n');
-      process.exit(1);
+      return 1;
   }
 }

--- a/src/commands/scope.ts
+++ b/src/commands/scope.ts
@@ -2,7 +2,7 @@ import { SecretStore } from '../secret-store';
 import { resolveBackendType } from '../backends/config';
 import { discoverScope, listBaselines, resetBaseline, loadBaseline, detectProvider } from '../scope';
 
-export function runScope(args: string[]): void {
+export async function runScope(args: string[]): Promise<number> {
   const subcommand = args[0];
 
   switch (subcommand) {
@@ -11,72 +11,74 @@ export function runScope(args: string[]): void {
       if (!credentialName) {
         console.error('\n  Usage: secretless-ai scope discover <credential-name>\n');
         console.log('  Reads the credential value from the secret store and discovers its scope.\n');
-        process.exit(1);
+        return 1;
       }
 
       const store = new SecretStore({ backendType: resolveBackendType() });
-      store.getSecret(credentialName).then(async (value) => {
-        if (!value) {
-          console.error(`\n  Credential "${credentialName}" not found in secret store.\n`);
-          process.exit(1);
+      let value: string | undefined;
+      try {
+        value = await store.getSecret(credentialName);
+      } catch (err) {
+        console.error(`\n  Error reading credential: ${err instanceof Error ? err.message : String(err)}\n`);
+        return 1;
+      }
+      if (!value) {
+        console.error(`\n  Credential "${credentialName}" not found in secret store.\n`);
+        return 1;
+      }
+
+      console.log(`\n  Scope Discovery: ${credentialName}\n`);
+
+      const provider = detectProvider(value);
+      if (!provider) {
+        console.error('  Unable to detect credential provider.');
+        console.log('  Supported: GCP service account key (JSON), Vault token (hvs./s. prefix), AWS access key (AKIA/ASIA prefix)\n');
+        return 1;
+      }
+
+      console.log(`  Provider: ${provider.toUpperCase()}`);
+      console.log('  Discovering permissions...\n');
+
+      try {
+        const result = await discoverScope(credentialName, value, { saveAsBaseline: true });
+
+        console.log(`  Permissions found: ${result.currentPermissions.length}`);
+        if (result.currentPermissions.length > 0) {
+          for (const p of result.currentPermissions) {
+            console.log(`    - ${p}`);
+          }
         }
 
-        console.log(`\n  Scope Discovery: ${credentialName}\n`);
+        if (result.baselinePermissions.length > 0) {
+          console.log(`\n  Baseline comparison:`);
+          console.log(`    Previous: ${result.baselinePermissions.length} permissions`);
+          console.log(`    Current:  ${result.currentPermissions.length} permissions`);
 
-        const provider = detectProvider(value);
-        if (!provider) {
-          console.error('  Unable to detect credential provider.');
-          console.log('  Supported: GCP service account key (JSON), Vault token (hvs./s. prefix), AWS access key (AKIA/ASIA prefix)\n');
-          process.exit(1);
-        }
-
-        console.log(`  Provider: ${provider.toUpperCase()}`);
-        console.log('  Discovering permissions...\n');
-
-        try {
-          const result = await discoverScope(credentialName, value, { saveAsBaseline: true });
-
-          console.log(`  Permissions found: ${result.currentPermissions.length}`);
-          if (result.currentPermissions.length > 0) {
-            for (const p of result.currentPermissions) {
+          if (result.added.length > 0) {
+            console.log(`\n  EXPANDED: +${result.added.length} new permissions`);
+            for (const p of result.added) {
+              console.log(`    + ${p}`);
+            }
+          }
+          if (result.removed.length > 0) {
+            console.log(`\n  Contracted: -${result.removed.length} removed permissions`);
+            for (const p of result.removed) {
               console.log(`    - ${p}`);
             }
           }
-
-          if (result.baselinePermissions.length > 0) {
-            console.log(`\n  Baseline comparison:`);
-            console.log(`    Previous: ${result.baselinePermissions.length} permissions`);
-            console.log(`    Current:  ${result.currentPermissions.length} permissions`);
-
-            if (result.added.length > 0) {
-              console.log(`\n  EXPANDED: +${result.added.length} new permissions`);
-              for (const p of result.added) {
-                console.log(`    + ${p}`);
-              }
-            }
-            if (result.removed.length > 0) {
-              console.log(`\n  Contracted: -${result.removed.length} removed permissions`);
-              for (const p of result.removed) {
-                console.log(`    - ${p}`);
-              }
-            }
-            if (result.added.length === 0 && result.removed.length === 0) {
-              console.log('    No changes since last baseline.');
-            }
-          } else {
-            console.log('\n  First baseline saved. Future checks will compare against this.');
+          if (result.added.length === 0 && result.removed.length === 0) {
+            console.log('    No changes since last baseline.');
           }
-
-          console.log(`\n  Baseline saved at: ${result.checkedAt}\n`);
-        } catch (err) {
-          console.error(`\n  Error: ${err instanceof Error ? err.message : String(err)}\n`);
-          process.exit(1);
+        } else {
+          console.log('\n  First baseline saved. Future checks will compare against this.');
         }
-      }).catch((err) => {
-        console.error(`\n  Error reading credential: ${err instanceof Error ? err.message : String(err)}\n`);
-        process.exit(1);
-      });
-      break;
+
+        console.log(`\n  Baseline saved at: ${result.checkedAt}\n`);
+        return 0;
+      } catch (err) {
+        console.error(`\n  Error: ${err instanceof Error ? err.message : String(err)}\n`);
+        return 1;
+      }
     }
 
     case 'check': {
@@ -84,57 +86,59 @@ export function runScope(args: string[]): void {
       if (!credentialName) {
         console.error('\n  Usage: secretless-ai scope check <credential-name>\n');
         console.log('  Re-checks scope and compares to stored baseline.\n');
-        process.exit(1);
+        return 1;
       }
 
       const baseline = loadBaseline(credentialName);
       if (!baseline) {
         console.error(`\n  No baseline found for "${credentialName}".`);
         console.log('  Run "secretless-ai scope discover" first to create a baseline.\n');
-        process.exit(1);
+        return 1;
       }
 
       const store = new SecretStore({ backendType: resolveBackendType() });
-      store.getSecret(credentialName).then(async (value) => {
-        if (!value) {
-          console.error(`\n  Credential "${credentialName}" not found in secret store.\n`);
-          process.exit(1);
-        }
-
-        try {
-          const result = await discoverScope(credentialName, value, { saveAsBaseline: false });
-
-          console.log(`\n  Scope Check: ${credentialName}`);
-          console.log(`  Provider: ${result.provider.toUpperCase()}`);
-          console.log(`  Last baseline: ${baseline.checkedAt}`);
-          console.log(`  Current permissions: ${result.currentPermissions.length}`);
-          console.log(`  Baseline permissions: ${result.baselinePermissions.length}`);
-
-          if (result.hasExpanded) {
-            console.log(`  EXPANDED: +${result.added.length} new permissions detected`);
-            for (const p of result.added) {
-              console.log(`    + ${p}`);
-            }
-            console.log(`\n  WARNING: Credential scope has expanded since baseline.`);
-            console.log(`  Run 'secretless-ai scope discover ${credentialName}' to update baseline.\n`);
-          } else if (result.removed.length > 0) {
-            console.log(`  Contracted: -${result.removed.length} removed permissions`);
-            for (const p of result.removed) {
-              console.log(`    - ${p}`);
-            }
-            console.log();
-          } else {
-            console.log('  No changes since baseline.\n');
-          }
-        } catch (err) {
-          console.error(`\n  Error: ${err instanceof Error ? err.message : String(err)}\n`);
-          process.exit(1);
-        }
-      }).catch((err) => {
+      let value: string | undefined;
+      try {
+        value = await store.getSecret(credentialName);
+      } catch (err) {
         console.error(`\n  Error reading credential: ${err instanceof Error ? err.message : String(err)}\n`);
-        process.exit(1);
-      });
-      break;
+        return 1;
+      }
+      if (!value) {
+        console.error(`\n  Credential "${credentialName}" not found in secret store.\n`);
+        return 1;
+      }
+
+      try {
+        const result = await discoverScope(credentialName, value, { saveAsBaseline: false });
+
+        console.log(`\n  Scope Check: ${credentialName}`);
+        console.log(`  Provider: ${result.provider.toUpperCase()}`);
+        console.log(`  Last baseline: ${baseline.checkedAt}`);
+        console.log(`  Current permissions: ${result.currentPermissions.length}`);
+        console.log(`  Baseline permissions: ${result.baselinePermissions.length}`);
+
+        if (result.hasExpanded) {
+          console.log(`  EXPANDED: +${result.added.length} new permissions detected`);
+          for (const p of result.added) {
+            console.log(`    + ${p}`);
+          }
+          console.log(`\n  WARNING: Credential scope has expanded since baseline.`);
+          console.log(`  Run 'secretless-ai scope discover ${credentialName}' to update baseline.\n`);
+        } else if (result.removed.length > 0) {
+          console.log(`  Contracted: -${result.removed.length} removed permissions`);
+          for (const p of result.removed) {
+            console.log(`    - ${p}`);
+          }
+          console.log();
+        } else {
+          console.log('  No changes since baseline.\n');
+        }
+        return 0;
+      } catch (err) {
+        console.error(`\n  Error: ${err instanceof Error ? err.message : String(err)}\n`);
+        return 1;
+      }
     }
 
     case 'list': {
@@ -142,7 +146,7 @@ export function runScope(args: string[]): void {
       if (baselines.length === 0) {
         console.log('\n  No scope baselines stored.\n');
         console.log('  Run "secretless-ai scope discover <credential-name>" to create one.\n');
-        break;
+        return 0;
       }
 
       console.log('\n  Scope Baselines\n');
@@ -153,14 +157,14 @@ export function runScope(args: string[]): void {
         console.log(`    Last check:  ${b.checkedAt}`);
         console.log();
       }
-      break;
+      return 0;
     }
 
     case 'reset': {
       const credentialName = args[1];
       if (!credentialName) {
         console.error('\n  Usage: secretless-ai scope reset <credential-name>\n');
-        process.exit(1);
+        return 1;
       }
 
       const cleared = resetBaseline(credentialName);
@@ -170,7 +174,7 @@ export function runScope(args: string[]): void {
       } else {
         console.log(`\n  No baseline found for "${credentialName}".\n`);
       }
-      break;
+      return 0;
     }
 
     default:
@@ -181,6 +185,6 @@ export function runScope(args: string[]): void {
       console.log('    check <name>      Re-check and compare to baseline');
       console.log('    list              Show all stored baselines');
       console.log('    reset <name>      Clear baseline for re-baseline\n');
-      process.exit(1);
+      return 1;
   }
 }

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -44,7 +44,7 @@ function ensureShellHook(): void {
   console.log(`  Run: source ~/${profileName}   (or open a new terminal)`);
 }
 
-export function runSecret(args: string[]): void {
+export async function runSecret(args: string[]): Promise<number> {
   const subcommand = args[0];
 
   switch (subcommand) {
@@ -52,7 +52,7 @@ export function runSecret(args: string[]): void {
       const nameArg = args[1];
       if (!nameArg) {
         console.error('\n  Usage: secretless-ai secret set <NAME[=VALUE]>\n');
-        process.exit(1);
+        return 1;
       }
 
       // Validate secret name format
@@ -66,102 +66,70 @@ export function runSecret(args: string[]): void {
         if (!value) {
           console.error('  Error: no value provided.');
           console.error('  Usage: secretless-ai secret set NAME=VALUE\n');
-          process.exit(1);
+          return 1;
         }
         if (!SECRET_NAME_RE.test(name)) {
           console.error('  Error: Invalid secret name. Use letters, numbers, underscores, hyphens. Must start with a letter.\n');
-          process.exit(1);
+          return 1;
         }
         const store = new SecretStore();
-        store.setSecret(name, value).then(() => {
+        try {
+          await store.setSecret(name, value);
           console.log(`  Stored: ${name}`);
           ensureShellHook();
-        }).catch((err) => {
+          return 0;
+        } catch (err) {
           console.error(`  Error: ${err instanceof Error ? err.message : String(err)}`);
-          process.exit(1);
-        });
-        return;
+          return 1;
+        }
       }
 
       // Read value from stdin
       const name = nameArg;
       if (!SECRET_NAME_RE.test(name)) {
         console.error('  Error: Invalid secret name. Use letters, numbers, underscores, hyphens. Must start with a letter.\n');
-        process.exit(1);
+        return 1;
       }
 
-      let input = '';
-      process.stdin.setEncoding('utf-8');
-
-      if (process.stdin.isTTY) {
-        process.stderr.write(`  Enter value for ${name}: `);
+      const value = await readSecretFromStdin(name);
+      if (value === null) {
+        console.error('  Error: no value provided.');
+        console.error('  Usage: secretless-ai secret set NAME=VALUE');
+        console.error('  Or:    echo "value" | secretless-ai secret set NAME\n');
+        return 1;
       }
-
-      process.stdin.on('data', (chunk) => {
-        input += chunk;
-        // In TTY mode, each Enter press delivers a line — store immediately.
-        // In piped mode, we may get multiple chunks, but the first is usually all.
-        if (process.stdin.isTTY) {
-          const value = input.trim();
-          if (!value) {
-            console.error('  Error: no value provided.');
-            console.error('  Usage: secretless-ai secret set NAME=VALUE');
-            console.error('  Or:    echo "value" | secretless-ai secret set NAME\n');
-            process.exit(1);
-          }
-          const store = new SecretStore();
-          store.setSecret(name, value).then(() => {
-            console.log(`  Stored: ${name}`);
-            ensureShellHook();
-            process.exit(0);
-          }).catch((err) => {
-            console.error(`  Error: ${err instanceof Error ? err.message : String(err)}`);
-            process.exit(1);
-          });
-        }
-      });
-
-      // Piped mode: wait for stdin to close, then store
-      process.stdin.on('end', () => {
-        const value = input.trim();
-        if (!value) {
-          console.error('  Error: no value provided.');
-          console.error('  Usage: secretless-ai secret set NAME=VALUE');
-          console.error('  Or:    echo "value" | secretless-ai secret set NAME\n');
-          process.exit(1);
-        }
-        const store = new SecretStore();
-        store.setSecret(name, value).then(() => {
-          console.log(`  Stored: ${name}`);
-          ensureShellHook();
-          process.exit(0);
-        }).catch((err) => {
-          console.error(`  Error: ${err instanceof Error ? err.message : String(err)}`);
-          process.exit(1);
-        });
-      });
-      break;
+      const store = new SecretStore();
+      try {
+        await store.setSecret(name, value);
+        console.log(`  Stored: ${name}`);
+        ensureShellHook();
+        return 0;
+      } catch (err) {
+        console.error(`  Error: ${err instanceof Error ? err.message : String(err)}`);
+        return 1;
+      }
     }
 
     case 'list': {
       const store = new SecretStore();
-      store.listSecrets().then((names) => {
+      try {
+        const names = await store.listSecrets();
         if (names.length === 0) {
           console.log('\n  No secrets stored.');
           console.log('  Store one:    npx secretless-ai secret set MY_KEY=my_value');
           console.log('  Import .env:  npx secretless-ai import .env\n');
-          return;
+          return 0;
         }
         console.log(`\n  ${names.length} secret(s):\n`);
-        for (const name of names) {
-          console.log(`    ${name}`);
+        for (const n of names) {
+          console.log(`    ${n}`);
         }
         console.log();
-      }).catch((err) => {
+        return 0;
+      } catch (err) {
         console.error(`  Error: ${err instanceof Error ? err.message : String(err)}`);
-        process.exit(1);
-      });
-      break;
+        return 1;
+      }
     }
 
     case 'get': {
@@ -169,7 +137,7 @@ export function runSecret(args: string[]): void {
       const name = positional[0];
       if (!name) {
         console.error('\n  Usage: secretless-ai secret get <NAME>\n');
-        process.exit(1);
+        return 1;
       }
 
       // Block output in non-interactive contexts (AI tools capture stdout).
@@ -182,25 +150,26 @@ export function runSecret(args: string[]): void {
         console.error('');
         console.error('  To force output (e.g. piping to clipboard):');
         console.error('    npx secretless-ai secret get <NAME> --force');
-        process.exit(1);
+        return 1;
       }
 
       const store = new SecretStore();
-      store.getSecret(name).then((value) => {
+      try {
+        const value = await store.getSecret(name);
         if (value === undefined) {
           console.error(`  Secret not found: ${name}`);
-          process.exit(1);
+          return 1;
         }
         process.stdout.write(value);
         // Add newline if stdout is a terminal
         if (process.stdout.isTTY) {
           process.stdout.write('\n');
         }
-      }).catch((err) => {
+        return 0;
+      } catch (err) {
         console.error(`  Error: ${err instanceof Error ? err.message : String(err)}`);
-        process.exit(1);
-      });
-      break;
+        return 1;
+      }
     }
 
     case 'rm':
@@ -209,26 +178,63 @@ export function runSecret(args: string[]): void {
       const name = args[1];
       if (!name) {
         console.error('\n  Usage: secretless-ai secret rm <NAME>\n');
-        process.exit(1);
+        return 1;
       }
       const store = new SecretStore();
-      store.removeSecret(name).then((removed) => {
+      try {
+        const removed = await store.removeSecret(name);
         if (removed) {
           console.log(`  Removed: ${name}`);
-        } else {
-          console.error(`  Secret not found: ${name}`);
-          process.exit(1);
+          return 0;
         }
-      }).catch((err) => {
+        console.error(`  Secret not found: ${name}`);
+        return 1;
+      } catch (err) {
         console.error(`  Error: ${err instanceof Error ? err.message : String(err)}`);
-        process.exit(1);
-      });
-      break;
+        return 1;
+      }
     }
 
     default:
       console.error(`\n  Unknown secret command: ${subcommand ?? '(none)'}`);
       console.log('  Usage: secretless-ai secret <set|list|get|rm> [args]\n');
-      process.exit(1);
+      return 1;
   }
+}
+
+/**
+ * Read a secret value from stdin. In TTY mode, reads one line (until Enter).
+ * In piped mode, reads until stdin closes. Returns null if value is empty.
+ */
+function readSecretFromStdin(name: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    let input = '';
+    process.stdin.setEncoding('utf-8');
+
+    if (process.stdin.isTTY) {
+      process.stderr.write(`  Enter value for ${name}: `);
+    }
+
+    let resolved = false;
+    const finish = (value: string): void => {
+      if (resolved) return;
+      resolved = true;
+      const trimmed = value.trim();
+      resolve(trimmed === '' ? null : trimmed);
+    };
+
+    process.stdin.on('data', (chunk) => {
+      input += chunk;
+      // In TTY mode, each Enter press delivers a line — store immediately.
+      // In piped mode, we may get multiple chunks; wait for 'end'.
+      if (process.stdin.isTTY) {
+        finish(input);
+      }
+    });
+
+    // Piped mode: wait for stdin to close, then store
+    process.stdin.on('end', () => {
+      finish(input);
+    });
+  });
 }

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -4,7 +4,7 @@ import { getSessionStatus } from '../session/session-state';
 import { installDaemon, uninstallDaemon, isDaemonInstalled } from '../session/install';
 import { formatRemainingTime } from './utils';
 
-export function runWarm(args: string[]): void {
+export async function runWarm(args: string[]): Promise<number> {
   // Parse --ttl flag (accepts seconds or duration strings like 5m, 1h, 1d)
   let ttlSeconds: number | undefined;
   for (let i = 0; i < args.length; i++) {
@@ -15,7 +15,7 @@ export function runWarm(args: string[]): void {
         ttlSeconds = parsed;
       } else {
         console.error(`\n  Invalid TTL: ${raw}. Examples: 300, 5m, 1h, 1d\n`);
-        process.exit(1);
+        return 1;
       }
     }
   }
@@ -31,17 +31,17 @@ export function runWarm(args: string[]): void {
     console.log(`  Expires in:   ${formatRemainingTime(current.remainingSeconds)}`);
     console.log(`  Expires at:   ${current.expiresAt}`);
     console.log();
-    return;
+    return 0;
   }
 
   console.log('  Warming session...');
 
-  warm(ttlSeconds, !noBroker).then((result) => {
+  try {
+    const result = await warm(ttlSeconds, !noBroker);
     if (!result.sessionWarm) {
       console.error(`  Session warming failed.${result.error ? ` ${result.error}` : ''}`);
       console.log('  Try again or check system authentication settings.\n');
-      process.exit(1);
-      return;
+      return 1;
     }
 
     console.log('  Session is warm.\n');
@@ -64,20 +64,20 @@ export function runWarm(args: string[]): void {
     }
 
     console.log('\n  You can now use AI tools without repeated auth prompts.\n');
-  }).catch((err) => {
+    return 0;
+  } catch (err) {
     console.error(`\n  Error: ${err instanceof Error ? err.message : String(err)}\n`);
-    process.exit(1);
-  });
+    return 1;
+  }
 }
 
-export function runInstall(args: string[]): void {
+export function runInstall(args: string[]): number {
   const subcommand = args[0];
 
   if (subcommand === 'uninstall' || subcommand === 'remove') {
     const result = uninstallDaemon();
     console.log(`\n  ${result.message}\n`);
-    if (!result.removed) process.exit(1);
-    return;
+    return result.removed ? 0 : 1;
   }
 
   if (subcommand === 'status' || subcommand === 'check') {
@@ -87,7 +87,7 @@ export function runInstall(args: string[]): void {
       console.log('  Install: npx secretless-ai install');
     }
     console.log();
-    return;
+    return 0;
   }
 
   // Reject unknown subcommands
@@ -97,7 +97,7 @@ export function runInstall(args: string[]): void {
     console.log('    secretless-ai install              Install broker as login daemon');
     console.log('    secretless-ai install uninstall     Remove login daemon');
     console.log('    secretless-ai install status        Check installation status\n');
-    process.exit(1);
+    return 1;
   }
 
   // Default: install
@@ -115,8 +115,8 @@ export function runInstall(args: string[]): void {
       console.log('  Broker daemon will start automatically on login.');
       console.log('  Warm your session: npx secretless-ai warm\n');
     }
-  } else {
-    console.log(`  ${result.message}\n`);
-    process.exit(1);
+    return 0;
   }
+  console.log(`  ${result.message}\n`);
+  return 1;
 }

--- a/src/commands/transcript.ts
+++ b/src/commands/transcript.ts
@@ -3,7 +3,7 @@ import { cleanTranscripts } from '../transcript';
 import { startWatch, stopWatch, isWatchRunning, installLaunchAgent, uninstallLaunchAgent } from '../watch';
 import { scanHistory, cleanHistory } from '../history';
 
-export function runClean(args: string[]): void {
+export function runClean(args: string[]): number {
   const dryRun = args.includes('--dry-run');
   const lastSession = args.includes('--last');
   let targetPath: string | undefined;
@@ -31,7 +31,7 @@ export function runClean(args: string[]): void {
   if (result.totalFindings === 0) {
     console.log(`  Scanned: ${result.filesScanned} files`);
     console.log('  No credentials found. Transcripts are clean.\n');
-    return;
+    return 0;
   }
 
   // Group findings by file
@@ -58,21 +58,22 @@ export function runClean(args: string[]): void {
   } else {
     console.log(`  Redacted: ${result.totalRedacted}\n`);
   }
+  return 0;
 }
 
-export function runWatch(args: string[]): void {
+export function runWatch(args: string[]): number {
   const action = args[0];
 
   switch (action) {
     case 'start':
       if (isWatchRunning()) {
         console.log('\n  Watcher is already running.\n');
-        return;
+        return 0;
       }
       console.log('\n  Starting Secretless transcript watcher...');
       console.log('  Press Ctrl+C to stop.\n');
       startWatch();
-      break;
+      return 0;
 
     case 'stop':
       if (stopWatch()) {
@@ -80,7 +81,7 @@ export function runWatch(args: string[]): void {
       } else {
         console.log('\n  No watcher is running.\n');
       }
-      break;
+      return 0;
 
     case 'status':
       if (isWatchRunning()) {
@@ -89,7 +90,7 @@ export function runWatch(args: string[]): void {
         console.log('\n  Watcher: not running');
         console.log('  Start: npx secretless-ai watch start\n');
       }
-      break;
+      return 0;
 
     case 'install':
       if (installLaunchAgent()) {
@@ -99,7 +100,7 @@ export function runWatch(args: string[]): void {
       } else {
         console.log('\n  LaunchAgent installation is only supported on macOS.\n');
       }
-      break;
+      return 0;
 
     case 'uninstall':
       if (uninstallLaunchAgent()) {
@@ -108,12 +109,13 @@ export function runWatch(args: string[]): void {
       } else {
         console.log('\n  No LaunchAgent found to remove.\n');
       }
-      break;
+      return 0;
 
     case '--help':
     case '-h':
-    default:
-      if (action && action !== '--help' && action !== '-h') {
+    default: {
+      const isUnknown = !!action && action !== '--help' && action !== '-h';
+      if (isUnknown) {
         console.error(`\n  Unknown watch action: ${action}`);
       }
       console.log('\n  Usage: secretless-ai watch <start|stop|status|install|uninstall>\n');
@@ -123,20 +125,21 @@ export function runWatch(args: string[]): void {
       console.log('    status     Show watcher status');
       console.log('    install    Install as macOS LaunchAgent');
       console.log('    uninstall  Remove LaunchAgent\n');
-      if (action && action !== '--help' && action !== '-h') process.exit(1);
-      break;
+      return isUnknown ? 1 : 0;
+    }
   }
 }
 
-export function runScanHistory(): void {
+export async function runScanHistory(): Promise<number> {
   console.log('\n  Shell History Scanner\n');
 
-  scanHistory().then((result) => {
+  try {
+    const result = await scanHistory();
     console.log(`  Files scanned: ${result.filesScanned}`);
 
     if (result.findingCount === 0) {
       console.log('  No credentials found in shell history.\n');
-      return;
+      return 0;
     }
 
     console.log(`  Found ${result.findingCount} credential(s):\n`);
@@ -149,21 +152,22 @@ export function runScanHistory(): void {
 
     console.log('  Run `npx secretless-ai clean-history` to redact credentials.');
     console.log('  Run `npx secretless-ai clean-history --dry-run` to preview changes.\n');
-    process.exit(1);
-  }).catch((err) => {
+    return 1;
+  } catch (err) {
     console.error(`\n  Error: ${err instanceof Error ? err.message : String(err)}\n`);
-    process.exit(1);
-  });
+    return 1;
+  }
 }
 
-export function runCleanHistory(dryRun: boolean): void {
+export async function runCleanHistory(dryRun: boolean): Promise<number> {
   if (dryRun) {
     console.log('\n  Shell History Cleaner (dry run)\n');
   } else {
     console.log('\n  Shell History Cleaner\n');
   }
 
-  cleanHistory(dryRun).then((result) => {
+  try {
+    const result = await cleanHistory(dryRun);
     console.log(`  Files scanned:  ${result.filesScanned}`);
     console.log(`  Files modified: ${result.filesModified}`);
     console.log(`  Lines redacted: ${result.linesRedacted}`);
@@ -182,8 +186,9 @@ export function runCleanHistory(dryRun: boolean): void {
     } else {
       console.log('\n  History cleaned. Backups saved with .bak extension.\n');
     }
-  }).catch((err) => {
+    return 0;
+  } catch (err) {
     console.error(`\n  Error: ${err instanceof Error ? err.message : String(err)}\n`);
-    process.exit(1);
-  });
+    return 1;
+  }
 }

--- a/src/commands/vault.test.ts
+++ b/src/commands/vault.test.ts
@@ -82,9 +82,8 @@ describe('runVault CLI dispatch', () => {
     });
   });
 
-  it('dispatches "register" without namespace shows usage and exits', () => {
-    runVault(['register']);
-    expect(exitSpy).toHaveBeenCalledWith(1);
+  it('dispatches "register" without namespace shows usage and exits', async () => {
+    expect(await runVault(['register'])).toBe(1);
     expect(vaultRegister).not.toHaveBeenCalled();
   });
 
@@ -106,9 +105,8 @@ describe('runVault CLI dispatch', () => {
     });
   });
 
-  it('dispatches "rotate" without namespace shows usage and exits', () => {
-    runVault(['rotate']);
-    expect(exitSpy).toHaveBeenCalledWith(1);
+  it('dispatches "rotate" without namespace shows usage and exits', async () => {
+    expect(await runVault(['rotate'])).toBe(1);
     expect(vaultRotate).not.toHaveBeenCalled();
   });
 
@@ -117,9 +115,8 @@ describe('runVault CLI dispatch', () => {
     expect(vaultRevoke).toHaveBeenCalledWith('github');
   });
 
-  it('dispatches "revoke" without namespace shows usage and exits', () => {
-    runVault(['revoke']);
-    expect(exitSpy).toHaveBeenCalledWith(1);
+  it('dispatches "revoke" without namespace shows usage and exits', async () => {
+    expect(await runVault(['revoke'])).toBe(1);
     expect(vaultRevoke).not.toHaveBeenCalled();
   });
 
@@ -155,9 +152,8 @@ describe('runVault CLI dispatch', () => {
     );
   });
 
-  it('dispatches "exec" without -- shows usage and exits', () => {
-    runVault(['exec', 'github', 'curl']);
-    expect(exitSpy).toHaveBeenCalledWith(1);
+  it('dispatches "exec" without -- shows usage and exits', async () => {
+    expect(await runVault(['exec', 'github', 'curl'])).toBe(1);
     expect(vaultExec).not.toHaveBeenCalled();
   });
 
@@ -181,9 +177,8 @@ describe('runVault CLI dispatch', () => {
     expect(output).toContain('vault exec');
   });
 
-  it('shows error and help for unknown subcommand', () => {
-    runVault(['unknown-cmd']);
-    expect(exitSpy).toHaveBeenCalledWith(1);
+  it('shows error and help for unknown subcommand', async () => {
+    expect(await runVault(['unknown-cmd'])).toBe(1);
     const errorOutput = consoleErrorSpy.mock.calls.flat().join(' ');
     expect(errorOutput).toContain('Unknown vault command: unknown-cmd');
   });

--- a/src/commands/vault.ts
+++ b/src/commands/vault.ts
@@ -17,65 +17,59 @@ import {
   vaultMigrate,
 } from '../vault-core';
 
-export function runVault(args: string[]): void {
+export async function runVault(args: string[]): Promise<number> {
   const subcommand = args[0];
 
   switch (subcommand) {
     case 'init':
-      handleInit(args.slice(1));
-      break;
+      return handleInit(args.slice(1));
     case 'register':
-      handleRegister(args.slice(1));
-      break;
+      return handleRegister(args.slice(1));
     case 'list':
     case 'ls':
-      handleList();
-      break;
+      return handleList();
     case 'rotate':
-      handleRotate(args.slice(1));
-      break;
+      return handleRotate(args.slice(1));
     case 'revoke':
-      handleRevoke(args.slice(1));
-      break;
+      return handleRevoke(args.slice(1));
     case 'audit':
-      handleAudit(args.slice(1));
-      break;
+      return handleAudit(args.slice(1));
     case 'scan':
-      handleScan(args.slice(1));
-      break;
+      return handleScan(args.slice(1));
     case 'exec':
-      handleExec(args.slice(1));
-      break;
+      return handleExec(args.slice(1));
     case 'test':
-      handleTest();
-      break;
+      return handleTest();
     case 'migrate':
-      handleMigrate(args.slice(1));
-      break;
+      return handleMigrate(args.slice(1));
     case '--help':
     case '-h':
       printVaultHelp();
-      break;
+      return 0;
     default: {
       const isUnknown = subcommand && subcommand !== '--help' && subcommand !== '-h';
       if (isUnknown) {
         console.error(`\n  Unknown vault command: ${subcommand}`);
       }
       printVaultHelp();
-      if (isUnknown) process.exit(1);
-      break;
+      return isUnknown ? 1 : 0;
     }
   }
 }
 
 // ── Subcommand handlers ────────────────────────────────────────────
 
-function handleInit(args: string[]): void {
+async function handleInit(args: string[]): Promise<number> {
   const agentName = parseFlag(args, '--name');
-  vaultInit(agentName ?? undefined).catch(handleError);
+  try {
+    await vaultInit(agentName ?? undefined);
+    return 0;
+  } catch (err) {
+    return handleError(err);
+  }
 }
 
-function handleRegister(args: string[]): void {
+async function handleRegister(args: string[]): Promise<number> {
   const namespace = args[0];
   if (!namespace || namespace.startsWith('-')) {
     console.error('\n  Usage: secretless-ai vault register <namespace> [options]\n');
@@ -85,8 +79,7 @@ function handleRegister(args: string[]): void {
     console.error('    --description <desc>  Namespace description');
     console.error('    --operations <ops>    Comma-separated: read,write,delete,admin');
     console.error('    --url-patterns <pats> Comma-separated URL patterns\n');
-    process.exit(1);
-    return;
+    return 1;
   }
 
   const value = parseFlag(args, '--value');
@@ -100,65 +93,93 @@ function handleRegister(args: string[]): void {
     : undefined;
   const urlPatterns = urlStr ? urlStr.split(',').map(u => u.trim()) : undefined;
 
-  vaultRegister(namespace, {
-    value: value ?? undefined,
-    envVar: envVar ?? undefined,
-    description: description ?? undefined,
-    operations,
-    urlPatterns,
-  }).catch(handleError);
+  try {
+    await vaultRegister(namespace, {
+      value: value ?? undefined,
+      envVar: envVar ?? undefined,
+      description: description ?? undefined,
+      operations,
+      urlPatterns,
+    });
+    return 0;
+  } catch (err) {
+    return handleError(err);
+  }
 }
 
-function handleList(): void {
-  vaultList().catch(handleError);
+async function handleList(): Promise<number> {
+  try {
+    await vaultList();
+    return 0;
+  } catch (err) {
+    return handleError(err);
+  }
 }
 
-function handleRotate(args: string[]): void {
+async function handleRotate(args: string[]): Promise<number> {
   const namespace = args[0];
   if (!namespace || namespace.startsWith('-')) {
     console.error('\n  Usage: secretless-ai vault rotate <namespace> [--value <value>] [--env <VAR>]\n');
-    process.exit(1);
-    return;
+    return 1;
   }
 
   const value = parseFlag(args, '--value');
   const envVar = parseFlag(args, '--env');
 
-  vaultRotate(namespace, {
-    value: value ?? undefined,
-    envVar: envVar ?? undefined,
-  }).catch(handleError);
+  try {
+    await vaultRotate(namespace, {
+      value: value ?? undefined,
+      envVar: envVar ?? undefined,
+    });
+    return 0;
+  } catch (err) {
+    return handleError(err);
+  }
 }
 
-function handleRevoke(args: string[]): void {
+async function handleRevoke(args: string[]): Promise<number> {
   const namespace = args[0];
   if (!namespace || namespace.startsWith('-')) {
     console.error('\n  Usage: secretless-ai vault revoke <namespace>\n');
-    process.exit(1);
-    return;
+    return 1;
   }
 
-  vaultRevoke(namespace).catch(handleError);
+  try {
+    await vaultRevoke(namespace);
+    return 0;
+  } catch (err) {
+    return handleError(err);
+  }
 }
 
-function handleAudit(args: string[]): void {
+async function handleAudit(args: string[]): Promise<number> {
   const limitStr = parseFlag(args, '--limit');
   const since = parseFlag(args, '--since');
   const namespace = parseFlag(args, '--namespace');
 
-  vaultAudit({
-    limit: limitStr ? parseInt(limitStr, 10) : undefined,
-    since: since ?? undefined,
-    namespace: namespace ?? undefined,
-  }).catch(handleError);
+  try {
+    await vaultAudit({
+      limit: limitStr ? parseInt(limitStr, 10) : undefined,
+      since: since ?? undefined,
+      namespace: namespace ?? undefined,
+    });
+    return 0;
+  } catch (err) {
+    return handleError(err);
+  }
 }
 
-function handleScan(args: string[]): void {
+async function handleScan(args: string[]): Promise<number> {
   const dir = args.find(a => !a.startsWith('-'));
-  vaultScan(dir).catch(handleError);
+  try {
+    await vaultScan(dir);
+    return 0;
+  } catch (err) {
+    return handleError(err);
+  }
 }
 
-function handleExec(args: string[]): void {
+async function handleExec(args: string[]): Promise<number> {
   // Parse: vault exec <namespace> [--env-name VAR] -- <command...>
   const dashDashIdx = args.indexOf('--');
   if (dashDashIdx === -1) {
@@ -166,8 +187,7 @@ function handleExec(args: string[]): void {
     console.error('  Example:');
     console.error('    secretless-ai vault exec github -- curl https://api.github.com/user');
     console.error('    secretless-ai vault exec aws-prod --env-name AWS_SECRET_ACCESS_KEY -- aws s3 ls\n');
-    process.exit(1);
-    return;
+    return 1;
   }
 
   const preArgs = args.slice(0, dashDashIdx);
@@ -176,31 +196,42 @@ function handleExec(args: string[]): void {
   const namespace = preArgs[0];
   if (!namespace || namespace.startsWith('-')) {
     console.error('\n  Error: namespace is required before --\n');
-    process.exit(1);
-    return;
+    return 1;
   }
 
   const envName = parseFlag(preArgs, '--env-name');
 
-  vaultExec(namespace, command, {
-    envName: envName ?? undefined,
-  }).then((code) => {
-    process.exit(code);
-  }).catch(handleError);
+  try {
+    return await vaultExec(namespace, command, {
+      envName: envName ?? undefined,
+    });
+  } catch (err) {
+    return handleError(err);
+  }
 }
 
-function handleTest(): void {
-  vaultTest().catch(handleError);
+async function handleTest(): Promise<number> {
+  try {
+    await vaultTest();
+    return 0;
+  } catch (err) {
+    return handleError(err);
+  }
 }
 
-function handleMigrate(args: string[]): void {
+async function handleMigrate(args: string[]): Promise<number> {
   const dryRun = args.includes('--dry-run');
   const envFile = parseFlag(args, '--env-file');
 
-  vaultMigrate({
-    dryRun,
-    envFile: envFile ?? undefined,
-  }).catch(handleError);
+  try {
+    await vaultMigrate({
+      dryRun,
+      envFile: envFile ?? undefined,
+    });
+    return 0;
+  } catch (err) {
+    return handleError(err);
+  }
 }
 
 // ── Help ───────────────────────────────────────────────────────────
@@ -262,8 +293,8 @@ function parseFlag(args: string[], flag: string): string | null {
   return args[idx + 1];
 }
 
-function handleError(err: unknown): void {
+function handleError(err: unknown): number {
   const message = err instanceof Error ? err.message : String(err);
   console.error(`\n  Error: ${message}\n`);
-  process.exit(1);
+  return 1;
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -10,7 +10,7 @@
  * export lines.
  *
  * Security:
- *   - Only outputs to TTY or when stdout is piped to eval (no AI tool capture)
+ *   - Output goes only to a TTY or to a shell `eval` consumer; AI tools never capture it.
  *   - Values are single-quoted to prevent shell expansion
  *   - The eval pattern means secrets never touch disk as plaintext
  */


### PR DESCRIPTION
## Summary

Closes #61. Replaces `process.exit()` calls across the command modules with explicit return-of-exit-code, threading exit codes through the dispatcher to `main()`'s sole `process.exit`. This lets the `try/finally` in `src/cli.ts:72-83` fire `tele.track + tele.flush` on every command path, including error/non-zero exits — previously only happy-path returns emitted telemetry.

The headline feature of 0.16.0 is anonymous adoption telemetry. Pre-fix, every error branch was invisible: scan-with-findings, verify FAIL/WARN, doctor unhealthy, and every command's error path emitted no telemetry, biasing adoption metrics toward "everything always works." Post-fix, every command emits exactly one event, with `success: false` on non-zero exit codes.

## Changes

- `src/cli.ts` — `dispatch()` is now `async (args, command): Promise<number>`; `main()` awaits it. `process.exit()` lives only in `main().then()` at line 178.
- All command handlers in `src/commands/*.ts` return `number` or `Promise<number>`:
  - core.ts: runInit, runScan, runVerify, runStatus, runDoctor
  - secrets.ts: runSecret (stdin reader extracted to a Promise helper with double-resolve guard)
  - vault.ts: runVault + handleX subhandlers + handleError
  - scope.ts: runScope
  - mcp.ts: runProtectMcp / runMcpStatus / runMcpUnprotect
  - broker.ts: runBroker (async/await replacing fire-and-forget; behavior preserved)
  - session.ts: runWarm / runInstall
  - rules.ts: runRules
  - transcript.ts: runClean / runWatch / runScanHistory / runCleanHistory
  - git.ts: runHook / runScanStaged (the `hook --check-only` fast path retains its silent runHookCheck() exit by design — Claude Code PreToolUse contract; would dominate telemetry)
  - backend.ts: runBackend / runMigrate / runCache
  - env-run.ts: runRun / runEnv / runImport / runSetupCommand (preserves child-process exit code at runRun and `vault exec` at vault.ts:188)
- `src/env.ts` — one-line JSDoc rephrase to suppress an HMA scanner false-positive (`eval (` substring match in a comment describing the shell `eval "$(...)"` pattern). No behavior change.

## Verification

- `npm run build` clean (tsc).
- `npm test` 873/873 green (5 vault.test.ts assertions updated to await + assert resolved exit code).
- Local smoke with `OPENA2A_TELEMETRY_DEBUG=print`: scan (with and without findings), verify (FAIL), status, doctor, rules, backend, and an unknown-command path each emit exactly one `[opena2a:telemetry]` event with the correct success bit. `telemetry`/`--version`/`--help` still emit zero lines (NON_TRACKED). Version line still shows "Telemetry: on (...)".
- Exit codes preserved: scan-empty=0, scan-nonexistent=1, scan-with-finding=1, verify-FAIL=1, doctor-unhealthy=1, unknown-command=1, vault-unknown=1, rules-bad-pattern=1, secret-rm-no-arg=1.
- HackMyAgent: 95/100, no CRITICAL or HIGH (the one MEDIUM is an HMA FP on the user-local, gitignored `.claude/settings.json` whose deny-rule patterns match a credential keyword regex).

## Test plan

- [x] `npm test` green
- [x] Manual exit-code matrix on every changed dispatcher entry
- [x] Telemetry payload audit with `OPENA2A_TELEMETRY_DEBUG=print` for scan/verify/status/doctor/rules/backend
- [x] Negative: telemetry/--version/--help still emit zero telemetry lines
- [ ] Re-run `/release-test` against the 0.16.1 tarball to retire #61 (planned next step)

## Out of scope

Issues #62 (init flag-as-path footgun), #63 (scan --json no-op), and #64 (scan vs verify disagreement) are tracked separately. Bundling them risks the re-test gate; one issue, one verb.