### PR TITLE
fix(backends): silence read-only commands — no more Touch ID / 1Password dialogs (0.16.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.2] - 2026-04-28
+
+### Fixed
+- **Read-only commands no longer trigger Touch ID or "1Password Access Requested" dialogs.** `secretless-ai backend` (no subcommand) and the local→keychain upgrade in `createBackend` were calling `isKeychainAvailable()` (`security default-keychain` — can fire Touch ID on Macs with biometric-locked keychains) and `isOnePasswordAvailable()` (`op account get` — fires the "Allow Terminal to get CLI access" dialog on Macs with the 1Password desktop app). A first-time user running `npx secretless-ai backend` to inspect available backends would see these prompts and reasonably uninstall. Split each probe into a `*Likely()` variant (cheap PATH/platform check, never spawns a process) and the existing `*Available()` variant (active probe, kept for genuine pre-flight on `backend set <type>` and `migrate`). Read-only display paths now use `*Likely()`. Regression test in `src/commands/backend.silence.test.ts` asserts `runBackend([])`, `runStatus`, and `createBackend('local')` never invoke `security` or `op` via `child_process`. Public API gains `isKeychainLikely` and `isOnePasswordLikely` exports.
+
 ## [0.16.1] - 2026-04-28
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "secretless-ai",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "secretless-ai",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@opena2a/cli-ui": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secretless-ai",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "One command to keep secrets out of AI. Works with Claude Code, Cursor, Copilot, Windsurf, and any AI coding tool.",
   "license": "Apache-2.0",
   "type": "commonjs",

--- a/src/backends/factory.ts
+++ b/src/backends/factory.ts
@@ -6,6 +6,9 @@
  * Falls back to 'local' on unsupported platforms with a console message.
  */
 
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
 import { LocalBackend } from './local';
 import { MacOSKeychainBackend } from './keychain-macos';
 import { LinuxKeychainBackend } from './keychain-linux';
@@ -35,9 +38,12 @@ export function createBackend(
 ): WritableSecretBackend {
   let backend: WritableSecretBackend;
 
-  // When callers request 'local', prefer keychain if the platform supports it
+  // When callers request 'local', prefer keychain if the platform supports it.
+  // Use the prompt-free Likely check here — this path runs from MCP wrappers,
+  // brokers, and resolvers that must not trigger Touch ID. Real auth happens
+  // lazily on the first secret read/write.
   if (type === 'local' && !config?.key) {
-    const keychainStatus = isKeychainAvailable();
+    const keychainStatus = isKeychainLikely();
     if (keychainStatus.available) {
       try {
         backend = createKeychainBackend(config);
@@ -110,15 +116,89 @@ export function createBackend(
 }
 
 /**
+ * Cheap, prompt-free signal that the OS keychain is likely usable.
+ *
+ * Safe for read-only commands (`backend` with no subcommand, `status`,
+ * `--version`) and for the local-to-keychain upgrade in `createBackend`.
+ * NEVER shells out to a binary that could prompt for biometrics — on macOS
+ * even `security default-keychain` can trigger Touch ID under certain configs.
+ */
+export function isKeychainLikely(): { available: boolean; platform: string; message: string } {
+  const platform = process.platform;
+
+  if (platform === 'darwin') {
+    return { available: true, platform: 'macOS', message: 'macOS Keychain assumed available (not probed)' };
+  }
+
+  if (platform === 'linux') {
+    if (binaryOnPath('secret-tool')) {
+      return { available: true, platform: 'Linux', message: 'secret-tool found on PATH (not probed)' };
+    }
+    return {
+      available: false,
+      platform: 'Linux',
+      message: 'secret-tool not found. Install libsecret-tools (Debian/Ubuntu) or libsecret (Fedora/RHEL).',
+    };
+  }
+
+  return {
+    available: false,
+    platform: platform,
+    message: `OS keychain is not supported on ${platform}. Using local encrypted backend.`,
+  };
+}
+
+/**
+ * Cheap, prompt-free signal that the 1Password CLI is likely usable.
+ *
+ * Checks PATH for the `op` binary without invoking it. Safe for read-only
+ * commands. The active probe (`op account get`) triggers the
+ * "1Password Access Requested" dialog on Macs with the desktop app — only
+ * call `isOnePasswordAvailable()` from genuine pre-flight paths.
+ */
+export function isOnePasswordLikely(): { available: boolean; message: string } {
+  if (binaryOnPath('op')) {
+    return { available: true, message: '1Password CLI (op) found on PATH (auth not probed)' };
+  }
+  return {
+    available: false,
+    message: '1Password CLI (op) not found. Install from https://developer.1password.com/docs/cli',
+  };
+}
+
+function binaryOnPath(name: string): boolean {
+  const PATH = process.env.PATH || '';
+  const sep = process.platform === 'win32' ? ';' : ':';
+  const exts = process.platform === 'win32' ? (process.env.PATHEXT || '.EXE').split(';') : [''];
+  for (const dir of PATH.split(sep)) {
+    if (!dir) continue;
+    for (const ext of exts) {
+      try {
+        const candidate = path.join(dir, name + ext);
+        fs.accessSync(candidate, fs.constants.X_OK);
+        return true;
+      } catch {
+        // not here, keep looking
+      }
+    }
+  }
+  return false;
+}
+
+/**
  * Check if the OS keychain is available on the current platform.
  * Returns a description of the keychain status.
+ *
+ * Note: on macOS this shells out to `security default-keychain`, which can
+ * trigger Touch ID under some configurations. Prefer `isKeychainLikely()`
+ * for read-only display paths; reserve this for genuine pre-flight checks
+ * (e.g. `backend set keychain`).
  */
 export function isKeychainAvailable(): { available: boolean; platform: string; message: string } {
   const platform = process.platform;
 
   if (platform === 'darwin') {
     try {
-      const { execFileSync } = require('child_process');
       execFileSync('security', ['default-keychain'], { stdio: 'pipe' });
       return { available: true, platform: 'macOS', message: 'macOS Keychain is available' };
     } catch {
@@ -128,7 +208,6 @@ export function isKeychainAvailable(): { available: boolean; platform: string; m
 
   if (platform === 'linux') {
     try {
-      const { execFileSync } = require('child_process');
       execFileSync('which', ['secret-tool'], { stdio: 'pipe' });
       return { available: true, platform: 'Linux', message: 'secret-tool is available (Linux Secret Service)' };
     } catch {
@@ -150,10 +229,14 @@ export function isKeychainAvailable(): { available: boolean; platform: string; m
 /**
  * Check if the 1Password CLI (`op`) is available and authenticated.
  * Returns availability status and an actionable message.
+ *
+ * Note: this calls `op account get`, which triggers a "1Password Access
+ * Requested" dialog on Macs with the 1Password desktop app integration
+ * enabled. Reserve for genuine pre-flight checks (e.g. `backend set
+ * 1password`); use `isOnePasswordLikely()` for read-only display paths.
  */
 export function isOnePasswordAvailable(): { available: boolean; message: string } {
   try {
-    const { execFileSync } = require('child_process');
     execFileSync('op', ['--version'], { stdio: 'pipe' });
   } catch {
     return {
@@ -163,7 +246,6 @@ export function isOnePasswordAvailable(): { available: boolean; message: string 
   }
 
   try {
-    const { execFileSync } = require('child_process');
     execFileSync('op', ['account', 'get', '--format', 'json'], { stdio: 'pipe' });
     return {
       available: true,

--- a/src/backends/index.ts
+++ b/src/backends/index.ts
@@ -4,7 +4,7 @@ export { MacOSKeychainBackend } from './keychain-macos';
 export { LinuxKeychainBackend } from './keychain-linux';
 export { VaultBackend, type VaultBackendConfig } from './vault';
 export { GCPSecretManagerBackend, isGCPAvailable, type GCPSecretManagerConfig } from './gcp-sm';
-export { createBackend, isKeychainAvailable } from './factory';
+export { createBackend, isKeychainAvailable, isKeychainLikely, isOnePasswordAvailable, isOnePasswordLikely } from './factory';
 export { readBackendConfig, writeBackendConfig, resolveBackendType, readCacheTtl, writeCacheTtl, parseDuration, formatTtl, DEFAULT_CACHE_TTL_SECONDS, type SelectableBackendType } from './config';
 export { CachedBackend, clearCacheFile } from './cache';
 export { migrateSecrets, type MigrateOptions, type MigrateResult } from './migrate';

--- a/src/commands/backend.silence.test.ts
+++ b/src/commands/backend.silence.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Regression guard for the 0.16.2 fix: read-only command paths must NOT shell
+// out to `security` (Touch ID on macOS) or `op` (the "1Password Access
+// Requested" dialog on Macs with the desktop app). If a future change pushes
+// an active probe back onto a silent path, these tests catch it before users do.
+
+const execFileMock = vi.fn();
+const execMock = vi.fn();
+const spawnSyncMock = vi.fn();
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    execFileSync: (...args: unknown[]) => {
+      execFileMock(...args);
+      const cmd = args[0] as string;
+      // Anything that's not security/op falls through to real implementation
+      // so unrelated commands (e.g. git in scan-staged) keep working.
+      if (cmd === 'security' || cmd === 'op' || cmd === 'which') {
+        // Simulate "not present" rather than actually shelling out — keeps the
+        // test deterministic on dev machines where these binaries exist.
+        const err = new Error(`mocked: ${cmd} not invoked in tests`);
+        throw err;
+      }
+      return actual.execFileSync(...(args as Parameters<typeof actual.execFileSync>));
+    },
+    execSync: (...args: unknown[]) => {
+      execMock(...args);
+      return actual.execSync(...(args as Parameters<typeof actual.execSync>));
+    },
+    spawnSync: (...args: unknown[]) => {
+      spawnSyncMock(...args);
+      return actual.spawnSync(...(args as Parameters<typeof actual.spawnSync>));
+    },
+  };
+});
+
+function makeFakeHome(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-silence-test-'));
+}
+
+function cleanup(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+describe('read-only commands stay silent (no biometric / 1P prompts)', () => {
+  let originalHome: string | undefined;
+  let originalLog: typeof console.log;
+  let originalError: typeof console.error;
+  let fakeHome: string;
+
+  beforeEach(() => {
+    fakeHome = makeFakeHome();
+    originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+
+    originalLog = console.log;
+    originalError = console.error;
+    console.log = () => {};
+    console.error = () => {};
+
+    execFileMock.mockClear();
+    execMock.mockClear();
+    spawnSyncMock.mockClear();
+  });
+
+  afterEach(() => {
+    console.log = originalLog;
+    console.error = originalError;
+    if (originalHome !== undefined) {
+      process.env.HOME = originalHome;
+    } else {
+      delete process.env.HOME;
+    }
+    cleanup(fakeHome);
+  });
+
+  function offending(): unknown[][] {
+    return [
+      ...execFileMock.mock.calls.filter(([cmd]) => cmd === 'security' || cmd === 'op'),
+      ...execMock.mock.calls.filter(([cmd]) => typeof cmd === 'string' && (cmd.includes('security ') || cmd.startsWith('op '))),
+      ...spawnSyncMock.mock.calls.filter(([cmd]) => cmd === 'security' || cmd === 'op'),
+    ];
+  }
+
+  it('runBackend with no subcommand does not invoke `security` or `op`', async () => {
+    const { runBackend } = await import('./backend');
+    const exitCode = await runBackend([]);
+    expect(exitCode).toBe(0);
+    expect(offending()).toEqual([]);
+  });
+
+  it('runStatus does not invoke `security` or `op`', async () => {
+    const { runStatus } = await import('./core');
+    const exitCode = runStatus(fakeHome);
+    expect(exitCode).toBe(0);
+    expect(offending()).toEqual([]);
+  });
+
+  it('createBackend("local") does not invoke `security` (keychain upgrade uses Likely probe)', async () => {
+    // No `key` in config — exercises the local→keychain upgrade branch in
+    // factory.ts, which is the path that used to fire `security default-keychain`
+    // and could trigger Touch ID on macOS.
+    const { createBackend } = await import('../backends/factory');
+    createBackend('local', { storeDir: fakeHome });
+    expect(offending()).toEqual([]);
+  });
+});

--- a/src/commands/backend.ts
+++ b/src/commands/backend.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { isKeychainAvailable, isOnePasswordAvailable, createBackend } from '../backends/factory';
+import { isKeychainAvailable, isKeychainLikely, isOnePasswordAvailable, isOnePasswordLikely, createBackend } from '../backends/factory';
 import { isGCPAvailable } from '../backends/gcp-sm';
 import { readBackendConfig, writeBackendConfig, resolveBackendType, readCacheTtl, writeCacheTtl, parseDuration, formatTtl } from '../backends/config';
 import { clearCacheFile } from '../backends/cache';
@@ -171,17 +171,21 @@ export async function runBackend(args: string[]): Promise<number> {
     return 0;
   }
 
-  // Default: show current backend status
+  // Default: show current backend status.
+  // Use the prompt-free *Likely() probes so listing the available backends
+  // never triggers Touch ID or a "1Password Access Requested" dialog. Run
+  // `npx secretless-ai backend set <type>` to invoke the active probe when
+  // the user actually wants to switch.
   const current = resolveBackendType();
   const configFile = readBackendConfig();
-  const kc = isKeychainAvailable();
-  const op = isOnePasswordAvailable();
+  const kc = isKeychainLikely();
+  const op = isOnePasswordLikely();
 
   console.log('\n  Secretless Backend\n');
   console.log(`  Current:      ${current}${configFile ? '' : ' (default)'}`);
   console.log(`  Config file:  ${configFile ?? '(not set)'}`);
-  console.log(`  Keychain:     ${kc.available ? 'available' : 'unavailable'} (${kc.message})`);
-  console.log(`  1Password:    ${op.available ? 'available' : 'unavailable'} (${op.message})`);
+  console.log(`  Keychain:     ${kc.available ? 'likely available' : 'unavailable'} (${kc.message})`);
+  console.log(`  1Password:    ${op.available ? 'likely available' : 'unavailable'} (${op.message})`);
   const vaultAddr = process.env.VAULT_ADDR;
   const vaultConfigured = !!(vaultAddr && process.env.VAULT_TOKEN);
   console.log(`  Vault:        ${vaultConfigured ? 'configured' : 'not configured'} (${vaultConfigured ? vaultAddr : 'set VAULT_ADDR + VAULT_TOKEN'})`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export {
 
 // Backend management
 export {
-  createBackend, isKeychainAvailable,
+  createBackend, isKeychainAvailable, isKeychainLikely, isOnePasswordAvailable, isOnePasswordLikely,
   resolveBackendType, readBackendConfig, writeBackendConfig,
   migrateSecrets,
   LocalBackend, MacOSKeychainBackend, LinuxKeychainBackend, VaultBackend,


### PR DESCRIPTION
## Summary

Read-only paths (`secretless-ai backend` with no subcommand, and the local→keychain upgrade in `createBackend`) used to call `isKeychainAvailable()` (`security default-keychain` — can fire Touch ID) and `isOnePasswordAvailable()` (`op account get` — fires the "1Password Access Requested — Allow Terminal to get CLI access" dialog on Macs with the 1Password desktop app). A first-time user inspecting available backends saw these prompts and reasonably uninstalled.

This PR splits each probe in two:

- **`*Likely()`** — cheap PATH/platform check, never spawns a process. Used by read-only display paths (`runBackend` default branch) and the local→keychain upgrade (`createBackend` line 45).
- **`*Available()`** — active probe (current behavior). Reserved for genuine pre-flight on `backend set <type>` and `migrate`.

Public API gains `isKeychainLikely` and `isOnePasswordLikely` exports. Regression test in `src/commands/backend.silence.test.ts` asserts `runBackend([])`, `runStatus`, and `createBackend('local')` never invoke `security` or `op` via `child_process` — and the test was verified to FAIL when the fix is reverted.

Bumps to 0.16.2.

## Visible change

```
$ secretless-ai backend
  Keychain:     likely available (macOS Keychain assumed available (not probed))
  1Password:    likely available (1Password CLI (op) found on PATH (auth not probed))
```

No more Touch ID prompt. No more "1Password Access Requested" dialog. The "(not probed)" parenthetical is honest about what the read-only display does and doesn't verify.

## Test plan
- [x] `npm test` — 876 tests pass (3 new regression tests in `backend.silence.test.ts`)
- [x] `npm run build` clean
- [x] Regression test verified: fails when `createBackend` is reverted to `isKeychainAvailable()`
- [x] Smoke: `secretless-ai --version`, `backend`, `status`, `backend list`, `cache` — zero biometric/auth prompts on a Mac with 1Password desktop app installed
- [x] `secretless-ai backend set 1password` preserved — still actively probes (correct, that's a genuine pre-flight)
- [x] /pre-push-review PASS
- [x] /release-test PASS — 0 P1 issues. Fresh-user subagent confirmed phrasing and silence.