### PR TITLE
fix(telemetry): treat exit 1 as success (credentials found ≠ failure)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -80,7 +80,9 @@ async function main(): Promise<number> {
     throw err;
   } finally {
     if (command && !NON_TRACKED.has(command)) {
-      await tele.track(command, { success: exitCode === 0, durationMs: Date.now() - startedAt });
+      // Exit 1 = scanner found credentials (the tool's job); >=2 = real error.
+      // npm audit / eslint convention. Matches @opena2a/telemetry.successFromExitCode.
+      await tele.track(command, { success: exitCode <= 1, durationMs: Date.now() - startedAt });
     }
     await tele.flush();
   }


### PR DESCRIPTION
## Summary

The dispatcher's success heuristic at `src/cli.ts:83` was `exitCode === 0`, which conflated "scanner found credentials" (intended exit 1 from scan / clean) with "real error" (exit ≥ 2). Production data from the new OpenA2A `/admin/cli-usage` dashboard:

| Command | Events | Success % |
|---|---:|---:|
| `secretless-ai clean` | 347 | 100% |
| `secretless-ai run` | 111 | 78% |
| `secretless-ai scan` | 54 | 39% ← inverted |
| `secretless-ai status` | 17 | 100% |

`scan` finding credentials is the tool succeeding at its job, not failing. Lookup-only commands (`status`, `secret`) sit at 100% because they never exit 1.

Change `exitCode === 0` → `exitCode <= 1` (security-tool convention; matches npm audit / eslint). Exit ≥ 2 still records as failure.

## Companion PRs (same bug, different repos)

- opena2a#144 — `@opena2a/telemetry@0.2.0` adds the centralised `successFromExitCode()` helper that this dispatcher can adopt once the dep pin bumps. Also fixes `install_id` instability in containers.
- hackmyagent#174 — same one-line fix (`hackmyagent secure` was 29% in prod).
- ai-trust#TBD, dvaa#TBD — same.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 988/988
- [x] `hackmyagent secure --ci` self-scan — **100/100**, 0 findings of any severity
- [x] Diff is 1 functional line (`=== 0` → `<= 1`) with comment

Audit doc: `~/workspace/opena2a-org/todo/2026-05-10-cli-telemetry-anomalies.md`