### PR TITLE
fix(cli): reject unknown --flags as dir args on init/status (closes release-test 2026-05-12 P1)

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { execFileSync } from 'child_process';
+import { execFileSync, spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -64,6 +64,76 @@ describe('cli --help handling', () => {
     try {
       const out = runCli(['scan', '-h'], { cwd: tmp });
       expect(out).toMatch(/Secretless v/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('init / status reject unknown flags as dir path (regression: release-test 2026-05-12 P1)', () => {
+  const hasBuild = fs.existsSync(CLI_PATH);
+  const itIfBuilt = hasBuild ? it : it.skip;
+
+  function runCliSpawn(args: string[], cwd: string) {
+    return spawnSync(process.execPath, [CLI_PATH, ...args], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd,
+    });
+  }
+
+  itIfBuilt('`init --ci` does NOT create a `--ci/` directory', () => {
+    // Pre-fix: secretless-ai init --ci scaffolded files into a literal `--ci/`
+    // dir because dispatch took args[1] as projectDir without validation.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-init-flag-'));
+    try {
+      const before = fs.readdirSync(tmp);
+      const res = runCliSpawn(['init', '--ci'], tmp);
+      const after = fs.readdirSync(tmp);
+      expect(after).toEqual(before); // nothing created
+      expect(res.status).toBe(2);
+      expect(res.stderr).toMatch(/Unknown option: --ci/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  itIfBuilt('`init --unknown` is rejected with actionable error', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-init-flag-'));
+    try {
+      const res = runCliSpawn(['init', '--unknown'], tmp);
+      expect(fs.readdirSync(tmp)).toEqual([]);
+      expect(res.status).toBe(2);
+      expect(res.stderr).toMatch(/Unknown option: --unknown/);
+      expect(res.stderr).toMatch(/Run `secretless-ai init --help` for usage/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  itIfBuilt('`status --foo` is rejected, not treated as dir', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-status-flag-'));
+    try {
+      const res = runCliSpawn(['status', '--foo'], tmp);
+      expect(fs.readdirSync(tmp)).toEqual([]);
+      expect(res.status).toBe(2);
+      expect(res.stderr).toMatch(/Unknown option: --foo/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  itIfBuilt('`init ./valid-dir` still works (positive case)', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-init-pos-'));
+    try {
+      const target = path.join(tmp, 'target');
+      fs.mkdirSync(target);
+      const res = runCliSpawn(['init', target], tmp);
+      // init exits 0 on success and writes files into target.
+      // Don't pin specific files — runInit's surface evolves — just assert
+      // it created something in target.
+      expect(res.status).toBe(0);
+      expect(fs.readdirSync(target).length).toBeGreaterThan(0);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -89,10 +89,29 @@ async function main(): Promise<number> {
   return exitCode;
 }
 
+/**
+ * Reject unknown `--flag` / `-flag` args that would otherwise be silently
+ * treated as a directory path by commands whose only positional is `[dir]`.
+ * Pre-fix: `secretless-ai init --ci` created a literal `--ci/` directory and
+ * scaffolded files into it (release-test 2026-05-12 P1).
+ *
+ * Returns `false` if the caller should bail with exit 2; `true` to proceed.
+ */
+function rejectUnknownFlagAsDirArg(command: string, dirArg: string | undefined): boolean {
+  if (dirArg && dirArg.startsWith('-')) {
+    console.error(`  Unknown option: ${dirArg}`);
+    console.error(`  \`${command}\` takes an optional directory path, not flags.`);
+    console.error(`  Run \`secretless-ai ${command} --help\` for usage.`);
+    return false;
+  }
+  return true;
+}
+
 async function dispatch(args: string[], command: string | undefined): Promise<number> {
   switch (command) {
     case 'init': {
       const dirArg = args[1];
+      if (!rejectUnknownFlagAsDirArg('init', dirArg)) return 2;
       const projectDir = dirArg ? path.resolve(dirArg) : process.cwd();
       return runInit(projectDir);
     }
@@ -135,6 +154,7 @@ async function dispatch(args: string[], command: string | undefined): Promise<nu
     }
     case 'status': {
       const dirArg = args[1];
+      if (!rejectUnknownFlagAsDirArg('status', dirArg)) return 2;
       const projectDir = dirArg ? path.resolve(dirArg) : process.cwd();
       return runStatus(projectDir);
     }


### PR DESCRIPTION
## Summary

Closes release-test 2026-05-12 P1: `secretless-ai init --ci` silently scaffolded files into a literal `--ci/` directory.

The global `--help`/`-h` intercept at cli.ts:52 already caught the canonical case (`init --help` → top-level help, not `--help/` dir). It covered only those two flags, so every other unknown long-flag fell through into the dispatch case and became a directory name. New `rejectUnknownFlagAsDirArg` helper closes the gap for the dir-only commands (`init`, `status`) without re-implementing argv parsing.

## Reproduction (pre-fix)

```
$ mkdir t && cd t
$ secretless-ai init --ci
$ ls
--ci/    # ← scaffolded into literal --ci/ directory
$ ls -- --ci/
CLAUDE.md  .claude/
```

## Post-fix

```
$ secretless-ai init --ci
  Unknown option: --ci
  `init` takes an optional directory path, not flags.
  Run `secretless-ai init --help` for usage.
$ echo $?
2
```

## Regression coverage

`src/cli.test.ts`:
- `init --ci` exits 2, no `--ci/` directory created
- `init --unknown` rejected with actionable error
- `status --foo` rejected, not treated as dir
- `init <real-dir>` still works (positive path)

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 992/992 pass (was 988; +4 regression tests)
- [x] Real install via `npm pack` + `npm install <tgz>` confirms exit 2 + no `--ci/` dir
- [ ] Post-merge: release-test re-run + tag v0.17.1 with combined diff (PR #73 + this PR)

## USER_VISIBLE_IMPACT
secretless-ai init no longer silently creates `--<flag>/` directories when invoked with unknown flags. Combined with the telemetry fix from PR #71 (already merged), v0.17.1 will ship both improvements.