### PR TITLE
scan warns on unknown flags; secret usage cleanup (#80, #81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`scan` warns on an unrecognized flag instead of silently ignoring it (#81).** A typo like `--show-placeholder` (for `--show-placeholders`) used to no-op with no feedback. `scan` now prints `Warning: ignoring unknown flag --x` plus the supported-flag list. The warning is non-fatal — the exit code still reflects findings.
+- **`secret` with no subcommand prints usage cleanly instead of an error (#80).** Bare `secretless-ai secret` showed `Unknown secret command: (none)` (which reads like an error for an empty invocation) and now prints the usage block and exits 0. A real unrecognized subcommand (`secret bogus`) still errors with `Unknown secret command: bogus` and exits 1.
+
 ## [0.18.0] - 2026-06-01
 
 ### Added

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -139,3 +139,58 @@ describe('init / status reject unknown flags as dir path (regression: release-te
     }
   });
 });
+
+describe('scan warns on unknown flags / secret usage (regression: #80, #81)', () => {
+  const hasBuild = fs.existsSync(CLI_PATH);
+  const itIfBuilt = hasBuild ? it : it.skip;
+
+  function runCliSpawn(args: string[], cwd: string) {
+    return spawnSync(process.execPath, [CLI_PATH, ...args], {
+      encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], cwd,
+    });
+  }
+
+  itIfBuilt('`scan --show-placeholder` (typo) warns instead of silently no-opping (#81)', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-scan-flag-'));
+    try {
+      const res = runCliSpawn(['scan', '.', '--show-placeholder'], tmp);
+      expect(res.stderr).toMatch(/ignoring unknown flag --show-placeholder/);
+      expect(res.status).toBe(0); // warning is non-fatal; clean dir still exits 0
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  itIfBuilt('`scan --json` (known flag) produces NO unknown-flag warning (#81)', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-scan-known-'));
+    try {
+      const res = runCliSpawn(['scan', '.', '--json'], tmp);
+      expect(res.stderr).not.toMatch(/unknown flag/i);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  itIfBuilt('`secret` with no subcommand prints usage cleanly, exit 0 (#80)', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-secret-'));
+    try {
+      const res = runCliSpawn(['secret'], tmp);
+      expect(res.status).toBe(0);
+      expect(res.stdout).toMatch(/Usage: secretless-ai secret/);
+      expect(`${res.stdout}${res.stderr}`).not.toMatch(/Unknown secret command/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  itIfBuilt('`secret bogus` (real unknown subcommand) still errors, exit 1 (#80)', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-secret-bad-'));
+    try {
+      const res = runCliSpawn(['secret', 'bogus'], tmp);
+      expect(res.status).toBe(1);
+      expect(res.stderr).toMatch(/Unknown secret command: bogus/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -141,14 +141,22 @@ async function dispatch(args: string[], command: string | undefined): Promise<nu
       }
       const flagFlag = new Set(['--include-tests', '--explain', '--no-ignore', '--json', '--show-placeholders', '--min-confidence']);
       const positionalArgs: string[] = [];
+      const unknownFlags: string[] = [];
       for (let k = 1; k < args.length; k++) {
         const a = args[k];
         if (flagFlag.has(a)) {
           if (a === '--min-confidence') k++;
           continue;
         }
-        if (a.startsWith('--')) continue;
+        // Warn (don't fail) on an unrecognized flag so a typo like `--show-placeholder`
+        // for `--show-placeholders` doesn't silently no-op (#81). Matches the warn-not-
+        // crash behavior already used for an invalid `--min-confidence` value.
+        if (a.startsWith('--')) { unknownFlags.push(a); continue; }
         positionalArgs.push(a);
+      }
+      if (unknownFlags.length > 0) {
+        console.error(`  Warning: ignoring unknown flag${unknownFlags.length > 1 ? 's' : ''} ${unknownFlags.join(', ')}.`);
+        console.error('  Run `secretless-ai scan` for supported flags (--json, --show-placeholders, --min-confidence, --no-ignore, --include-tests, --explain).');
       }
       const dirArg = positionalArgs[0];
       const projectDir = dirArg ? path.resolve(dirArg) : process.cwd();

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -196,7 +196,13 @@ export async function runSecret(args: string[]): Promise<number> {
     }
 
     default:
-      console.error(`\n  Unknown secret command: ${subcommand ?? '(none)'}`);
+      // No subcommand is an exploration, not an error — show usage cleanly and succeed
+      // (#80). Reserve the "Unknown secret command" error for a real unrecognized token.
+      if (subcommand === undefined) {
+        console.log('\n  Usage: secretless-ai secret <set|list|get|rm> [args]\n');
+        return 0;
+      }
+      console.error(`\n  Unknown secret command: ${subcommand}`);
       console.log('  Usage: secretless-ai secret <set|list|get|rm> [args]\n');
       return 1;
   }


### PR DESCRIPTION
Two P3 polish fixes found by the 0.18.0 release test.

## #81 — `scan` warns on unknown flags
A typo like `--show-placeholder` (for `--show-placeholders`) silently no-op'd. `scan` now prints `Warning: ignoring unknown flag --x` plus the supported-flag list. Non-fatal — exit code still reflects findings. Consistent with `init`'s flag rejection and `--min-confidence`'s invalid-value warning.

## #80 — `secret` no-subcommand prints usage, not an error
Bare `secretless-ai secret` showed `Unknown secret command: (none)`, which reads like an error for an empty invocation. It now prints the usage block and exits 0. A real unknown subcommand (`secret bogus`) still errors with `Unknown secret command: bogus` and exits 1.

## Testing
- 1095 tests pass; HMA 100/100.
- 4 new regression tests spawn the built CLI and assert: unknown scan flag warns (exit unchanged), known flag produces no false warning, bare `secret` is clean (exit 0), `secret bogus` still errors (exit 1).

Closes #80, #81.
