### PR TITLE
release: secretless-ai 0.16.3 — lockstep with @opena2a/credential-patterns@0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.3] - 2026-04-29
+
+### Added
+- Runtime dependency on `@opena2a/credential-patterns@0.1.0` (exact pin). PR 1 of the credential-pattern consolidation lifted the local pattern catalog into a shared, SLSA-attested package so secretless-ai and hackmyagent stop maintaining duplicate regex copies. This release brings the package in as a peer of the local catalog and asserts they stay in lockstep.
+- `src/lockstep.test.ts` — equivalence test that fails CI on any drift between local `src/patterns.ts` and the package: pattern count, per-pattern (`id`, `name`, `regex.source`, `regex.flags`, `envPrefix`, `category`), `CREDENTIAL_PREFIX_QUICK_CHECK`, `KNOWN_EXAMPLE_KEYS`, `PLACEHOLDER_INDICATORS`, `SECRET_FILE_PATTERNS`, `CONFIG_FILES`, `SOURCE_FILE_EXTENSIONS`, `SOURCE_SKIP_DIRS`, plus functional parity of `isKnownExample` / `findRealMatch` on a panel of allowlist-branch oracle inputs. Mutation-tested: a regex change or allowlist addition on either side fails this test with a precise per-pattern diagnostic.
+
+### Changed
+- No behavior change. No public API change. `import { CREDENTIAL_PATTERNS } from 'secretless-ai'` still resolves to the local CommonJS-friendly catalog. `scan` / `verify` / `init` / `transcript` / `mcp` / `doctor` / `history` / `scan-staged` paths continue to read from `src/patterns.ts`. The full migration that moves consumer code onto the package directly requires converting secretless-ai from CommonJS to ESM (the package is ESM-only) and is tracked separately for a future major version.
+
 ## [0.16.2] - 2026-04-28
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "secretless-ai",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "secretless-ai",
-      "version": "0.16.2",
+      "version": "0.16.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@opena2a/cli-ui": "0.4.0",
+        "@opena2a/credential-patterns": "0.1.0",
         "@opena2a/telemetry": "0.1.2"
       },
       "bin": {
@@ -126,6 +127,12 @@
       "dependencies": {
         "chalk": "^5.3.0"
       }
+    },
+    "node_modules/@opena2a/credential-patterns": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@opena2a/credential-patterns/-/credential-patterns-0.1.0.tgz",
+      "integrity": "sha512-TiEYTOicugmeK7TC3i+VSnJvM2xDC5v9PYljjODnNyPPwzeuKTy/M+XHdoik/gjrTfbS+8lb/I2LAqCgmY2/qQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@opena2a/telemetry": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secretless-ai",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "One command to keep secrets out of AI. Works with Claude Code, Cursor, Copilot, Windsurf, and any AI coding tool.",
   "license": "Apache-2.0",
   "type": "commonjs",
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "@opena2a/cli-ui": "0.4.0",
+    "@opena2a/credential-patterns": "0.1.0",
     "@opena2a/telemetry": "0.1.2"
   }
 }

--- a/src/lockstep.test.ts
+++ b/src/lockstep.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Lockstep equivalence test: local src/patterns.ts must match
+ * @opena2a/credential-patterns byte-for-byte.
+ *
+ * The package was published in PR 1 by relocating this file. As long as
+ * secretless-ai keeps a local CommonJS-compatible copy (the public
+ * `import { CREDENTIAL_PATTERNS } from 'secretless-ai'` API depends on it),
+ * any drift between the two catalogs is a bug. This test fires on:
+ *  - new patterns added on one side only
+ *  - regex source/flags changed on one side only
+ *  - allowlist (KNOWN_EXAMPLE_KEYS / PLACEHOLDER_INDICATORS) drift
+ *  - SECRET_FILE_PATTERNS / CONFIG_FILES / SOURCE_FILE_EXTENSIONS / SOURCE_SKIP_DIRS drift
+ *  - findRealMatch / isKnownExample behavioral drift on oracle inputs
+ *
+ * When the package version bumps, intentional changes land here first
+ * (re-sync src/patterns.ts), then the package version pin in package.json
+ * is bumped. A failing test means: do not ship until the catalogs match.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  CREDENTIAL_PATTERNS as LOCAL_PATTERNS,
+  CREDENTIAL_PREFIX_QUICK_CHECK as LOCAL_QUICK_CHECK,
+  KNOWN_EXAMPLE_KEYS as LOCAL_EXAMPLES,
+  PLACEHOLDER_INDICATORS as LOCAL_PLACEHOLDERS,
+  SECRET_FILE_PATTERNS as LOCAL_SECRET_FILES,
+  CONFIG_FILES as LOCAL_CONFIG_FILES,
+  SOURCE_FILE_EXTENSIONS as LOCAL_SOURCE_EXTS,
+  SOURCE_SKIP_DIRS as LOCAL_SKIP_DIRS,
+} from './patterns';
+import { findRealMatch as localFindRealMatch, isKnownExample as localIsKnownExample } from './scan';
+
+type PkgModule = typeof import('@opena2a/credential-patterns');
+
+let pkgPromise: Promise<PkgModule> | null = null;
+function loadPkg(): Promise<PkgModule> {
+  if (!pkgPromise) pkgPromise = import('@opena2a/credential-patterns');
+  return pkgPromise;
+}
+
+describe('lockstep: local src/patterns.ts === @opena2a/credential-patterns', () => {
+  it('CREDENTIAL_PATTERNS arrays have identical length', async () => {
+    const pkg = await loadPkg();
+    expect(LOCAL_PATTERNS.length).toBe(pkg.CREDENTIAL_PATTERNS.length);
+  });
+
+  it('CREDENTIAL_PATTERNS entries match by index (id, name, regex.source, regex.flags, envPrefix, category)', async () => {
+    const pkg = await loadPkg();
+    const len = Math.max(LOCAL_PATTERNS.length, pkg.CREDENTIAL_PATTERNS.length);
+    const drift: string[] = [];
+    for (let i = 0; i < len; i++) {
+      const local = LOCAL_PATTERNS[i];
+      const remote = pkg.CREDENTIAL_PATTERNS[i];
+      if (!local || !remote) {
+        drift.push(`index ${i}: missing on ${local ? 'package' : 'local'} side`);
+        continue;
+      }
+      if (local.id !== remote.id) drift.push(`index ${i}: id local=${local.id} pkg=${remote.id}`);
+      if (local.name !== remote.name) drift.push(`index ${i} (${local.id}): name local=${local.name} pkg=${remote.name}`);
+      if (local.regex.source !== remote.regex.source) drift.push(`index ${i} (${local.id}): regex.source local=${local.regex.source} pkg=${remote.regex.source}`);
+      if (local.regex.flags !== remote.regex.flags) drift.push(`index ${i} (${local.id}): regex.flags local=${local.regex.flags} pkg=${remote.regex.flags}`);
+      if (local.envPrefix !== remote.envPrefix) drift.push(`index ${i} (${local.id}): envPrefix local=${local.envPrefix} pkg=${remote.envPrefix}`);
+      if (local.category !== remote.category) drift.push(`index ${i} (${local.id}): category local=${local.category} pkg=${remote.category}`);
+    }
+    expect(drift, drift.join('\n')).toEqual([]);
+  });
+
+  it('CREDENTIAL_PREFIX_QUICK_CHECK source + flags match', async () => {
+    const pkg = await loadPkg();
+    expect(LOCAL_QUICK_CHECK.source).toBe(pkg.CREDENTIAL_PREFIX_QUICK_CHECK.source);
+    expect(LOCAL_QUICK_CHECK.flags).toBe(pkg.CREDENTIAL_PREFIX_QUICK_CHECK.flags);
+  });
+
+  it('KNOWN_EXAMPLE_KEYS sets contain identical members', async () => {
+    const pkg = await loadPkg();
+    const localList = [...LOCAL_EXAMPLES].sort();
+    const pkgList = [...pkg.KNOWN_EXAMPLE_KEYS].sort();
+    expect(localList).toEqual(pkgList);
+  });
+
+  it('PLACEHOLDER_INDICATORS arrays match (order-sensitive)', async () => {
+    const pkg = await loadPkg();
+    expect(LOCAL_PLACEHOLDERS).toEqual(pkg.PLACEHOLDER_INDICATORS);
+  });
+
+  it('SECRET_FILE_PATTERNS arrays match (order-sensitive)', async () => {
+    const pkg = await loadPkg();
+    expect(LOCAL_SECRET_FILES).toEqual(pkg.SECRET_FILE_PATTERNS);
+  });
+
+  it('CONFIG_FILES arrays match (order-sensitive)', async () => {
+    const pkg = await loadPkg();
+    expect(LOCAL_CONFIG_FILES).toEqual(pkg.CONFIG_FILES);
+  });
+
+  it('SOURCE_FILE_EXTENSIONS sets contain identical members', async () => {
+    const pkg = await loadPkg();
+    const localList = [...LOCAL_SOURCE_EXTS].sort();
+    const pkgList = [...pkg.SOURCE_FILE_EXTENSIONS].sort();
+    expect(localList).toEqual(pkgList);
+  });
+
+  it('SOURCE_SKIP_DIRS sets contain identical members', async () => {
+    const pkg = await loadPkg();
+    const localList = [...LOCAL_SKIP_DIRS].sort();
+    const pkgList = [...pkg.SOURCE_SKIP_DIRS].sort();
+    expect(localList).toEqual(pkgList);
+  });
+});
+
+describe('lockstep: isKnownExample / findRealMatch parity on oracle inputs', () => {
+  // Each row covers a real allowlist branch in isKnownExample. A behavior
+  // change in either implementation flips one of these.
+  const ORACLE_LINES: string[] = [
+    'const k = "AKIAIOSFODNN7EXAMPLE"',                 // KNOWN_EXAMPLE_KEYS hit
+    'const k = "AKIAREALKEY1234567890"',                // real-looking AWS key, no allowlist marker
+    '# TODO: rotate AKIAREALKEY1234567890 next sprint', // issue #50: TODO is a placeholder substring -> example
+    'const k = "your_api_key_here"',                    // PLACEHOLDER_INDICATORS hit
+    '// example: AKIAREALKEY1234567890',                // comment-marker example branch
+    'const real = "ghp_abcdefghijklmnopqrstuvwxyz1234567890"', // real-looking GitHub PAT
+    'old="AKIAIOSFODNN7EXAMPLE"; new_="ghp_abcdefghijklmnopqrstuvwxyz1234567890"', // issue #51 shadowing
+    'plain text with no credential',                    // no match at all
+  ];
+
+  it('isKnownExample returns identical results across local vs package on every oracle line × every regex match', async () => {
+    const pkg = await loadPkg();
+    const drift: string[] = [];
+    for (const line of ORACLE_LINES) {
+      for (const pattern of LOCAL_PATTERNS) {
+        const globalRegex = new RegExp(pattern.regex.source, pattern.regex.flags + (pattern.regex.flags.includes('g') ? '' : 'g'));
+        for (const m of line.matchAll(globalRegex)) {
+          const local = localIsKnownExample(line, m);
+          const remote = pkg.isKnownExample(line, m);
+          if (local !== remote) {
+            drift.push(`pattern=${pattern.id} match=${m[0]} line=${JSON.stringify(line)} local=${local} pkg=${remote}`);
+          }
+        }
+      }
+    }
+    expect(drift, drift.join('\n')).toEqual([]);
+  });
+
+  it('findRealMatch returns identical results across local vs package on every oracle line × every pattern', async () => {
+    const pkg = await loadPkg();
+    const drift: string[] = [];
+    for (const line of ORACLE_LINES) {
+      for (const pattern of LOCAL_PATTERNS) {
+        const localResult = localFindRealMatch(line, pattern);
+        const remoteResult = pkg.findRealMatch(line, pattern);
+        const localStr = localResult ? localResult[0] : null;
+        const remoteStr = remoteResult ? remoteResult[0] : null;
+        if (localStr !== remoteStr) {
+          drift.push(`pattern=${pattern.id} line=${JSON.stringify(line)} local=${localStr} pkg=${remoteStr}`);
+        }
+      }
+    }
+    expect(drift, drift.join('\n')).toEqual([]);
+  });
+
+  it('PR 1 contract: AWS allowlist still catches AKIAIOSFODNN7EXAMPLE in package', async () => {
+    const pkg = await loadPkg();
+    expect(pkg.KNOWN_EXAMPLE_KEYS.has('AKIAIOSFODNN7EXAMPLE')).toBe(true);
+    expect(pkg.KNOWN_EXAMPLE_KEYS.has('AKIAI44QH8DHBEXAMPLE')).toBe(true);
+  });
+
+  it('PR 1 contract: findRealMatch on AWS-example + real-PAT line returns the PAT, not null (issue #51)', async () => {
+    const pkg = await loadPkg();
+    const line = 'const old = "AKIAIOSFODNN7EXAMPLE"; const new_ = "ghp_abcdefghijklmnopqrstuvwxyz1234567890";';
+    const ghPattern = pkg.CREDENTIAL_PATTERNS.find((p: import('@opena2a/credential-patterns').CredentialPattern) => p.id === 'github-pat')!;
+    const m = pkg.findRealMatch(line, ghPattern);
+    expect(m).not.toBeNull();
+    expect(m![0]).toBe('ghp_abcdefghijklmnopqrstuvwxyz1234567890');
+  });
+});


### PR DESCRIPTION
## Summary

- PR 2 of the credential-pattern consolidation. Brings `@opena2a/credential-patterns@0.1.0` (PR 1, on the registry as of 2026-04-29) in as a runtime dependency with an exact pin.
- Adds `src/lockstep.test.ts` — a CI test that fails on any drift between the local `src/patterns.ts` catalog and the package's catalog (length, per-pattern fields, allowlist, prefix quick-check, placeholder list, secret-file list, config-file list, source-extensions set, source-skip-dirs set, plus functional parity of `isKnownExample` / `findRealMatch` on a panel of allowlist-branch oracle inputs).
- No behavior change. No public API change. No consumer code touched. Bumps 0.16.2 → 0.16.3 patch.

## Why dual-source instead of full migration

The original PR 2 plan was to migrate `secretless-ai`'s consumer code onto the package directly and bump 0.17.0 minor. Two constraints blocked that:

1. **Public library API.** `package.json` declares `"main": "dist/index.js"` and `src/index.ts:6` re-exports `CREDENTIAL_PATTERNS, SECRET_FILE_PATTERNS, CONFIG_FILES, CREDENTIAL_PREFIX_QUICK_CHECK, CredentialPattern` as part of the published library — `import { CREDENTIAL_PATTERNS } from 'secretless-ai'` is a real surface. Removing or asynchronizing those exports is breaking.
2. **Module-system mismatch.** `secretless-ai` is `"type": "commonjs"`. `@opena2a/credential-patterns` is `"type": "module"`-only. CommonJS code can't `export ... from` an ESM-only package — only `await import(...)` works, which forces the public API surface to become async.

Migrating consumer code onto the package therefore requires a full ESM conversion of `secretless-ai`, which is a larger change than this PR. That conversion lands as a future major version bump. In the meantime, this PR locks the local catalog in lockstep with the package so PR 3 (hackmyagent) can ship against the same canonical source without risking drift.

## What the lockstep test asserts

13 assertions across two `describe` blocks. Catches any of the following drifting on either side:

- `CREDENTIAL_PATTERNS.length` count.
- Per-pattern (matched by index): `id`, `name`, `regex.source`, `regex.flags`, `envPrefix`, `category`. Failures emit a per-pattern-id diagnostic — e.g. `"index 8 (fireworks): regex.source local=... pkg=..."`.
- `CREDENTIAL_PREFIX_QUICK_CHECK` source + flags.
- `KNOWN_EXAMPLE_KEYS` set membership (sorted-list compare).
- `PLACEHOLDER_INDICATORS` array (order-sensitive).
- `SECRET_FILE_PATTERNS` array (order-sensitive).
- `CONFIG_FILES` array (order-sensitive).
- `SOURCE_FILE_EXTENSIONS` set membership.
- `SOURCE_SKIP_DIRS` set membership.
- `isKnownExample(line, match)` returning identical results on local + package across every pattern × every regex match × 8 allowlist-branch oracle lines.
- `findRealMatch(line, pattern)` returning identical results on local + package across every pattern × 8 oracle lines (covers the issue #51 shadowing case).
- PR 1 contract sanity: AWS allowlist still has `AKIAIOSFODNN7EXAMPLE` + `AKIAI44QH8DHBEXAMPLE`; `findRealMatch` on AWS-example + real-PAT line returns the PAT, not null.

## Phase 4.5 mutation tests (run pre-merge)

| Mutation | Expected | Actual |
|---|---|---|
| Change `fireworks` regex on local side from `{20,}` to `{99,}` | Lockstep test fails with `index 8 (fireworks): regex.source local=fw_[a-zA-Z0-9]{99,} pkg=fw_[a-zA-Z0-9]{20,}` | ✓ Caught |
| Add `AKIANEWFAKEEXAMPLE99` to local `KNOWN_EXAMPLE_KEYS` | `KNOWN_EXAMPLE_KEYS` test fails with sorted-list diff showing the extra key | ✓ Caught |

## Test plan

- [x] `npm run build` — clean (tsc).
- [x] `npm test` — 56/56 test files, 889/889 tests pass; the lockstep file alone runs 13 assertions.
- [x] Comparison run: `secretless-ai 0.16.2` (current latest on the registry) vs branch build, on `opena2a-corpus/repo/malicious/kitchen-sink` — diff empty (1 critical PostgreSQL Connection String at `.env:5`, exit=1, byte-identical output).
- [x] Negative control: same comparison on `opena2a-corpus/repo/benign/tiny-clean-repo` — diff empty (no findings, exit=0).
- [x] Mutation-tested the lockstep test as documented above.
- [ ] After merge: tag `v0.16.3` from main; GHA workflow exchanges OIDC and registers SLSA v1 attestations; verify with `npm view secretless-ai@0.16.3 dist.attestations --json`.
- [ ] After registry release: bump `homebrew-tap/Formula/secretless-ai.rb` (url + sha256) + version table in `homebrew-tap/README.md`.

## Files changed

- `package.json` — adds `@opena2a/credential-patterns: "0.1.0"` exact pin, version bump.
- `package-lock.json` — regenerated.
- `CHANGELOG.md` — 0.16.3 entry.
- `src/lockstep.test.ts` (new, 130 LOC) — equivalence test.

No edits to `src/patterns.ts`, any of the 11 consumers (`src/scan.ts`, `src/scan-staged.ts`, `src/verify.ts`, `src/init.ts`, `src/history.ts`, `src/doctor.ts`, `src/transcript.ts`, `src/mcp/classify.ts`, `src/index.ts`, `src/patterns.test.ts`, `src/scan.test.ts`), or any code outside the file list above.

## Follow-ups

- ESM conversion of `secretless-ai` + actual consumer migration onto the package — separate PR, separate session, future major bump.
- PR 3 (hackmyagent) — separate session, starts after this lands and `secretless-ai 0.16.3` is on the registry.
- `0.1.1` follow-up issue on `opena2a-org/opena2a` for the catalog improvements PR 1's bot reviewer flagged (`isKnownExample` dead-code, ReDoS test expansion, multi-real test, allowlist additions).