### PR TITLE
docs: add from-source install path + SLSA provenance verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,11 +174,26 @@ opena2a review          # Full security dashboard
 opena2a secrets init    # Initialize secretless protection
 ```
 
-## Development
+## Development (from source)
 
 ```bash
-npm run build && npm test    # 809 tests
+git clone https://github.com/opena2a-org/secretless-ai.git
+cd secretless-ai
+npm install
+npm run build && npm test    # 988 tests
+node dist/index.js verify    # run the freshly-built binary
 ```
+
+## Verifying what you installed
+
+Every release is published via npm Trusted Publishing with SLSA v1 provenance — there is no long-lived `NPM_TOKEN` in the publish workflow; the GitHub Actions runner exchanges its OIDC token with npm at publish time. To verify the package you installed was actually built from the source you can read on GitHub:
+
+```bash
+npm view secretless-ai dist.attestations --json
+# → non-empty result with predicateType "https://slsa.dev/provenance/v1"
+```
+
+Secretless itself never reads or transmits the credential values it manages — backends (OS keychain, 1Password, HashiCorp Vault, encrypted file) decrypt on demand at subprocess spawn time. See `secretless-ai verify` for an integrity check of your local install.
 
 ## Telemetry
 


### PR DESCRIPTION
Two gaps the OpenA2A README consistency audit (2026-05-10) flagged against the AIM + opena2a-cli rework pattern.

## What's missing today

1. **No from-source install path.** The `Development` section was a single `npm run build && npm test` one-liner. Contributors and security-conscious users couldn't see how to clone, build, and run from source.
2. **No SLSA verification.** Every OpenA2A package publishes via npm Trusted Publishing with SLSA v1 provenance now (per the cross-org standard); secretless-ai's README didn't surface the verifier command.

## What changed

- Renamed `## Development` → `## Development (from source)` with full `git clone → npm install → npm run build → node dist/index.js verify` walkthrough.
- New `## Verifying what you installed` section with the `npm view secretless-ai dist.attestations --json` SLSA check, matching the block in [agent-identity-management PR #121](https://github.com/opena2a-org/agent-identity-management/pull/121).
- Bumped the inline test-count comment 809 → 988 (matches the badge at the top of the file).

Docs-only diff. No code changes.

## Test plan

- [x] **Phase 1** sensitive: PASS (docs only)
- [x] **Phase 2** syntax: N/A (Markdown)
- [x] **Phase 3** AI review: `npm view secretless-ai dist.attestations --json` returns non-empty on the current 0.17.0 release; verified against npm registry.
- [x] **Phase 7** docs: no stale refs introduced; updated stale test count.
