### PR TITLE
feat(0.16.4): .secretlessignore + init/status redesign per CISO Rule 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.4] - 2026-04-29
+
+### Added
+- `.secretlessignore` — gitignore-style file at the project root that suppresses scan findings for paths the user has marked as fixtures or examples. The default-ignore list is applied automatically on top of the user file and covers `__tests__/`, `__fixtures__/`, `test/`, `tests/`, `test-server/`, `docs/vhs/`, `examples/`, `e2e/`, `.golden/`, `node_modules/`, `dist/`, `build/`. Each default path is justified by a real-world false positive observed during dogfooding (e.g. `docs/vhs/setup-lab.sh` fixture credentials, `test-server/agents.js` adversarial system prompts). Negative patterns (`!docs/vhs/`) re-enable scanning for a default-ignored path. New CLI flag `--no-ignore` on `scan` and `scan-staged` disables both the user file and the defaults. Public API: `loadSecretlessIgnore`, `buildMatcher`, `DEFAULT_IGNORE_PATTERNS`, `IgnoreMatcher`.
+- `secretless-ai feedback` — opt-in subcommand that prints the star/issue/discussion links. Replaces the unconditional "Helpful? Star the project" line that previously trailed every `init` invocation.
+
+### Changed
+- **`init` output redesigned** per CISO Rule 11. Collapsed the redundant Detected + Configured pair into one line (`Configured: Claude Code (1 of 1 detected)`); the previous `+` / `*` glyph distinction was confusing. The `Modified:` line now says exactly what changed (`.claude/settings.json (added 21 deny patterns)`) instead of just naming the file. Dropped the misleading `Done. Secrets are now blocked from AI context.` line — `init` configures hooks, the actual blocking happens at AI-tool invocation. Added a `Next steps:` block (Verify / Scan / Status) so every run ends in a runnable verb. Removed the unconditional star-prompt line from `init` output (now lives in `secretless-ai feedback`). `init` re-runs over an already-configured project now print `Already up to date. No files changed.` instead of an empty Created/Modified pair.
+- **`status` output redesigned** per CISO Rule 11. The previous five sub-blocks (top-level metrics, Session, Broker, Transcript Protection, transcript line counts) collapsed into one Observations table. Every warning row ends in `→ <runnable command>` so the user has no dead end. Glyphs differentiate satisfied (`✓`) from needs-action (`⚠`). The Verdict line now reflects the warning count instead of a bare `Protected: Yes` — `Protected — Clean`, `Protected (4 unblocked credentials need review)`, `Not protected. Run secretless-ai init to install hooks.`
+- **Catalog re-pin to `@opena2a/credential-patterns@0.1.1`** with three new false-positive suppression branches (mirrored locally to keep the lockstep test green): block-comment marker recognition for line-level `'''`/`"""`/`<!--`/`-->`/`*` (JSDoc continuation lines now allowlisted when paired with the substring `example`), bare `'fake'` in `PLACEHOLDER_INDICATORS` (replaces `'fake_'` and `'fake-'` — case-insensitive substring match accepts `sk-proj-fake1234567890abcdefghijklmnop`), and a localhost-bound demo-password allowlist for connection strings (`postgres://admin:password123@localhost`/`@127.0.0.1`/`@[::1]` recognized as tutorial fixtures).
+- `init` `InitResult` interface gained `denyRulesAdded` (delta this run) and `denyRulesTotal` (full count after merge). The existing `denyRuleCount` on `StatusResult` is unchanged.
+
+### Internal
+- New `src/secretlessignore.ts` parser (gitignore-subset glob → regex) plus 18-test `secretlessignore.test.ts` covering defaults, user file, negation, glob semantics, anchor rules, Windows path normalization, and path-traversal rejection. New `scan()` integration tests assert default-ignore suppression of fixture paths and `--no-ignore` round-trip.
+- `walkSourceFiles` now consults the ignore matcher at directory level (prunes whole subtrees) and again at file level (file-name globs).
+
 ## [0.16.3] - 2026-04-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![npm version](https://img.shields.io/npm/v/secretless-ai.svg)](https://www.npmjs.com/package/secretless-ai)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Tests](https://img.shields.io/badge/tests-809-brightgreen)](https://github.com/opena2a-org/secretless-ai)
+[![Tests](https://img.shields.io/badge/tests-915-brightgreen)](https://github.com/opena2a-org/secretless-ai)
 
 Keep API keys and secrets invisible to AI coding tools. Works with Claude Code, Cursor, GitHub Copilot, Windsurf, Cline, and Aider.
 
@@ -14,10 +14,22 @@ npx secretless-ai init
 ```
 
 ```
-  Detected:  Claude Code, Cursor
-  Protected: .env, .aws/credentials, *.key, *.pem (21 file patterns)
-  Blocked:   49 credential patterns from AI context
-  Done.      Secrets are now invisible to AI tools.
+  Secretless v0.16.4
+  Keeping secrets out of AI
+
+  Configured: Claude Code (1 of 1 detected)
+
+  Created:
+    + .claude/hooks/secretless-guard.sh
+    + CLAUDE.md
+
+  Modified:
+    ~ .claude/settings.json (added 69 deny patterns)
+
+  Next steps:
+    Verify: secretless-ai verify
+    Scan:   secretless-ai scan
+    Status: secretless-ai status
 ```
 
 ![Secretless AI Demo](docs/secretless-ai-demo.gif)
@@ -60,7 +72,7 @@ npx secretless-ai mcp-unprotect                    # Restore original configs fr
 
 ## How It Works
 
-1. **Scans** your project for hardcoded credentials in config files *and* source code (49 patterns across .js, .ts, .py, .go, .java, .rb, and more)
+1. **Scans** your project for hardcoded credentials in config files *and* source code (56 patterns from `@opena2a/credential-patterns@0.1.1`, lockstep-asserted, across .js, .ts, .py, .go, .java, .rb, and more). Suppresses fixture-path false positives via `.secretlessignore` defaults (`test/`, `__tests__/`, `examples/`, `e2e/`, `docs/vhs/`, `node_modules/` ...)
 2. **Migrates** them to secure storage (OS keychain, 1Password, Vault, GCP Secret Manager)
 3. **Blocks** AI tools from reading credential files (21 file patterns)
 4. **Brokers** access through environment variables -- secrets never enter AI context

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "secretless-ai",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "secretless-ai",
-      "version": "0.16.3",
+      "version": "0.16.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@opena2a/cli-ui": "0.4.0",
-        "@opena2a/credential-patterns": "0.1.0",
+        "@opena2a/credential-patterns": "0.1.1",
         "@opena2a/telemetry": "0.1.2"
       },
       "bin": {
@@ -129,9 +129,9 @@
       }
     },
     "node_modules/@opena2a/credential-patterns": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@opena2a/credential-patterns/-/credential-patterns-0.1.0.tgz",
-      "integrity": "sha512-TiEYTOicugmeK7TC3i+VSnJvM2xDC5v9PYljjODnNyPPwzeuKTy/M+XHdoik/gjrTfbS+8lb/I2LAqCgmY2/qQ==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@opena2a/credential-patterns/-/credential-patterns-0.1.1.tgz",
+      "integrity": "sha512-7yfSCcxqhgGHIEysLtBP8pEaMeY+44Y9dnhQDZTDPt/d5qFL7EDrugQHd8ysEiNYtE+U6GBmu7IGb6kO3ueyOw==",
       "license": "Apache-2.0"
     },
     "node_modules/@opena2a/telemetry": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secretless-ai",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "description": "One command to keep secrets out of AI. Works with Claude Code, Cursor, Copilot, Windsurf, and any AI coding tool.",
   "license": "Apache-2.0",
   "type": "commonjs",
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@opena2a/cli-ui": "0.4.0",
-    "@opena2a/credential-patterns": "0.1.0",
+    "@opena2a/credential-patterns": "0.1.1",
     "@opena2a/telemetry": "0.1.2"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ import { runBroker } from './commands/broker';
 import { runVault } from './commands/vault';
 import { runScope } from './commands/scope';
 import { runWarm, runInstall } from './commands/session';
+import { runFeedback } from './commands/feedback';
 import { printHelp } from './commands/help';
 
 const TOOL = 'secretless-ai';
@@ -97,10 +98,11 @@ async function dispatch(args: string[], command: string | undefined): Promise<nu
       }
       const includeTests = args.includes('--include-tests');
       const explain = args.includes('--explain');
+      const noIgnore = args.includes('--no-ignore');
       const positionalArgs = args.slice(1).filter(a => !a.startsWith('--'));
       const dirArg = positionalArgs[0];
       const projectDir = dirArg ? path.resolve(dirArg) : process.cwd();
-      return runScan(projectDir, { includeTests, explain });
+      return runScan(projectDir, { includeTests, explain, noIgnore });
     }
     case 'status': {
       const dirArg = args[1];
@@ -145,7 +147,7 @@ async function dispatch(args: string[], command: string | undefined): Promise<nu
     case 'hook':
       return runHook(args.slice(1));
     case 'scan-staged':
-      return runScanStaged();
+      return runScanStaged(args.slice(1));
     case 'cache':
       return runCache(args.slice(1));
     case 'broker':
@@ -162,6 +164,8 @@ async function dispatch(args: string[], command: string | undefined): Promise<nu
       return runWarm(args.slice(1));
     case 'install':
       return runInstall(args.slice(1));
+    case 'feedback':
+      return runFeedback();
     case '--help':
     case '-h':
     case undefined:

--- a/src/commands/core.ts
+++ b/src/commands/core.ts
@@ -222,85 +222,86 @@ export function runStatus(projectDir: string): number {
   const tp = s.transcriptProtection;
   const configuredBackend = readBackendConfig();
 
-  // Build observation rows. Each row: glyph + message + optional → command.
+  // Build observation rows. Each row: glyph + label + optional → command.
   // Satisfied observations use ✓; needs-action use ⚠. Every ⚠ ends in a
   // runnable verb so the user has no dead end (CISO Rule 11).
-  type Row = { glyph: '✓' | '⚠'; message: string; action?: string };
+  type Row = { glyph: '✓' | '⚠'; label: string; action?: string };
   const rows: Row[] = [];
+  const addRow = (row: Row): void => { rows[rows.length] = row; };
 
   // Protection / hook.
   if (s.hookInstalled) {
     const denyText = s.denyRuleCount > 0 ? ` — ${s.denyRuleCount} deny pattern${s.denyRuleCount === 1 ? '' : 's'}` : '';
-    rows.push({ glyph: '✓', message: `Claude Code hook installed (.claude/settings.json${denyText})` });
+    addRow({ glyph: '✓', label: `Claude Code hook installed (.claude/settings.json${denyText})` });
   } else {
-    rows.push({ glyph: '⚠', message: 'Claude Code hook not installed', action: 'secretless-ai init' });
+    addRow({ glyph: '⚠', label: 'Claude Code hook not installed', action: 'secretless-ai init' });
   }
 
   // Stop hook (transcript redaction).
   if (tp.stopHookInstalled) {
-    rows.push({ glyph: '✓', message: 'Stop hook installed (transcript redaction)' });
+    addRow({ glyph: '✓', label: 'Stop hook installed (transcript redaction)' });
   } else {
-    rows.push({ glyph: '⚠', message: 'Stop hook not installed (transcripts unredacted)', action: 'secretless-ai init' });
+    addRow({ glyph: '⚠', label: 'Stop hook not installed (transcripts unredacted)', action: 'secretless-ai init' });
   }
 
   // Configured tools (instructions present in tool config files).
   if (s.configuredTools.length > 0) {
-    rows.push({ glyph: '✓', message: `Tool instructions: ${s.configuredTools.map(toolDisplayName).join(', ')}` });
+    addRow({ glyph: '✓', label: `Tool instructions: ${s.configuredTools.map(toolDisplayName).join(', ')}` });
   }
 
   // Secrets in config files.
   if (s.secretsFound > 0) {
-    rows.push({ glyph: '⚠', message: `${s.secretsFound} credential${s.secretsFound === 1 ? '' : 's'} detected in config files`, action: 'secretless-ai scan' });
+    addRow({ glyph: '⚠', label: `${s.secretsFound} credential${s.secretsFound === 1 ? '' : 's'} detected in config files`, action: 'secretless-ai scan' });
   } else {
-    rows.push({ glyph: '✓', message: 'No credentials in config files' });
+    addRow({ glyph: '✓', label: 'No credentials in config files' });
   }
 
   // Session warmth (only relevant when a backend that prompts is configured).
   const sessionRelevant = configuredBackend === '1password' || configuredBackend === 'keychain';
   if (sessionRelevant) {
     if (session.warm) {
-      rows.push({ glyph: '✓', message: `Biometric session warm (expires ${formatRemainingTime(session.remainingSeconds)})` });
+      addRow({ glyph: '✓', label: `Biometric session warm (expires ${formatRemainingTime(session.remainingSeconds)})` });
     } else if (session.authenticatedAt) {
-      rows.push({ glyph: '⚠', message: `Biometric session expired (last auth ${session.authenticatedAt})`, action: 'secretless-ai warm' });
+      addRow({ glyph: '⚠', label: `Biometric session expired (last auth ${session.authenticatedAt})`, action: 'secretless-ai warm' });
     } else {
-      rows.push({ glyph: '⚠', message: 'Biometric session not initialized', action: 'secretless-ai warm' });
+      addRow({ glyph: '⚠', label: 'Biometric session not initialized', action: 'secretless-ai warm' });
     }
   }
 
   // Watcher running (transcript file monitoring).
   if (tp.watcherRunning) {
-    rows.push({ glyph: '✓', message: 'Transcript watcher running' });
+    addRow({ glyph: '✓', label: 'Transcript watcher running' });
   } else {
-    rows.push({ glyph: '⚠', message: 'Transcript watcher not running', action: 'secretless-ai watch' });
+    addRow({ glyph: '⚠', label: 'Transcript watcher not running', action: 'secretless-ai watch' });
   }
 
   // Transcript files + secrets within them.
   if (tp.transcriptSecretsFound > 0) {
-    rows.push({ glyph: '⚠', message: `${tp.transcriptSecretsFound} credential${tp.transcriptSecretsFound === 1 ? '' : 's'} in recent transcripts`, action: 'secretless-ai clean' });
+    addRow({ glyph: '⚠', label: `${tp.transcriptSecretsFound} credential${tp.transcriptSecretsFound === 1 ? '' : 's'} in recent transcripts`, action: 'secretless-ai clean' });
   } else if (tp.transcriptFiles > 0) {
-    rows.push({ glyph: '✓', message: `Transcripts clean (${tp.transcriptFiles} file${tp.transcriptFiles === 1 ? '' : 's'} scanned)` });
+    addRow({ glyph: '✓', label: `Transcripts clean (${tp.transcriptFiles} file${tp.transcriptFiles === 1 ? '' : 's'} scanned)` });
   }
 
   // Broker daemon.
   if (brokerStatus) {
-    rows.push({ glyph: '✓', message: `Broker running (PID ${brokerStatus.pid}, ${formatUptime(brokerStatus.uptimeSeconds)})` });
+    addRow({ glyph: '✓', label: `Broker running (PID ${brokerStatus.pid}, ${formatUptime(brokerStatus.uptimeSeconds)})` });
   } else if (brokerInstalled) {
-    rows.push({ glyph: '⚠', message: 'Broker daemon not running', action: 'secretless-ai broker start' });
+    addRow({ glyph: '⚠', label: 'Broker daemon not running', action: 'secretless-ai broker start' });
   } else {
-    rows.push({ glyph: '⚠', message: 'Broker daemon not installed', action: 'secretless-ai install' });
+    addRow({ glyph: '⚠', label: 'Broker daemon not installed', action: 'secretless-ai install' });
   }
 
   // Render the Observations block. We measure the visible width (glyph +
-  // message) so the `→ command` column lines up tidily across rows.
+  // label) so the `→ command` column lines up tidily across rows.
   const headerLine = '──────────────────────────────────────────────────────────';
   console.log(`  ── Observations ${headerLine.slice(0, Math.max(0, 44))}`);
   let leftWidth = 0;
   for (const row of rows) {
-    const visible = row.glyph + ' ' + row.message;
+    const visible = row.glyph + ' ' + row.label;
     if (visible.length > leftWidth) leftWidth = visible.length;
   }
   for (const row of rows) {
-    const left = `${row.glyph} ${row.message}`;
+    const left = `${row.glyph} ${row.label}`;
     if (row.action) {
       const padded = left.padEnd(leftWidth, ' ');
       console.log(`  ${padded}  → ${row.action}`);

--- a/src/commands/core.ts
+++ b/src/commands/core.ts
@@ -19,79 +19,97 @@ export function runInit(projectDir: string): number {
 
   const result = init(projectDir);
 
-  // Report detected tools
-  if (result.toolsDetected.length > 0) {
-    console.log('  Detected:');
-    for (const tool of result.toolsDetected) {
-      console.log(`    + ${toolDisplayName(tool)}`);
+  // Configured line: collapse Detected + Configured into one row that tells
+  // the user what's now active and how it compares to what we found.
+  const configuredCount = result.toolsConfigured.length;
+  const detectedCount = result.toolsDetected.length;
+  if (configuredCount > 0) {
+    const names = result.toolsConfigured.map(toolDisplayName).join(', ');
+    if (detectedCount === 0) {
+      console.log(`  Configured: ${names} (no AI tools detected — defaulted to Claude Code)`);
+    } else {
+      console.log(`  Configured: ${names} (${configuredCount} of ${detectedCount} detected)`);
     }
   } else {
-    console.log('  No AI tools detected, defaulting to Claude Code');
+    console.log('  Configured: none');
   }
-  console.log();
 
-  // Report configured tools
-  console.log('  Configured:');
-  for (const tool of result.toolsConfigured) {
-    console.log(`    * ${toolDisplayName(tool)}`);
-  }
-  console.log();
+  // Files: keep the breakdown but with a specific deny-rule count when
+  // settings.json was modified. The count is the load-bearing fact (not just
+  // "modified") — users want to know what changed, not that it changed.
+  const settingsModified = result.filesModified.includes('.claude/settings.json');
+  const otherModified = result.filesModified.filter(f => f !== '.claude/settings.json');
 
-  // Report files
   if (result.filesCreated.length > 0) {
+    console.log();
     console.log('  Created:');
     for (const f of result.filesCreated) {
       console.log(`    + ${f}`);
     }
-    console.log();
   }
 
-  if (result.filesModified.length > 0) {
+  if (settingsModified || otherModified.length > 0) {
+    console.log();
     console.log('  Modified:');
-    for (const f of result.filesModified) {
+    if (settingsModified) {
+      if (result.denyRulesAdded > 0) {
+        console.log(`    ~ .claude/settings.json (added ${result.denyRulesAdded} deny pattern${result.denyRulesAdded === 1 ? '' : 's'})`);
+      } else {
+        console.log(`    ~ .claude/settings.json`);
+      }
+    }
+    for (const f of otherModified) {
       console.log(`    ~ ${f}`);
     }
+  }
+
+  // No-op case: nothing created, nothing modified — already up to date.
+  if (result.filesCreated.length === 0 && !settingsModified && otherModified.length === 0) {
     console.log();
+    console.log('  Already up to date. No files changed.');
   }
 
-  // Report secrets found
+  // Surface inline observations: secrets found + shell profile fix. Each
+  // observation ends in a runnable verb (no dead ends).
   if (result.secretsFound > 0) {
-    console.log(`  Warning: found ${result.secretsFound} hardcoded credential(s)`);
-    console.log('  Run `npx secretless-ai scan` to see details\n');
+    console.log();
+    console.log(`  Warning: ${result.secretsFound} hardcoded credential${result.secretsFound === 1 ? '' : 's'} in config files  → secretless-ai scan`);
   }
 
-  // Auto-fix shell profile issues
   const fix = fixProfiles();
   if (fix) {
-    console.log('  Shell profile fix:');
-    console.log(`    Copied ${fix.fixed.length} export(s) from ~/${fix.sourceProfile} to ~/${fix.targetProfile}`);
+    console.log();
+    console.log(`  Shell profile fix: copied ${fix.fixed.length} export${fix.fixed.length === 1 ? '' : 's'} from ~/${fix.sourceProfile} to ~/${fix.targetProfile}`);
     for (const v of fix.fixed) {
-      console.log(`      + ${v}`);
+      console.log(`    + ${v}`);
     }
     if (fix.created) {
       console.log(`    Created ~/${fix.targetProfile}`);
     }
-    console.log('    Restart your terminal for changes to take effect.\n');
+    console.log('    Restart your terminal for changes to take effect.');
   }
 
-  console.log('  Done. Secrets are now blocked from AI context.\n');
-
-  // Suggest warm for backends that trigger OS auth prompts
+  // Suggest warm for backends that trigger OS auth prompts.
   const configuredBackend = readBackendConfig();
   if (configuredBackend === '1password' || configuredBackend === 'keychain') {
-    console.log(`  Tip: Run 'npx secretless-ai warm' before starting an AI session`);
-    console.log(`  to avoid repeated ${configuredBackend === '1password' ? '1Password' : 'keychain'} auth prompts.\n`);
+    const backendName = configuredBackend === '1password' ? '1Password' : 'keychain';
+    console.log();
+    console.log(`  Tip: Run \`secretless-ai warm\` before starting an AI session to avoid`);
+    console.log(`  repeated ${backendName} auth prompts.`);
   }
 
-  // Star prompt (interactive TTY only)
-  if (process.stdout.isTTY) {
-    console.log('  Helpful? Star the project: https://github.com/opena2a-org/secretless-ai\n');
-  }
+  // Next steps block — every action ends in a runnable verb.
+  console.log();
+  console.log('  Next steps:');
+  console.log('    Verify: secretless-ai verify');
+  console.log('    Scan:   secretless-ai scan');
+  console.log('    Status: secretless-ai status');
+  console.log();
 
   return 0;
 }
 
-export async function runScan(projectDir: string, options?: { includeTests?: boolean; explain?: boolean }): Promise<number> {
+export async function runScan(projectDir: string, options?: { includeTests?: boolean; explain?: boolean; noIgnore?: boolean }): Promise<number> {
   console.log('\n  Secretless Scanner\n');
 
   const nodeFs = require('fs') as typeof import('fs');
@@ -101,7 +119,13 @@ export async function runScan(projectDir: string, options?: { includeTests?: boo
     return 1;
   }
 
-  const findings = scan(projectDir, { includeTests: options?.includeTests });
+  const findings = scan(projectDir, {
+    includeTests: options?.includeTests,
+    // `noIgnore` disables BOTH the user `.secretlessignore` and the
+    // default-ignore list. Used when a user wants to see every finding,
+    // including known-fixture noise.
+    ignore: options?.noIgnore ? false : undefined,
+  });
 
   if (findings.length === 0) {
     console.log('  No hardcoded credentials found.');
@@ -192,60 +216,113 @@ export function runStatus(projectDir: string): number {
   console.log('\n  Secretless Status\n');
 
   const s = status(projectDir);
-
-  console.log(`  Protected:  ${s.isProtected ? 'Yes' : 'No'}`);
-  console.log(`  Tools:      ${s.configuredTools.map(toolDisplayName).join(', ') || 'None'}`);
-  console.log(`  Hook:       ${s.hookInstalled ? 'Installed' : 'Not installed'}`);
-  console.log(`  Deny rules: ${s.denyRuleCount}`);
-  console.log(`  Secrets:    ${s.secretsFound} found in config files`);
-
-  // Session status
   const session = getSessionStatus();
-  console.log();
-  console.log('  Session:');
-  if (session.warm) {
-    console.log(`    Status:    warm`);
-    console.log(`    Expires:   ${formatRemainingTime(session.remainingSeconds)} (${session.expiresAt})`);
-  } else if (session.authenticatedAt) {
-    console.log(`    Status:    expired`);
-    console.log(`    Last auth: ${session.authenticatedAt}`);
-    console.log('    Warm it:   npx secretless-ai warm');
-  } else {
-    console.log(`    Status:    not initialized`);
-    console.log('    Set up:    npx secretless-ai warm');
-  }
-
-  // Broker status
   const brokerStatus = getDaemonStatus();
-  console.log();
-  console.log('  Broker:');
-  if (brokerStatus) {
-    console.log(`    Status:    running (PID ${brokerStatus.pid})`);
-    console.log(`    Uptime:    ${formatUptime(brokerStatus.uptimeSeconds)}`);
-    console.log(`    Socket:    ${brokerStatus.socketPath}`);
-    console.log(`    Policies:  ${brokerStatus.policyCount}`);
+  const brokerInstalled = isDaemonInstalled();
+  const tp = s.transcriptProtection;
+  const configuredBackend = readBackendConfig();
+
+  // Build observation rows. Each row: glyph + message + optional → command.
+  // Satisfied observations use ✓; needs-action use ⚠. Every ⚠ ends in a
+  // runnable verb so the user has no dead end (CISO Rule 11).
+  type Row = { glyph: '✓' | '⚠'; message: string; action?: string };
+  const rows: Row[] = [];
+
+  // Protection / hook.
+  if (s.hookInstalled) {
+    const denyText = s.denyRuleCount > 0 ? ` — ${s.denyRuleCount} deny pattern${s.denyRuleCount === 1 ? '' : 's'}` : '';
+    rows.push({ glyph: '✓', message: `Claude Code hook installed (.claude/settings.json${denyText})` });
   } else {
-    console.log(`    Status:    not running`);
-    const installed = isDaemonInstalled();
-    if (!installed) {
-      console.log('    Install:   npx secretless-ai install');
+    rows.push({ glyph: '⚠', message: 'Claude Code hook not installed', action: 'secretless-ai init' });
+  }
+
+  // Stop hook (transcript redaction).
+  if (tp.stopHookInstalled) {
+    rows.push({ glyph: '✓', message: 'Stop hook installed (transcript redaction)' });
+  } else {
+    rows.push({ glyph: '⚠', message: 'Stop hook not installed (transcripts unredacted)', action: 'secretless-ai init' });
+  }
+
+  // Configured tools (instructions present in tool config files).
+  if (s.configuredTools.length > 0) {
+    rows.push({ glyph: '✓', message: `Tool instructions: ${s.configuredTools.map(toolDisplayName).join(', ')}` });
+  }
+
+  // Secrets in config files.
+  if (s.secretsFound > 0) {
+    rows.push({ glyph: '⚠', message: `${s.secretsFound} credential${s.secretsFound === 1 ? '' : 's'} detected in config files`, action: 'secretless-ai scan' });
+  } else {
+    rows.push({ glyph: '✓', message: 'No credentials in config files' });
+  }
+
+  // Session warmth (only relevant when a backend that prompts is configured).
+  const sessionRelevant = configuredBackend === '1password' || configuredBackend === 'keychain';
+  if (sessionRelevant) {
+    if (session.warm) {
+      rows.push({ glyph: '✓', message: `Biometric session warm (expires ${formatRemainingTime(session.remainingSeconds)})` });
+    } else if (session.authenticatedAt) {
+      rows.push({ glyph: '⚠', message: `Biometric session expired (last auth ${session.authenticatedAt})`, action: 'secretless-ai warm' });
     } else {
-      console.log('    Start:     npx secretless-ai broker start');
+      rows.push({ glyph: '⚠', message: 'Biometric session not initialized', action: 'secretless-ai warm' });
     }
   }
 
-  // Transcript protection status
-  if (s.transcriptProtection) {
-    console.log();
-    console.log('  Transcript Protection:');
-    console.log(`    Stop hook: ${s.transcriptProtection.stopHookInstalled ? 'Installed' : 'Not installed'}`);
-    console.log(`    Watcher:   ${s.transcriptProtection.watcherRunning ? 'Running' : 'Not running'}`);
-    console.log(`    Files:     ${s.transcriptProtection.transcriptFiles} transcript files`);
-    if (s.transcriptProtection.transcriptSecretsFound > 0) {
-      console.log(`    Secrets:   ${s.transcriptProtection.transcriptSecretsFound} found in recent transcripts`);
+  // Watcher running (transcript file monitoring).
+  if (tp.watcherRunning) {
+    rows.push({ glyph: '✓', message: 'Transcript watcher running' });
+  } else {
+    rows.push({ glyph: '⚠', message: 'Transcript watcher not running', action: 'secretless-ai watch' });
+  }
+
+  // Transcript files + secrets within them.
+  if (tp.transcriptSecretsFound > 0) {
+    rows.push({ glyph: '⚠', message: `${tp.transcriptSecretsFound} credential${tp.transcriptSecretsFound === 1 ? '' : 's'} in recent transcripts`, action: 'secretless-ai clean' });
+  } else if (tp.transcriptFiles > 0) {
+    rows.push({ glyph: '✓', message: `Transcripts clean (${tp.transcriptFiles} file${tp.transcriptFiles === 1 ? '' : 's'} scanned)` });
+  }
+
+  // Broker daemon.
+  if (brokerStatus) {
+    rows.push({ glyph: '✓', message: `Broker running (PID ${brokerStatus.pid}, ${formatUptime(brokerStatus.uptimeSeconds)})` });
+  } else if (brokerInstalled) {
+    rows.push({ glyph: '⚠', message: 'Broker daemon not running', action: 'secretless-ai broker start' });
+  } else {
+    rows.push({ glyph: '⚠', message: 'Broker daemon not installed', action: 'secretless-ai install' });
+  }
+
+  // Render the Observations block. We measure the visible width (glyph +
+  // message) so the `→ command` column lines up tidily across rows.
+  const headerLine = '──────────────────────────────────────────────────────────';
+  console.log(`  ── Observations ${headerLine.slice(0, Math.max(0, 44))}`);
+  let leftWidth = 0;
+  for (const row of rows) {
+    const visible = row.glyph + ' ' + row.message;
+    if (visible.length > leftWidth) leftWidth = visible.length;
+  }
+  for (const row of rows) {
+    const left = `${row.glyph} ${row.message}`;
+    if (row.action) {
+      const padded = left.padEnd(leftWidth, ' ');
+      console.log(`  ${padded}  → ${row.action}`);
     } else {
-      console.log(`    Secrets:   Clean`);
+      console.log(`  ${left}`);
     }
+  }
+
+  // Verdict — reflects warnings (count of ⚠ rows). "Protected" requires
+  // the hook installed; "Clean" requires zero warnings.
+  console.log();
+  console.log(`  ── Verdict ${headerLine.slice(0, Math.max(0, 49))}`);
+  const warningCount = rows.filter(r => r.glyph === '⚠').length;
+  if (!s.isProtected) {
+    console.log('  Not protected. Run `secretless-ai init` to install hooks.');
+  } else if (warningCount === 0) {
+    console.log('  Protected — Clean');
+  } else {
+    const credSuffix = s.secretsFound > 0
+      ? ` (${s.secretsFound} unblocked credential${s.secretsFound === 1 ? '' : 's'} need review)`
+      : ` (${warningCount} observation${warningCount === 1 ? '' : 's'} need attention)`;
+    console.log(`  Protected${credSuffix}`);
   }
 
   console.log();

--- a/src/commands/feedback.ts
+++ b/src/commands/feedback.ts
@@ -1,0 +1,27 @@
+/**
+ * `secretless-ai feedback` — opt-in star/feedback subcommand.
+ *
+ * Background: prior to 0.16.4, every `init` invocation printed the
+ * "Helpful? Star the project" line. That conflated the operational
+ * outcome with marketing fluff and violated the "no dead ends" rule
+ * (the only place a user could act on the line was their browser).
+ *
+ * The redesign moved the marketing ask out of the per-action output
+ * and into a one-command opt-in. Users who want to leave feedback
+ * run `secretless-ai feedback`; everyone else gets clean output.
+ */
+
+import { c } from './colors';
+
+export function runFeedback(): number {
+  console.log();
+  console.log(`  ${c.boldWhite('Secretless feedback')}`);
+  console.log();
+  console.log('  Helpful? Star the project:  https://github.com/opena2a-org/secretless-ai');
+  console.log('  Feedback / issues:          https://github.com/opena2a-org/secretless-ai/issues/new');
+  console.log('  Discussions:                https://github.com/opena2a-org/secretless-ai/discussions');
+  console.log();
+  console.log('  Thanks — every issue and discussion sharpens the tool.');
+  console.log();
+  return 0;
+}

--- a/src/commands/git.ts
+++ b/src/commands/git.ts
@@ -48,8 +48,9 @@ export function runHook(args: string[]): number {
   }
 }
 
-export function runScanStaged(): number {
-  const { findings, blockedFiles } = scanStagedFiles();
+export function runScanStaged(args: string[] = []): number {
+  const noIgnore = args.includes('--no-ignore');
+  const { findings, blockedFiles } = scanStagedFiles({ noIgnore });
   const total = findings.length + blockedFiles.length;
 
   if (total === 0) {

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -118,6 +118,12 @@ export function printHelp(): void {
   Scan options:
     --include-tests  Include test files in source code scan
     --explain        Use NanoMind for rich context explanations (requires @nanomind/engine)
+    --no-ignore      Disable .secretlessignore + default-ignore (scan everything)
+
+  Other:
+    npx secretless-ai feedback   Star, file an issue, or join the discussion
+    .secretlessignore            gitignore-style file at repo root; default-ignore
+                                 covers test/, __tests__/, examples/, e2e/, etc.
 
   Options:
     -v, --version    Show version

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export { status, type StatusResult } from './status';
 export { verify, type VerifyResult } from './verify';
 export { detectAITools, toolDisplayName, type AITool } from './detect';
 export { CREDENTIAL_PATTERNS, SECRET_FILE_PATTERNS, CONFIG_FILES, CREDENTIAL_PREFIX_QUICK_CHECK, type CredentialPattern } from './patterns';
+export { loadSecretlessIgnore, buildMatcher, DEFAULT_IGNORE_PATTERNS, type IgnoreMatcher, type LoadOptions as IgnoreLoadOptions } from './secretlessignore';
 export { cleanTranscripts, discoverTranscripts, type CleanResult, type CleanOptions, type TranscriptFinding } from './transcript';
 export { startWatch, stopWatch, isWatchRunning } from './watch';
 export { doctor, quickDiagnosis, fixProfiles, type DoctorOptions, type DoctorResult, type DoctorFinding, type QuickDiagnosisResult, type ProfileInfo, type FixResult, type Severity, type HealthStatus } from './doctor';

--- a/src/init.ts
+++ b/src/init.ts
@@ -9,6 +9,7 @@ import { detectAITools, toolDisplayName, type AITool } from './detect';
 import { SECRET_FILE_PATTERNS, CREDENTIAL_PATTERNS, CONFIG_FILES } from './patterns';
 import { loadCustomRules, customRulesToDenyRules, customRulesToHookBlocks, customRulesToFilePatterns, mergeRules } from './custom-rules';
 import type { CustomRules } from './custom-rules';
+import { loadSecretlessIgnore } from './secretlessignore';
 
 /** Known API services with their auth header formats */
 const SERVICE_HINTS: Record<string, { service: string; authHeader: string }> = {
@@ -57,6 +58,17 @@ interface InitResult {
   filesCreated: string[];
   filesModified: string[];
   secretsFound: number;
+  /**
+   * Total deny rules now in `.claude/settings.json` after merge. Useful for
+   * rendering "21 deny patterns" in the configured-tools line.
+   */
+  denyRulesTotal: number;
+  /**
+   * Deny rules added during this `init` invocation. Zero when re-running
+   * over an already-configured project. Used by `runInit` to tell the user
+   * "Added 21 deny patterns" vs "Already up to date".
+   */
+  denyRulesAdded: number;
 }
 
 /**
@@ -70,6 +82,8 @@ export function init(projectDir: string): InitResult {
     filesCreated: [],
     filesModified: [],
     secretsFound: 0,
+    denyRulesTotal: 0,
+    denyRulesAdded: 0,
   };
 
   // Detect AI tools
@@ -272,11 +286,15 @@ function configureClaudeCode(projectDir: string, result: InitResult): void {
     ? mergeRules(denyRules, customRulesToDenyRules(projectCustomRules))
     : denyRules;
 
+  let added = 0;
   for (const rule of allDenyRules) {
     if (!settings.permissions.deny.includes(rule)) {
       settings.permissions.deny.push(rule);
+      added++;
     }
   }
+  result.denyRulesAdded += added;
+  result.denyRulesTotal = settings.permissions.deny.length;
 
   writeJsonFile(settingsPath, settings);
 
@@ -548,7 +566,16 @@ exit 0
 
 function quickScan(projectDir: string): number {
   let count = 0;
+  // Honor `.secretlessignore` + defaults so the count rendered after
+  // `init` matches what `secretless-ai scan` would report.
+  let ignore: ReturnType<typeof loadSecretlessIgnore> | null = null;
+  try {
+    ignore = loadSecretlessIgnore(projectDir);
+  } catch {
+    // Best-effort — fall through.
+  }
   for (const configFile of CONFIG_FILES) {
+    if (ignore && ignore.matches(configFile)) continue;
     const fullPath = path.join(projectDir, configFile);
     if (!fs.existsSync(fullPath)) continue;
 

--- a/src/lockstep.test.ts
+++ b/src/lockstep.test.ts
@@ -120,6 +120,22 @@ describe('lockstep: isKnownExample / findRealMatch parity on oracle inputs', () 
     'const real = "ghp_abcdefghijklmnopqrstuvwxyz1234567890"', // real-looking GitHub PAT
     'old="AKIAIOSFODNN7EXAMPLE"; new_="ghp_abcdefghijklmnopqrstuvwxyz1234567890"', // issue #51 shadowing
     'plain text with no credential',                    // no match at all
+    // 0.1.1 — block-comment marker branches
+    ' * example: AKIAEXAMPLEKEY1234567 in JSDoc',       // JSDoc continuation
+    '/* example AKIAEXAMPLEKEY1234567 */',              // /* block-open
+    '<!-- example AKIAEXAMPLEKEY1234567 -->',           // HTML comment
+    '"""example AKIAEXAMPLEKEY1234567"""',              // Python docstring
+    "'''example AKIAEXAMPLEKEY1234567'''",              // Python single-quote docstring
+    'const computed = AKIAREALKEY1234567890 * factor;', // multiplication is NOT a comment
+    // 0.1.1 — localhost+demo-password DB allowlist
+    'DATABASE_URL=postgres://admin:password123@localhost:5432/mydb',     // localhost+demo
+    'DATABASE_URL=postgres://admin:Password123@localhost:5432/mydb',     // capitalized demo password (Phase 4.5)
+    'DATABASE_URL=postgres://admin:password@[::1]:5432/db',              // IPv6 loopback (Phase 4.5)
+    'DATABASE_URL=postgres://app:H4Wj8z9KqMpL2nXr7sBv5tNc@localhost:5432/dev', // localhost + REAL password — must NOT allowlist
+    'DATABASE_URL=postgres://admin:password@localhost.evil.com:5432/db', // localhost-prefix bypass attempt
+    // 0.1.1 — bare 'fake' substring on bodies that allow it
+    'GITLAB_TOKEN=glpat-fake_1234567890abcdefghij',     // legacy fake_ form, body permits underscore
+    'GITLAB_TOKEN=glpat-fake-1234567890abcdefghij',     // legacy fake- form, body permits hyphen
   ];
 
   it('isKnownExample returns identical results across local vs package on every oracle line × every regex match', async () => {

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -124,7 +124,7 @@ export const KNOWN_EXAMPLE_KEYS = new Set([
  */
 export const PLACEHOLDER_INDICATORS = [
   'example', 'placeholder', 'your_', 'your-', 'insert_', 'insert-',
-  'xxx', 'XXXX', 'test_key', 'test_secret', 'fake_', 'fake-',
+  'xxx', 'XXXX', 'test_key', 'test_secret', 'fake',
   'dummy', 'sample', 'replace_me', 'change_me', 'todo', '<your',
   'not-a-real', 'not_a_real', 'just-for-testing', 'supabase-demo',
 ];

--- a/src/scan-staged.test.ts
+++ b/src/scan-staged.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { scanStagedFiles } from './scan-staged';
+import { buildMatcher } from './secretlessignore';
 
 // Mock child_process to avoid requiring a real git repo
 vi.mock('child_process', () => ({
@@ -129,6 +130,33 @@ describe('scanStagedFiles', () => {
     const result = scanStagedFiles();
     const names = result.findings.map(f => f.patternName);
     expect(names).toContain('GitHub Token');
+  });
+
+  it('respects an injected ignore matcher (default-ignore for fixture dirs)', () => {
+    mockExecFileSync.mockImplementation((cmd: string, args?: readonly string[]) => {
+      if (args && args.includes('--name-only')) {
+        return 'docs/vhs/setup-lab.sh\nsrc/cli.ts\n';
+      }
+      // Both files: a real-shape GitHub PAT.
+      return 'const t = "ghp_abcdefghijklmnopqrstuvwxyz1234567890";\n';
+    });
+    // Inject a matcher that ignores docs/vhs only — same as the default list.
+    const ignore = buildMatcher(['docs/vhs/']);
+    const result = scanStagedFiles({ ignore });
+    // src/cli.ts still flagged; docs/vhs/setup-lab.sh suppressed.
+    expect(result.findings.map(f => f.file)).toEqual(['src/cli.ts']);
+  });
+
+  it('--no-ignore (noIgnore: true) bypasses both defaults and user file', () => {
+    mockExecFileSync.mockImplementation((cmd: string, args?: readonly string[]) => {
+      if (args && args.includes('--name-only')) {
+        return 'docs/vhs/setup-lab.sh\n';
+      }
+      return 'const t = "ghp_abcdefghijklmnopqrstuvwxyz1234567890";\n';
+    });
+    const result = scanStagedFiles({ noIgnore: true });
+    // No filtering — the docs/vhs file is still scanned.
+    expect(result.findings.map(f => f.file)).toEqual(['docs/vhs/setup-lab.sh']);
   });
 
   it('issue #51: does NOT let a known-example AWS key shadow a real AWS key later on the same line', () => {

--- a/src/scan-staged.ts
+++ b/src/scan-staged.ts
@@ -8,6 +8,16 @@
 import { execFileSync } from 'child_process';
 import { CREDENTIAL_PATTERNS, SECRET_FILE_PATTERNS, CREDENTIAL_PREFIX_QUICK_CHECK } from './patterns';
 import { findRealMatch } from './scan';
+import { loadSecretlessIgnore, type IgnoreMatcher } from './secretlessignore';
+
+export interface ScanStagedOptions {
+  /** Repo root used to load `.secretlessignore`. Defaults to `git rev-parse --show-toplevel`. */
+  rootDir?: string;
+  /** Skip the default-ignore list + user `.secretlessignore`. Default: false. */
+  noIgnore?: boolean;
+  /** Inject a pre-built matcher (tests, callers wiring in from `runScanStaged`). */
+  ignore?: IgnoreMatcher;
+}
 
 interface StagedFinding {
   file: string;
@@ -18,7 +28,7 @@ interface StagedFinding {
 /**
  * Scan staged files for secrets. Returns findings and exit code.
  */
-export function scanStagedFiles(): { findings: StagedFinding[]; blockedFiles: string[] } {
+export function scanStagedFiles(options?: ScanStagedOptions): { findings: StagedFinding[]; blockedFiles: string[] } {
   const findings: StagedFinding[] = [];
   const blockedFiles: string[] = [];
 
@@ -37,6 +47,39 @@ export function scanStagedFiles(): { findings: StagedFinding[]; blockedFiles: st
 
   if (stagedFiles.length === 0) {
     return { findings, blockedFiles };
+  }
+
+  // Resolve ignore matcher. Priority:
+  //   1. options.ignore (caller-provided),
+  //   2. options.noIgnore=true → null (defaults disabled, user file disabled),
+  //   3. otherwise: loadSecretlessIgnore from rootDir or git toplevel.
+  let ignore: IgnoreMatcher | null = null;
+  if (options?.ignore) {
+    ignore = options.ignore;
+  } else if (!options?.noIgnore) {
+    let rootDir = options?.rootDir;
+    if (!rootDir) {
+      try {
+        rootDir = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+          encoding: 'utf-8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+        }).trim();
+      } catch {
+        // Fall through — no ignore filter applied.
+      }
+    }
+    if (rootDir) {
+      try {
+        ignore = loadSecretlessIgnore(rootDir);
+      } catch {
+        ignore = null;
+      }
+    }
+  }
+
+  // Filter out ignored staged files BEFORE filename + content scan.
+  if (ignore) {
+    stagedFiles = stagedFiles.filter(f => !ignore!.matches(f.replace(/\\/g, '/')));
   }
 
   // Check filenames against secret file patterns

--- a/src/scan.test.ts
+++ b/src/scan.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { isKnownExample, findRealMatch } from './scan';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { isKnownExample, findRealMatch, scan } from './scan';
 import { CREDENTIAL_PATTERNS } from './patterns';
+import { buildMatcher } from './secretlessignore';
 
 function patternByName(name: string) {
   const p = CREDENTIAL_PATTERNS.find(p => p.name === name);
@@ -66,5 +70,77 @@ describe('findRealMatch (issue #51 — known-example shadowing)', () => {
     const line = '// examples: AKIAIOSFODNN7EXAMPLE';
     const awsPattern = patternByName('AWS Access Key');
     expect(findRealMatch(line, awsPattern)).toBeNull();
+  });
+});
+
+describe('scan() — .secretlessignore integration', () => {
+  function tmpProjectWith(files: Record<string, string>): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-ignore-'));
+    for (const [rel, content] of Object.entries(files)) {
+      const full = path.join(dir, rel);
+      fs.mkdirSync(path.dirname(full), { recursive: true });
+      fs.writeFileSync(full, content);
+    }
+    return dir;
+  }
+
+  // Real-shape OpenAI project key constructed via [].join('') so GitHub
+  // Push Protection (and our own scanner if it ever scans this test file)
+  // doesn't flag the literal string at commit time.
+  const REAL_OPENAI_KEY = ['sk-proj-', 'A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q7R8S9T0U1V2'].join('');
+
+  it('default-ignore suppresses findings under fixture dirs (docs/vhs)', () => {
+    const dir = tmpProjectWith({
+      'docs/vhs/setup-lab.sh': `OPENAI_API_KEY=${REAL_OPENAI_KEY}\n`,
+    });
+    const findings = scan(dir, { scanGlobal: false });
+    expect(findings).toEqual([]);
+  });
+
+  it('default-ignore suppresses findings under test-server/', () => {
+    const dir = tmpProjectWith({
+      'test-server/agents.js': `const k = '${REAL_OPENAI_KEY}';\n`,
+    });
+    const findings = scan(dir, { scanGlobal: false });
+    expect(findings).toEqual([]);
+  });
+
+  it('--no-ignore (ignore: false) re-enables findings inside fixture dirs', () => {
+    const dir = tmpProjectWith({
+      'docs/vhs/setup-lab.sh': `const k = '${REAL_OPENAI_KEY}';\n`,
+    });
+    const findings = scan(dir, { scanGlobal: false, ignore: false });
+    expect(findings.length).toBeGreaterThan(0);
+    expect(findings[0].file).toBe('docs/vhs/setup-lab.sh');
+  });
+
+  it('user-provided matcher takes precedence over loading from disk', () => {
+    const dir = tmpProjectWith({
+      'src/cred.ts': `const k = '${REAL_OPENAI_KEY}';\n`,
+      // A user .secretlessignore that ignores src/ would suppress findings.
+      // We pass a custom matcher that does NOT ignore src/ — assert it wins.
+      '.secretlessignore': 'src/\n',
+    });
+    const m = buildMatcher([]); // empty matcher = nothing ignored
+    const findings = scan(dir, { scanGlobal: false, ignore: m });
+    expect(findings.length).toBeGreaterThan(0);
+  });
+
+  it('user-defined patterns add to defaults', () => {
+    const dir = tmpProjectWith({
+      'src/cred.ts': `const k = '${REAL_OPENAI_KEY}';\n`,
+      '.secretlessignore': 'src/\n',
+    });
+    const findings = scan(dir, { scanGlobal: false });
+    expect(findings).toEqual([]);
+  });
+
+  it('default-ignore does NOT suppress non-fixture dirs (src/, lib/, root)', () => {
+    const dir = tmpProjectWith({
+      'src/cred.ts': `const k = '${REAL_OPENAI_KEY}';\n`,
+    });
+    const findings = scan(dir, { scanGlobal: false });
+    expect(findings.length).toBeGreaterThan(0);
+    expect(findings[0].file).toBe('src/cred.ts');
   });
 });

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -49,6 +49,56 @@ export interface ScanOptions {
 }
 
 /**
+ * Demo-tier passwords that combine with localhost-bound DB connection strings
+ * to mark a value as a tutorial fixture, not a real credential. Local mirror
+ * of the catalog @opena2a/credential-patterns 0.1.1 set — lockstep test gates.
+ */
+const DEMO_PASSWORDS = new Set([
+  'password',
+  'password123',
+  'secret',
+  'admin',
+  'root',
+  'demo',
+  'test',
+  'changeme',
+]);
+
+function isLocalhostDemoConnectionString(value: string): boolean {
+  const protoEnd = value.indexOf('://');
+  if (protoEnd === -1) return false;
+  const atIdx = value.lastIndexOf('@');
+  if (atIdx === -1 || atIdx <= protoEnd + 3) return false;
+  const userInfo = value.slice(protoEnd + 3, atIdx);
+  const host = value.slice(atIdx + 1);
+  // Anchored host check defeats `localhost.evil.com` bypass. IPv4 loopback
+  // `127.0.0.1`, IPv6 loopback `[::1]`, and the `localhost` literal accepted.
+  if (!/^(\[::1\]|localhost|127\.0\.0\.1)(:|\/|$)/i.test(host)) return false;
+  const colonIdx = userInfo.indexOf(':');
+  if (colonIdx === -1) return false;
+  // Password lookup is case-insensitive — capitalized demo passwords are
+  // functionally the same fixture (`Password123` vs `password123`).
+  const password = userInfo.slice(colonIdx + 1).toLowerCase();
+  return DEMO_PASSWORDS.has(password);
+}
+
+function isExampleInComment(line: string): boolean {
+  const lineLC = line.toLowerCase();
+  if (!lineLC.includes('example')) return false;
+  if (lineLC.includes('//')) return true;
+  if (lineLC.includes('#')) return true;
+  if (lineLC.includes('/*')) return true;
+  if (lineLC.includes('<!--')) return true;
+  if (lineLC.includes('-->')) return true;
+  if (lineLC.includes("'''")) return true;
+  if (lineLC.includes('"""')) return true;
+  // JSDoc continuation: line starts with optional whitespace then `*`.
+  // Anchored so `x * y` (multiplication) does NOT match.
+  if (/^\s*\*/.test(line)) return true;
+  return false;
+}
+
+/**
  * Check if a matched credential is a known example or placeholder.
  * Returns true if the match should be excluded from results.
  *
@@ -58,16 +108,11 @@ export interface ScanOptions {
  */
 export function isKnownExample(line: string, match: RegExpMatchArray): boolean {
   const value = match[0];
-  // Check exact known example keys
   if (KNOWN_EXAMPLE_KEYS.has(value)) return true;
-  // Check placeholder indicators (case-insensitive)
   const lower = value.toLowerCase();
   if (PLACEHOLDER_INDICATORS.some(p => lower.includes(p))) return true;
-  // Check if the line contains a comment marking it as an example
-  const lineLC = line.toLowerCase();
-  if (lineLC.includes('example') && (lineLC.includes('//') || lineLC.includes('#'))) {
-    if (lineLC.includes('example') || lineLC.includes('placeholder') || lineLC.includes('fake')) return true;
-  }
+  if (isLocalhostDemoConnectionString(value)) return true;
+  if (isExampleInComment(line)) return true;
   return false;
 }
 

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -6,6 +6,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { CREDENTIAL_PATTERNS, CONFIG_FILES, CREDENTIAL_PREFIX_QUICK_CHECK, SOURCE_FILE_EXTENSIONS, SOURCE_SKIP_DIRS, KNOWN_EXAMPLE_KEYS, PLACEHOLDER_INDICATORS, type CredentialPattern } from './patterns';
+import { loadSecretlessIgnore, type IgnoreMatcher } from './secretlessignore';
 
 export interface ScanFinding {
   file: string;
@@ -46,6 +47,15 @@ export interface ScanOptions {
   includeTests?: boolean;
   /** Max source files to scan before stopping (default: 5000) */
   maxSourceFiles?: number;
+  /**
+   * Skip files matched by `.secretlessignore` and the default-ignore list.
+   * Default: true. Pass `false` to scan everything (includes fixture dirs).
+   *
+   * If `ignore` is provided as an `IgnoreMatcher`, that matcher is used
+   * verbatim (callers wiring through `scan-staged` etc). If `true` (default)
+   * and `projectDir` exists, `loadSecretlessIgnore(projectDir)` is called.
+   */
+  ignore?: boolean | IgnoreMatcher;
 }
 
 /**
@@ -156,6 +166,18 @@ export function scan(projectDir: string, options?: ScanOptions): ScanFinding[] {
   const findings: ScanFinding[] = [];
   const scanGlobal = options?.scanGlobal !== false;
 
+  // Resolve the ignore matcher. Default: load `<projectDir>/.secretlessignore`
+  // plus the default-ignore list. `ignore: false` disables both.
+  const ignore: IgnoreMatcher | null = (() => {
+    if (options?.ignore === false) return null;
+    if (options?.ignore && typeof options.ignore === 'object') return options.ignore;
+    try {
+      return loadSecretlessIgnore(projectDir);
+    } catch {
+      return null;
+    }
+  })();
+
   // Scan global config files (keys in ~/.claude/CLAUDE.md are in every session's context)
   for (const global of (scanGlobal ? GLOBAL_CONFIG_FILES : [])) {
     const fullPath = path.join(global.dir, global.file);
@@ -192,6 +214,7 @@ export function scan(projectDir: string, options?: ScanOptions): ScanFinding[] {
 
   // Scan project-level config files
   for (const configFile of CONFIG_FILES) {
+    if (ignore && ignore.matches(configFile)) continue;
     const fullPath = path.join(projectDir, configFile);
     if (!fs.existsSync(fullPath)) continue;
 
@@ -242,12 +265,15 @@ export function scan(projectDir: string, options?: ScanOptions): ScanFinding[] {
     const configFileSet = new Set(CONFIG_FILES);
     const maxFiles = options?.maxSourceFiles ?? 5000;
     const includeTests = options?.includeTests ?? false;
-    const sourceFiles = walkSourceFiles(projectDir, maxFiles, includeTests);
+    const sourceFiles = walkSourceFiles(projectDir, maxFiles, includeTests, ignore);
 
     for (const filePath of sourceFiles) {
       const relPath = path.relative(projectDir, filePath);
       // Skip files already covered by config scan
       if (configFileSet.has(relPath)) continue;
+      // Apply user/default ignore filter at file level too — defends
+      // against entries inside an otherwise-walked directory.
+      if (ignore && ignore.matches(relPath.replace(/\\/g, '/'))) continue;
 
       try {
         const stat = fs.statSync(filePath);
@@ -317,8 +343,17 @@ function isTestFile(name: string): boolean {
  * Walk a directory tree and return source files matching SOURCE_FILE_EXTENSIONS.
  * Skips directories in SOURCE_SKIP_DIRS. Stops after maxFiles.
  * By default, skips test files and test directories.
+ *
+ * Also honors an `IgnoreMatcher` (from `.secretlessignore` + defaults). The
+ * matcher is consulted at the directory level (cheaper, prunes whole subtrees)
+ * and again at the file level (in case the user uses a file-name glob).
  */
-function walkSourceFiles(dir: string, maxFiles: number, includeTests: boolean): string[] {
+function walkSourceFiles(
+  dir: string,
+  maxFiles: number,
+  includeTests: boolean,
+  ignore: IgnoreMatcher | null,
+): string[] {
   const results: string[] = [];
   const queue: string[] = [dir];
 
@@ -334,15 +369,23 @@ function walkSourceFiles(dir: string, maxFiles: number, includeTests: boolean): 
     for (const entry of entries) {
       if (results.length >= maxFiles) break;
 
+      const entryPath = path.join(current, entry.name);
+      const relFromRoot = path.relative(dir, entryPath).replace(/\\/g, '/');
+
       if (entry.isDirectory()) {
         if (SOURCE_SKIP_DIRS.has(entry.name) || entry.name.startsWith('.')) continue;
         if (!includeTests && TEST_DIRS.has(entry.name)) continue;
-        queue.push(path.join(current, entry.name));
+        // Prune whole-tree ignored directories. The matcher's directory
+        // patterns end with `/`, so we test the dir path with a trailing
+        // segment; equivalently, append `/dummy`.
+        if (ignore && ignore.matches(relFromRoot + '/.')) continue;
+        queue.push(entryPath);
       } else if (entry.isFile()) {
         const ext = path.extname(entry.name);
         if (!SOURCE_FILE_EXTENSIONS.has(ext)) continue;
         if (!includeTests && isTestFile(entry.name)) continue;
-        results.push(path.join(current, entry.name));
+        if (ignore && ignore.matches(relFromRoot)) continue;
+        results.push(entryPath);
       }
     }
   }

--- a/src/secretlessignore.test.ts
+++ b/src/secretlessignore.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  buildMatcher,
+  loadSecretlessIgnore,
+  DEFAULT_IGNORE_PATTERNS,
+} from './secretlessignore';
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'secretlessignore-'));
+}
+
+describe('secretlessignore — defaults', () => {
+  it('applies the default-ignore list to a fresh project', () => {
+    const m = loadSecretlessIgnore(tmpDir());
+    // Every default-ignore directory must match a file underneath it.
+    expect(m.matches('test/fixtures/api.ts')).toBe(true);
+    expect(m.matches('tests/foo.spec.ts')).toBe(true);
+    expect(m.matches('__tests__/x.ts')).toBe(true);
+    expect(m.matches('__fixtures__/y.ts')).toBe(true);
+    expect(m.matches('test-server/agents.js')).toBe(true);
+    expect(m.matches('docs/vhs/setup-lab.sh')).toBe(true);
+    expect(m.matches('examples/index.ts')).toBe(true);
+    expect(m.matches('e2e/login.spec.ts')).toBe(true);
+    expect(m.matches('.golden/expected.json')).toBe(true);
+    expect(m.matches('node_modules/foo/index.js')).toBe(true);
+    expect(m.matches('dist/cli.js')).toBe(true);
+    expect(m.matches('build/output.js')).toBe(true);
+  });
+
+  it('does not ignore source files outside the default list', () => {
+    const m = loadSecretlessIgnore(tmpDir());
+    expect(m.matches('src/scan.ts')).toBe(false);
+    expect(m.matches('lib/client.ts')).toBe(false);
+    expect(m.matches('CHANGELOG.md')).toBe(false);
+  });
+
+  it('skipDefaults disables the default-ignore list', () => {
+    const m = loadSecretlessIgnore(tmpDir(), { skipDefaults: true });
+    expect(m.matches('test/foo.ts')).toBe(false);
+    expect(m.matches('docs/vhs/setup-lab.sh')).toBe(false);
+    expect(m.patternCount).toBe(0);
+  });
+
+  it('exports the documented default-ignore list', () => {
+    expect(DEFAULT_IGNORE_PATTERNS).toContain('test/');
+    expect(DEFAULT_IGNORE_PATTERNS).toContain('docs/vhs/');
+    expect(DEFAULT_IGNORE_PATTERNS.length).toBeGreaterThanOrEqual(10);
+  });
+});
+
+describe('secretlessignore — user file', () => {
+  it('user patterns add to defaults', () => {
+    const dir = tmpDir();
+    fs.writeFileSync(path.join(dir, '.secretlessignore'), 'private-fixtures/\n');
+    const m = loadSecretlessIgnore(dir);
+    expect(m.matches('private-fixtures/secret.txt')).toBe(true);
+    // Defaults still apply.
+    expect(m.matches('test/foo.ts')).toBe(true);
+  });
+
+  it('user comments and blank lines are skipped', () => {
+    const dir = tmpDir();
+    fs.writeFileSync(
+      path.join(dir, '.secretlessignore'),
+      [
+        '# A comment',
+        '',
+        '# Another comment',
+        'private/',
+      ].join('\n'),
+    );
+    const m = loadSecretlessIgnore(dir);
+    expect(m.matches('private/x.ts')).toBe(true);
+    expect(m.matches('src/x.ts')).toBe(false);
+  });
+
+  it('negation re-enables default-ignored paths', () => {
+    const dir = tmpDir();
+    fs.writeFileSync(path.join(dir, '.secretlessignore'), '!docs/vhs/\n');
+    const m = loadSecretlessIgnore(dir);
+    expect(m.matches('docs/vhs/setup-lab.sh')).toBe(false);
+  });
+
+  it('falls back silently when the ignore file is unreadable', () => {
+    const dir = tmpDir();
+    // Write a binary blob exceeding 1MB cap.
+    const big = Buffer.alloc(2 * 1024 * 1024, 0);
+    fs.writeFileSync(path.join(dir, '.secretlessignore'), big);
+    const m = loadSecretlessIgnore(dir);
+    // Defaults still apply (the file is ignored — too large).
+    expect(m.matches('test/x.ts')).toBe(true);
+  });
+});
+
+describe('secretlessignore — glob semantics', () => {
+  it('* matches within a path segment', () => {
+    const m = buildMatcher(['*.tmp']);
+    expect(m.matches('foo.tmp')).toBe(true);
+    expect(m.matches('a/b/foo.tmp')).toBe(true);
+    expect(m.matches('foo.txt')).toBe(false);
+  });
+
+  it('** matches across path segments', () => {
+    const m = buildMatcher(['fixtures/**/secret.json']);
+    expect(m.matches('fixtures/secret.json')).toBe(true);
+    expect(m.matches('fixtures/a/secret.json')).toBe(true);
+    expect(m.matches('fixtures/a/b/c/secret.json')).toBe(true);
+    expect(m.matches('other/secret.json')).toBe(false);
+  });
+
+  it('? matches one character', () => {
+    const m = buildMatcher(['file?.txt']);
+    expect(m.matches('file1.txt')).toBe(true);
+    expect(m.matches('file12.txt')).toBe(false);
+  });
+
+  it('leading slash anchors to root', () => {
+    const m = buildMatcher(['/build/']);
+    expect(m.matches('build/x.js')).toBe(true);
+    expect(m.matches('a/build/x.js')).toBe(false);
+  });
+
+  it('a pattern with internal slash anchors to root by default', () => {
+    const m = buildMatcher(['docs/vhs/']);
+    expect(m.matches('docs/vhs/x.sh')).toBe(true);
+    // gitignore semantics: `docs/vhs/` does NOT match nested `lib/docs/vhs/x`.
+    expect(m.matches('lib/docs/vhs/x.sh')).toBe(false);
+  });
+
+  it('a pattern without a slash matches at any depth', () => {
+    const m = buildMatcher(['__tests__/']);
+    expect(m.matches('__tests__/x.ts')).toBe(true);
+    expect(m.matches('packages/foo/__tests__/x.ts')).toBe(true);
+  });
+
+  it('Windows backslashes normalize to forward slashes', () => {
+    const m = buildMatcher(['test/']);
+    expect(m.matches('test\\foo.ts')).toBe(true);
+  });
+
+  it('rejects path traversal in input', () => {
+    const m = buildMatcher(['test/']);
+    expect(m.matches('../test/secret.txt')).toBe(false);
+  });
+
+  it('rejects path traversal in pattern', () => {
+    const m = buildMatcher(['../foo/']);
+    // Pattern was discarded; nothing matches.
+    expect(m.matches('foo/x.ts')).toBe(false);
+    expect(m.patternCount).toBe(0);
+  });
+
+  it('handles trailing-slash-only directories correctly', () => {
+    const m = buildMatcher(['secrets/']);
+    // The directory itself is ignored (anything below).
+    expect(m.matches('secrets/api-key')).toBe(true);
+    // A file literally named `secrets` (no trailing slash) is NOT ignored.
+    expect(m.matches('secrets')).toBe(false);
+  });
+});

--- a/src/secretlessignore.ts
+++ b/src/secretlessignore.ts
@@ -1,0 +1,241 @@
+/**
+ * `.secretlessignore` parser — gitignore-style globs that skip paths from
+ * scanning. Designed to suppress real-world false positives where intentional
+ * fixture credentials live (test fixtures, demo scripts, e2e seeds).
+ *
+ * The user file is additive on top of a default-ignore list. Each default
+ * path is justified by a real-world FP class observed during dogfooding;
+ * see `handoff_secretless_ai_0_16_4_pickup.md` for the FP table.
+ *
+ * Negative patterns (`!pattern`) override defaults — a user can re-enable
+ * scanning for a default-ignored path by adding `!docs/vhs/` to their
+ * `.secretlessignore`.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Default-ignore list. Every entry maps to a real-world false-positive
+ * class. Do NOT add speculatively.
+ *
+ * - `__tests__/`, `__fixtures__/`, `test/`, `tests/`, `test-server/` —
+ *   fixture dirs (closes adversarial-fixture FPs from hackmyagent dogfooding)
+ * - `docs/vhs/` — VHS demo scripts (sk-proj-fake + postgres://demo creds)
+ * - `examples/` — by-convention example code
+ * - `e2e/` — end-to-end test dirs
+ * - `.golden/` — fixture golden files (HMA convention)
+ * - `node_modules/`, `dist/`, `build/` — generated artifacts (defensive
+ *   layer over scan.ts SOURCE_SKIP_DIRS)
+ */
+export const DEFAULT_IGNORE_PATTERNS: readonly string[] = Object.freeze([
+  '__tests__/',
+  '__fixtures__/',
+  'test/',
+  'tests/',
+  'test-server/',
+  'docs/vhs/',
+  'examples/',
+  'e2e/',
+  '.golden/',
+  'node_modules/',
+  'dist/',
+  'build/',
+]);
+
+/** Match function for a relative POSIX path. */
+export interface IgnoreMatcher {
+  /** Returns true if the relative path is ignored. */
+  matches(relativePath: string): boolean;
+  /** Number of patterns active (defaults + user, after negatives applied). */
+  patternCount: number;
+}
+
+interface CompiledPattern {
+  /** Original literal pattern (debug only). */
+  source: string;
+  /** Compiled regex. */
+  regex: RegExp;
+  /** True for `!pattern` negations — re-includes a previously ignored path. */
+  negate: boolean;
+  /** True if pattern ends with `/` — directory-only (matches anything under it). */
+  dirOnly: boolean;
+}
+
+/**
+ * Parse a single gitignore-style line into a CompiledPattern.
+ * Returns null for blank lines and comments.
+ *
+ * Supported syntax (subset of gitignore):
+ * - `#` comment lines
+ * - blank lines ignored
+ * - leading `!` negates
+ * - trailing `/` matches directory + everything below
+ * - `*` matches any character except `/`
+ * - `**` matches any number of directories (including zero)
+ * - `?` matches one character except `/`
+ * - leading `/` anchors to repo root
+ *
+ * Path traversal (`..`) and absolute system paths are not allowed —
+ * patterns are interpreted as repo-relative globs only.
+ */
+function compilePattern(rawLine: string): CompiledPattern | null {
+  let line = rawLine.trim();
+  if (!line) return null;
+  if (line.startsWith('#')) return null;
+
+  let negate = false;
+  if (line.startsWith('!')) {
+    negate = true;
+    line = line.slice(1);
+  }
+
+  // Reject path traversal — security guard. A pattern like `../foo` would
+  // otherwise resolve outside the repo root.
+  if (line.includes('..')) return null;
+
+  // A leading `/` anchors to repo root and is otherwise stripped. Track this
+  // separately from "the pattern contains a slash internally" so that
+  // `/build/` anchors to root while `build/` matches at any depth.
+  let anchoredToRoot = false;
+  if (line.startsWith('/')) {
+    anchoredToRoot = true;
+    while (line.startsWith('/')) line = line.slice(1);
+  }
+
+  const dirOnly = line.endsWith('/');
+  if (dirOnly) line = line.slice(0, -1);
+  if (!line) return null;
+
+  // Convert glob to regex. Escape regex metacharacters except `*`, `?`.
+  // Two passes: `**` first, then `*`, so we don't double-encode.
+  let regexSrc = '';
+  let i = 0;
+  while (i < line.length) {
+    const ch = line[i];
+    if (ch === '*' && line[i + 1] === '*') {
+      // `**` — match zero or more path segments. Consume optional trailing `/`.
+      regexSrc += '(?:.*)';
+      i += 2;
+      if (line[i] === '/') i++;
+    } else if (ch === '*') {
+      regexSrc += '[^/]*';
+      i++;
+    } else if (ch === '?') {
+      regexSrc += '[^/]';
+      i++;
+    } else if (/[.+^${}()|[\]\\]/.test(ch)) {
+      regexSrc += '\\' + ch;
+      i++;
+    } else {
+      regexSrc += ch;
+      i++;
+    }
+  }
+
+  // Anchoring: a pattern with an internal slash (or leading `/`) anchors to
+  // root; a slash-free pattern matches at any depth (gitignore behavior).
+  const hasInternalSlash = line.includes('/');
+  const anchorPrefix = (anchoredToRoot || hasInternalSlash) ? '^' : '^(?:.*?/)?';
+  // `dir/` matches the directory contents — we require a trailing `/something`.
+  // Bare `name` (no trailing slash) matches the file itself or anything below.
+  const anchorSuffix = dirOnly ? '/.*$' : '(?:/.*)?$';
+
+  return {
+    source: rawLine,
+    regex: new RegExp(anchorPrefix + regexSrc + anchorSuffix),
+    negate,
+    dirOnly,
+  };
+}
+
+function compileAll(lines: readonly string[]): CompiledPattern[] {
+  const out: CompiledPattern[] = [];
+  for (const line of lines) {
+    const cp = compilePattern(line);
+    if (cp) out.push(cp);
+  }
+  return out;
+}
+
+/**
+ * Normalize a relative path for matching:
+ * - Convert backslashes to forward slashes (Windows compatibility).
+ * - Remove leading `./`.
+ * - Reject any input that traverses out of root via `..`.
+ *
+ * Returns null if the path is not safe to match (caller should treat as
+ * "do not ignore" — we never block a scan due to a malformed path).
+ */
+function normalize(relativePath: string): string | null {
+  let p = relativePath.replace(/\\/g, '/');
+  while (p.startsWith('./')) p = p.slice(2);
+  if (p === '.' || p === '') return null;
+  // Reject traversal — caller is using us as a safety filter, not a sandbox,
+  // but we still don't want a `../foo` to match a default like `test/`.
+  if (p.split('/').includes('..')) return null;
+  return p;
+}
+
+export interface LoadOptions {
+  /** Skip the default-ignore list (only the user file applies). */
+  skipDefaults?: boolean;
+}
+
+/**
+ * Build a matcher from `<rootDir>/.secretlessignore` plus the defaults.
+ *
+ * If the file does not exist, the defaults still apply (unless skipDefaults
+ * is set). If the file is unreadable, we fall back to defaults silently —
+ * scanning should never fail because of a malformed ignore file.
+ */
+export function loadSecretlessIgnore(rootDir: string, options?: LoadOptions): IgnoreMatcher {
+  const lines: string[] = [];
+  if (!options?.skipDefaults) {
+    lines.push(...DEFAULT_IGNORE_PATTERNS);
+  }
+
+  const filePath = path.join(rootDir, '.secretlessignore');
+  if (fs.existsSync(filePath)) {
+    try {
+      const stat = fs.statSync(filePath);
+      // Defensive size cap — a 10MB ignore file is almost certainly broken.
+      if (stat.isFile() && stat.size <= 1024 * 1024) {
+        const content = fs.readFileSync(filePath, 'utf-8');
+        for (const line of content.split(/\r?\n/)) {
+          lines.push(line);
+        }
+      }
+    } catch {
+      // Fall through — defaults still apply.
+    }
+  }
+
+  return buildMatcher(lines);
+}
+
+/**
+ * Build a matcher from an explicit list of pattern strings. Useful for
+ * tests and for callers that want to compose patterns programmatically
+ * without touching disk.
+ */
+export function buildMatcher(patternLines: readonly string[]): IgnoreMatcher {
+  const compiled = compileAll(patternLines);
+
+  return {
+    patternCount: compiled.length,
+    matches(relativePath: string): boolean {
+      const norm = normalize(relativePath);
+      if (norm === null) return false;
+      // Last-write-wins semantics: walk through compiled patterns in order
+      // and let later negations override earlier ignores.
+      let ignored = false;
+      for (const cp of compiled) {
+        if (cp.regex.test(norm)) {
+          ignored = !cp.negate;
+        }
+      }
+      return ignored;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `.secretlessignore` (gitignore-style) with default-ignore list covering `test/`, `__tests__/`, `__fixtures__/`, `tests/`, `test-server/`, `docs/vhs/`, `examples/`, `e2e/`, `.golden/`, `node_modules/`, `dist/`, `build/`. Each default path maps to a real-world false positive observed during dogfooding. Negative patterns (`!docs/vhs/`) re-enable scanning. `--no-ignore` flag on `scan` and `scan-staged` disables both the user file and the defaults.
- Redesigns `init` output per CISO Rule 11: collapsed Detected + Configured into one line, drops the misleading `Done. Secrets are now blocked.` line, names the deny-rule delta on the Modified line, adds a Verify/Scan/Status next-step block.
- Redesigns `status` output per CISO Rule 11: 5 sub-blocks collapse into one Observations table; every warning ends in a runnable verb; Verdict line reflects the warning count.
- New `secretless-ai feedback` subcommand for the star/issue/discussion links (replaces the unconditional star prompt that previously trailed `init`).
- Re-pins `@opena2a/credential-patterns` to `0.1.1` (lockstep test stays green; catalog adds block-comment marker recognition, bare `'fake'` placeholder, localhost+demo allowlist).

Verified against `~/workspace/opena2a-org/hackmyagent`: 4 false positives at 0.16.3 drop to 1 at 0.16.4 (the remaining 1 is documented out-of-scope JSDoc-without-`example` case).

## Test plan

- [x] `npm test` (915 / 915 pass)
- [x] `npm run build`
- [x] HMA self-scan 95/100 (residual MEDIUM is on local-only `.claude/settings.json`, not committed)
- [x] /pre-push-review (8 phases all PASS)
- [x] /release-test (fresh-user walkthrough — all commands working, no emoji, every ⚠ ends in runnable command)
- [x] `--no-ignore` round-trip verified end-to-end
- [x] User-supplied `.secretlessignore` is additive and `--no-ignore` overrides