### PR TITLE
chore(release): bump version to 0.17.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npx secretless-ai init
 ```
 
 ```
-  Secretless v0.17.0
+  Secretless v0.17.1
   Keeping secrets out of AI
 
   Configured: Claude Code (1 of 1 detected)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secretless-ai",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "One command to keep secrets out of AI. Works with Claude Code, Cursor, Copilot, Windsurf, and any AI coding tool.",
   "license": "Apache-2.0",
   "type": "commonjs",


### PR DESCRIPTION
## Summary

Telemetry-fix release. PR #71 (the substantive fix) is already merged on main; this branch bumps `package.json` 0.17.0 → 0.17.1 and updates the README init-banner sample. Tag push triggers GHA OIDC publish.

USER_VISIBLE_IMPACT: secretless-ai 0.17.1 — exit-code-1-with-findings (credentials found) is now reported as success in telemetry (visible via Registry dashboard /admin/cli-usage). Pre-fix the failure rate showed inflated values in production; with this release the dashboard success rate will trend toward ~100% as users upgrade. User authorized 2026-05-12.

## Changes
- `package.json` 0.17.0 → 0.17.1
- `README.md` init-banner sample bumped to `v0.17.1`

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 988/988 pass
- [x] HMA self-scan — 100/100, 0 findings
- [x] Pre-push 8-phase review — PASS
- [ ] Post-merge: tag `v0.17.1` and verify GHA OIDC publish + SLSA v1 attestation