### PR TITLE
Dual-support ATX v1.1 (JCS) in the AAP broker grant path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "secretless-ai",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "secretless-ai",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@opena2a/cli-ui": "0.4.0",
         "@opena2a/credential-patterns": "0.1.1",
-        "@opena2a/telemetry": "0.1.2"
+        "@opena2a/telemetry": "0.1.2",
+        "canonicalize": "2.1.0"
       },
       "bin": {
         "secretless-ai": "dist/cli.js",
@@ -616,6 +617,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/canonicalize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
+      "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
       }
     },
     "node_modules/chai": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "dependencies": {
     "@opena2a/cli-ui": "0.4.0",
     "@opena2a/credential-patterns": "0.1.1",
-    "@opena2a/telemetry": "0.1.2"
+    "@opena2a/telemetry": "0.1.2",
+    "canonicalize": "2.1.0"
   }
 }

--- a/src/broker/atx.test.ts
+++ b/src/broker/atx.test.ts
@@ -3,6 +3,7 @@ import * as crypto from 'crypto';
 import {
   LocalAtxVerifier,
   canonicalPayload,
+  canonicalPayloadV11,
   normalizeRfc3339,
   type Atx,
   type AtxTrustAnchors,
@@ -159,5 +160,105 @@ describe('canonical form', () => {
   it('normalizes RFC 3339 to seconds-precision UTC Z', () => {
     expect(normalizeRfc3339('2026-06-08T00:00:00.123Z')).toBe('2026-06-08T00:00:00Z');
     expect(normalizeRfc3339('2026-06-08T02:00:00+02:00')).toBe('2026-06-08T00:00:00Z');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ATX v1.1 (JCS / RFC 8785). The verifier signs JCS(TBS), so capabilities,
+// scanSummary, issuerChain, and publisher are integrity-protected.
+// ---------------------------------------------------------------------------
+
+// The credential that projects to the jcs-vectors baseline vector. Its canonical
+// bytes are pinned across all four implementations.
+const V11_BASELINE: Omit<Atx, 'signatures'> = {
+  atcVersion: '1.1',
+  agentId: 'agent_conformance_test_001',
+  agentDid: 'did:opena2a:agent:agent_conformance_test_001',
+  publisher: 'opena2a-conformance',
+  publisherDid: 'did:opena2a:publisher:opena2a-conformance',
+  version: '1.0.0',
+  contentHash: '0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff',
+  buildAttestation: 'https://slsa.dev/provenance/v1#opena2a-conformance',
+  issuerDid: 'did:opena2a:authority:opena2a.org',
+  issuerChain: ['did:opena2a:authority:opena2a.org-root', 'did:opena2a:authority:opena2a.org'],
+  trustLevel: 4,
+  trustScore: 87.5,
+  issuedAt: '2026-05-23T00:00:00Z',
+  expiresAt: '2099-12-31T23:59:59Z',
+  capabilities: ['read:public', 'write:owned'],
+  behavioralProfile: { checksum: 'sha256:ghi789', generatedAt: '2026-05-19T00:00:00Z', observationDays: 14 },
+  scanSummary: {
+    hma: 'passed',
+    criticalFindings: 0,
+    highFindings: 0,
+    secretless: 'clean',
+    cryptoServe: 'no-weak-crypto',
+    oasbLevel: 'L1',
+  },
+};
+
+// Pinned in atx-conformance/jcs-vectors/vectors/01-baseline.json. The broker MUST
+// reproduce these exact bytes or it will reject credentials the registry signs.
+const V11_BASELINE_CANONICAL_HEX =
+  '7b226167656e74446964223a226469643a6f70656e6132613a6167656e743a6167656e745f636f6e666f726d616e63655f746573745f303031222c226167656e744964223a226167656e745f636f6e666f726d616e63655f746573745f303031222c2261746356657273696f6e223a22312e31222c226265686176696f72616c50726f66696c65223a7b22636865636b73756d223a227368613235363a676869373839222c2267656e6572617465644174223a22323032362d30352d31395430303a30303a30305a222c226f62736572766174696f6e44617973223a31347d2c226275696c644174746573746174696f6e223a2268747470733a2f2f736c73612e6465762f70726f76656e616e63652f7631236f70656e6132612d636f6e666f726d616e6365222c226361706162696c6974696573223a5b22726561643a7075626c6963222c2277726974653a6f776e6564225d2c22636f6e74656e7448617368223a2230303030313131313232323233333333343434343535353536363636373737373838383839393939616161616262626263636363646464646565656566666666222c22657870697265734174223a22323039392d31322d33315432333a35393a35395a222c226973737565644174223a22323032362d30352d32335430303a30303a30305a222c22697373756572436861696e223a5b226469643a6f70656e6132613a617574686f726974793a6f70656e6132612e6f72672d726f6f74222c226469643a6f70656e6132613a617574686f726974793a6f70656e6132612e6f7267225d2c22697373756572446964223a226469643a6f70656e6132613a617574686f726974793a6f70656e6132612e6f7267222c227075626c6973686572223a226f70656e6132612d636f6e666f726d616e6365222c227075626c6973686572446964223a226469643a6f70656e6132613a7075626c69736865723a6f70656e6132612d636f6e666f726d616e6365222c227363616e53756d6d617279223a7b22637269746963616c46696e64696e6773223a302c2263727970746f5365727665223a226e6f2d7765616b2d63727970746f222c226869676846696e64696e6773223a302c22686d61223a22706173736564222c226f6173624c6576656c223a224c31222c227365637265746c657373223a22636c65616e227d2c2274727573744c6576656c223a342c22747275737453636f7265223a2238372e353030303030222c2276657273696f6e223a22312e302e30227d';
+
+/** Sign a v1.1 ATX over its JCS(TBS) with a fresh key; mutate after signing for tamper tests. */
+function makeSignedV11Atx(mutate?: (a: Atx) => void): { atx: Atx; pubHex: string } {
+  const { privateKey, pubHex } = makeKeypair();
+  const atx: Atx = { ...V11_BASELINE, signatures: [] };
+  const sig = crypto.sign(null, canonicalPayloadV11(atx), privateKey);
+  atx.signatures = [{ keyId: 'test#ed25519', algorithm: 'Ed25519', value: sig.toString('base64') }];
+  if (mutate) mutate(atx);
+  return { atx, pubHex };
+}
+
+describe('ATX v1.1 (JCS)', () => {
+  it('reproduces the pinned jcs-vectors baseline canonical bytes', () => {
+    const atx: Atx = { ...V11_BASELINE, signatures: [] };
+    expect(canonicalPayloadV11(atx).toString('hex')).toBe(V11_BASELINE_CANONICAL_HEX);
+  });
+
+  it('accepts a valid v1.1 credential and marks capabilities as signed', () => {
+    const { atx, pubHex } = makeSignedV11Atx();
+    const r = new LocalAtxVerifier(makeTrustAnchors(pubHex)).verify(atx);
+    expect(r.valid).toBe(true);
+    expect(r.context?.signedCapabilities).toBe(true);
+    expect(r.context?.capabilities).toEqual(['read:public', 'write:owned']);
+  });
+
+  it('marks v1.0 capabilities as unsigned', () => {
+    const { atx, pubHex } = makeSignedAtx();
+    const r = new LocalAtxVerifier(makeTrustAnchors(pubHex)).verify(atx);
+    expect(r.valid).toBe(true);
+    expect(r.context?.signedCapabilities).toBe(false);
+  });
+
+  it('rejects a v1.1 credential whose capabilities were escalated after signing', () => {
+    const { atx, pubHex } = makeSignedV11Atx((a) => {
+      a.capabilities = ['read:public', 'write:owned', 'admin:all'];
+    });
+    const r = new LocalAtxVerifier(makeTrustAnchors(pubHex)).verify(atx);
+    expect(r.valid).toBe(false);
+    expect(r.rejectCategory).toBe('SIGNATURE_INVALID');
+  });
+
+  it('rejects tampering of other now-signed fields (scanSummary, issuerChain, publisher)', () => {
+    const mutations: Array<(a: Atx) => void> = [
+      (a) => { a.scanSummary = { ...a.scanSummary, oasbLevel: 'L3' }; },
+      (a) => { a.issuerChain = ['did:opena2a:authority:opena2a.org', 'did:opena2a:authority:opena2a.org-root']; },
+      (a) => { a.publisher = 'evil-corp'; },
+    ];
+    for (const mutate of mutations) {
+      const { atx, pubHex } = makeSignedV11Atx(mutate);
+      const r = new LocalAtxVerifier(makeTrustAnchors(pubHex)).verify(atx);
+      expect(r.valid).toBe(false);
+      expect(r.rejectCategory).toBe('SIGNATURE_INVALID');
+    }
+  });
+
+  it('fails closed on a 1.1 -> 1.0 downgrade', () => {
+    const { atx, pubHex } = makeSignedV11Atx((a) => { a.atcVersion = '1.0'; });
+    const r = new LocalAtxVerifier(makeTrustAnchors(pubHex)).verify(atx);
+    expect(r.valid).toBe(false);
   });
 });

--- a/src/broker/atx.ts
+++ b/src/broker/atx.ts
@@ -8,31 +8,46 @@
  * `opena2a-registry/pkg/atcverify/verify.go canonicalPayload()`) VERBATIM so a broker
  * accepts exactly the credentials the conformance suite accepts.
  *
- * (ATX is the current name for the credential formerly called ATC; fixtures still use
- * the `atcVersion` field and the canonical form hardcodes "1.0" — both replicated here.)
+ * (ATX is the current name for the credential formerly called ATC; fixtures use the
+ * `atcVersion` field. This verifier dual-supports both signing forms.)
  *
  * Scope: Ed25519 is verified fully. ML-DSA-65 presence is recorded but verification is
  * delegated — Node's stdlib has no ML-DSA, exactly as the Python reference verifier
  * skips it. Production wires the post-quantum half + the live trusted-issuer/CRL anchors
  * to AIM's verification path (see AtxVerifier / RegistryAtxVerifier seam below).
  *
- * SECURITY — signature coverage (matches the upstream canonical form, see canonicalPayload):
- * The ATX/ATC canonical signing string covers identity, issuer, trustLevel, trustScore,
- * contentHash, buildAttestation, and the validity window. It does NOT cover `capabilities`,
- * `scanSummary.oasbLevel`, `issuerChain`, or `jurisdiction`. A holder of ANY validly-signed
- * ATX can therefore edit those fields without invalidating the Ed25519 signature. Because
- * the broker authorizes on `capabilities` (the trust-class gate) and `oasbLevel`, a
- * production verifier MUST source those authorization attributes from the issuing
- * Registry/AIM for the verified `agentId` — NOT trust them from the presented credential
- * blob. The LocalAtxVerifier is faithful to the wire format for conformance; it is not a
- * sufficient authorization oracle on its own. Tracked as an ATX-spec hardening item
- * (bind the trust-class set into the canonical payload or a signed content hash).
+ * SECURITY — signature coverage depends on atcVersion:
+ *  - v1.0 (canonicalPayload): the pipe-delimited string covers identity, issuer,
+ *    trustLevel, trustScore, contentHash, buildAttestation, and the validity window.
+ *    It does NOT cover `capabilities`, `scanSummary.oasbLevel`, `issuerChain`, or
+ *    `jurisdiction`. A holder of any validly-signed v1.0 ATX can edit those without
+ *    invalidating the signature, so they MUST NOT be trusted for authorization.
+ *  - v1.1 (canonicalPayloadV11): the signature covers JCS(TBS), which includes
+ *    `capabilities`, `scanSummary`, `issuerChain`, and `publisher`. Those fields are
+ *    integrity-protected and safe to authorize on.
+ *
+ * The verified context exposes `signedCapabilities` (true iff v1.1) so callers can tell
+ * the two apart. Phase 3 of the ATX v1.1 rollout adds a `requireSignedCapabilities`
+ * grant-policy flag that refuses capability-gated grants whose context has
+ * `signedCapabilities === false`. Until then a production verifier still SHOULD source
+ * authorization attributes for v1.0 credentials from the issuing Registry/AIM for the
+ * verified `agentId` rather than the presented blob.
  */
 
 import * as crypto from 'crypto';
+import canonicalize from 'canonicalize';
 
-/** The hardcoded schema version in the canonical signing string (Go quirk, replicated). */
+/** Legacy schema version: signs the 11-field pipe string (Go quirk, replicated). */
 export const SUPPORTED_ATX_VERSION = '1.0';
+
+/**
+ * ATX v1.1: signs JCS(TBS) (RFC 8785) per atx-spec core.md §1.3a.2, bringing
+ * capabilities, scanSummary, issuerChain, publisher, and behavioralProfile under
+ * the signature. Verified here using the same canonicalizer (erdtman/canonicalize)
+ * and the same TBS projection the registry and conformance verifiers use; byte
+ * agreement is proven by atx-conformance/jcs-vectors.
+ */
+export const SUPPORTED_ATX_VERSION_V11 = '1.1';
 
 /** A signature reference on an ATX. */
 export interface AtxSignature {
@@ -47,6 +62,9 @@ export interface Atx {
   atcVersion?: string;
   agentId: string;
   agentDid: string;
+  /** Publisher identity. Unsigned under v1.0; covered by the v1.1 signature. */
+  publisher?: string;
+  publisherDid?: string;
   version: string;
   contentHash: string;
   buildAttestation?: string;
@@ -57,6 +75,8 @@ export interface Atx {
   issuedAt: string;
   expiresAt: string;
   capabilities?: string[];
+  /** Observed-behavior summary. Covered by the v1.1 signature. */
+  behavioralProfile?: { checksum?: string; generatedAt?: string; observationDays?: number } | null;
   scanSummary?: { oasbLevel?: string; [k: string]: unknown };
   /** Optional, optional-to-ignore jurisdiction claim (AAP §9). */
   jurisdiction?: string[];
@@ -100,6 +120,13 @@ export interface ResolutionContext {
   capabilities: string[];
   oasbLevel?: string;
   jurisdiction?: string[];
+  /**
+   * True when the credential is v1.1+, i.e. capabilities/scanSummary/issuerChain
+   * are covered by the signature and may be trusted for authorization. False for
+   * v1.0, where those fields are forgeable by the holder. Phase 3 of the ATX v1.1
+   * rollout gates capability-based grants on this.
+   */
+  signedCapabilities: boolean;
 }
 
 export interface AtxVerificationResult {
@@ -130,10 +157,12 @@ export class LocalAtxVerifier implements AtxVerifier {
   verify(atx: Atx): AtxVerificationResult {
     const now = (this.anchors.now ?? (() => new Date()))();
 
-    // Step 1: schema version.
-    if (atx.atcVersion !== SUPPORTED_ATX_VERSION) {
+    // Step 1: schema version. Dispatch on atcVersion: "1.0" verifies the legacy
+    // pipe form, "1.1" verifies JCS(TBS) (atx-spec §1.3a).
+    if (atx.atcVersion !== SUPPORTED_ATX_VERSION && atx.atcVersion !== SUPPORTED_ATX_VERSION_V11) {
       return reject('UNSUPPORTED_VERSION', `unsupported atxVersion ${String(atx.atcVersion)}`);
     }
+    const isV11 = atx.atcVersion === SUPPORTED_ATX_VERSION_V11;
 
     // Step 2: expiry.
     const expires = new Date(atx.expiresAt);
@@ -160,7 +189,18 @@ export class LocalAtxVerifier implements AtxVerifier {
     }
 
     // Step 5: signature verification (Ed25519 fully; ML-DSA-65 presence recorded).
-    const payload = canonicalPayload(atx);
+    // A v1.1 TBS that fails to canonicalize is a malformed credential, not a
+    // verifier error: reject closed rather than throwing.
+    let payload: Buffer;
+    if (isV11) {
+      try {
+        payload = canonicalPayloadV11(atx);
+      } catch (err) {
+        return reject('MALFORMED', `v1.1 canonicalization failed: ${(err as Error).message}`);
+      }
+    } else {
+      payload = canonicalPayload(atx);
+    }
     const edKeys = this.anchors.publicKeys
       .filter((k) => k.algorithm === 'Ed25519')
       .map((k) => ed25519FromRawHex(k.publicKeyHex))
@@ -211,6 +251,7 @@ export class LocalAtxVerifier implements AtxVerifier {
         capabilities: atx.capabilities ?? [],
         oasbLevel: atx.scanSummary?.oasbLevel,
         jurisdiction: atx.jurisdiction,
+        signedCapabilities: isV11,
       },
     };
   }
@@ -240,6 +281,72 @@ export function canonicalPayload(atx: Atx): Buffer {
     SUPPORTED_ATX_VERSION,
   ];
   return Buffer.from(fields.join('|'), 'utf-8');
+}
+
+/**
+ * Project an ATX into the v1.1 TBS and return JCS(TBS) (RFC 8785). Unlike
+ * canonicalPayload, this covers capabilities, scanSummary, issuerChain,
+ * publisher, and behavioralProfile. The projection (canonical empties,
+ * always-full scanSummary, %.6f string trustScore, root-first issuerChain) and
+ * the canonicalizer match opena2a-registry/pkg/atcverify and the conformance
+ * verifiers exactly; byte agreement is pinned by atx-conformance/jcs-vectors.
+ */
+export function canonicalPayloadV11(atx: Atx): Buffer {
+  const scan = (atx.scanSummary ?? {}) as Record<string, unknown>;
+  const tbs: Record<string, unknown> = {
+    atcVersion: atx.atcVersion,
+    agentId: atx.agentId,
+    agentDid: atx.agentDid,
+    publisher: atx.publisher ?? '',
+    publisherDid: atx.publisherDid ?? '',
+    version: atx.version,
+    contentHash: atx.contentHash,
+    buildAttestation: atx.buildAttestation ?? '',
+    capabilities: atx.capabilities ?? [],
+    behavioralProfile: projectBehavioralProfile(atx.behavioralProfile),
+    scanSummary: {
+      hma: asString(scan.hma),
+      criticalFindings: asInt(scan.criticalFindings),
+      highFindings: asInt(scan.highFindings),
+      secretless: asString(scan.secretless),
+      cryptoServe: asString(scan.cryptoServe),
+      oasbLevel: asString(scan.oasbLevel),
+    },
+    // trustScore is the %.6f string form so trustLevel is the only JSON number.
+    trustScore: Number(atx.trustScore).toFixed(6),
+    trustLevel: Math.trunc(atx.trustLevel),
+    issuedAt: normalizeRfc3339(atx.issuedAt),
+    expiresAt: normalizeRfc3339(atx.expiresAt),
+    issuerDid: atx.issuerDid,
+    issuerChain: atx.issuerChain ?? [],
+  };
+  const canonical = canonicalize(tbs);
+  if (typeof canonical !== 'string') {
+    throw new Error('canonicalize returned non-string');
+  }
+  return Buffer.from(canonical, 'utf-8');
+}
+
+/** behavioralProfile -> null when absent, else the canonical three-field object. */
+function projectBehavioralProfile(
+  bp: Atx['behavioralProfile'],
+): null | { checksum: string; generatedAt: string; observationDays: number } {
+  if (bp === null || bp === undefined) {
+    return null;
+  }
+  return {
+    checksum: asString(bp.checksum),
+    generatedAt: bp.generatedAt ? normalizeRfc3339(bp.generatedAt) : '',
+    observationDays: asInt(bp.observationDays),
+  };
+}
+
+function asString(v: unknown): string {
+  return typeof v === 'string' ? v : '';
+}
+
+function asInt(v: unknown): number {
+  return typeof v === 'number' && Number.isFinite(v) ? Math.trunc(v) : 0;
 }
 
 /** Normalize an RFC 3339 timestamp to UTC "YYYY-MM-DDTHH:MM:SSZ" (Go time.RFC3339 for UTC). */


### PR DESCRIPTION
## Dual-support ATX v1.1 (JCS) in the AAP grant path

The AAP Exchange broker (#76) is merged; this builds on it. The broker's ATX verifier now dual-supports the v1.1 credential form so the grant path can trust the credential's `capabilities` once issuance flips to v1.1.

### What changed (`src/broker/atx.ts`)
- Dispatch on `atcVersion`: `"1.0"` verifies the legacy eleven-field pipe form unchanged; `"1.1"` verifies the signature over `JCS(TBS)` (RFC 8785) per atx-spec §1.3a.2, so `capabilities`, `scanSummary`, `issuerChain`, and `publisher` are covered.
- `canonicalPayloadV11` projects the TBS with the normative determinism rules (canonical empties, full six-field `scanSummary`, `%.6f` string `trustScore` so `trustLevel` is the only JSON number, `behavioralProfile` null-or-object, root-first `issuerChain`) and canonicalizes with `canonicalize` (erdtman, the RFC 8785 reference impl) — the same canonicalizer and projection the registry and conformance verifiers use. Byte agreement is pinned by `atx-conformance/jcs-vectors`.
- The verified `ResolutionContext` now exposes `signedCapabilities` (true iff v1.1). This is the seam Phase 3 uses: a `requireSignedCapabilities` grant-policy flag will refuse capability-gated grants whose context has `signedCapabilities === false`, closing the forgeable-capabilities hole for real v1.0 credentials after the credential TTL. The module SECURITY note is updated to state coverage per version accurately.

### Tests
- Cross-repo **known-answer test**: `canonicalPayloadV11` reproduces the exact baseline bytes pinned in `jcs-vectors`.
- v1.1 round-trip accept; v1.0 marked `signedCapabilities=false`; escalating `capabilities`/`scanSummary`/`issuerChain`/`publisher` after signing each rejects; `1.1` to `1.0` downgrade fails closed.
- `canonicalize@2.1.0` pinned exact (zero runtime deps). `tsc` build clean; full vitest suite green.

### Dependency
Adds `canonicalize@2.1.0` (erdtman, the RFC 8785 reference implementation), pinned exact per the supply-chain policy.
