### PR TITLE
fix(scope): print usage cleanly on no subcommand, exit 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.1] - 2026-06-01
+
 ### Fixed
+- **`scope` with no subcommand prints usage cleanly instead of an error.** Bare `secretless-ai scope` showed `Unknown scope command: (none)` and exited 1 (reads like an error for an empty invocation); it now prints the usage block and exits 0, mirroring the `secret` fix in #80. A real unrecognized subcommand (`scope bogus`) still errors with `Unknown scope command: bogus` and exits 1.
 - **`scan` warns on an unrecognized flag instead of silently ignoring it (#81).** A typo like `--show-placeholder` (for `--show-placeholders`) used to no-op with no feedback. `scan` now prints `Warning: ignoring unknown flag --x` plus the supported-flag list. The warning is non-fatal — the exit code still reflects findings.
 - **`secret` with no subcommand prints usage cleanly instead of an error (#80).** Bare `secretless-ai secret` showed `Unknown secret command: (none)` (which reads like an error for an empty invocation) and now prints the usage block and exits 0. A real unrecognized subcommand (`secret bogus`) still errors with `Unknown secret command: bogus` and exits 1.
 - **`init` no longer blocks committed env template files (`.env.example`, `.env.sample`, `.env.template`, `.env.dist`).** These hold placeholders, not real secrets, and are meant to be read/edited/committed, but the generated config blocked them three ways: the `Read(.env*)` / `Grep(*.env*)` deny globs, the guard hook's `.env.*` dotfile arm, and the `.aiderignore` `.env.*` entry. Deny rules now enumerate real env files (`.env`, `.env.local`, `.env.*.local`, `.env.{development,production,staging,test}`, `*.env`) instead of a broad `.env*` glob — Claude Code deny rules can't negate and `deny` beats `allow`, so enumeration is the only way to let templates fall through. The guard hook exempts `*.example` / `*.sample` / `*.template` / `*.dist` basenames before any block logic, and the generated `.aiderignore` un-ignores them. Real env files and other secrets stay blocked. Matches the env-file policy shipped to the user's global config.

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -193,4 +193,27 @@ describe('scan warns on unknown flags / secret usage (regression: #80, #81)', ()
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });
+
+  itIfBuilt('`scope` with no subcommand prints usage cleanly, exit 0', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-scope-'));
+    try {
+      const res = runCliSpawn(['scope'], tmp);
+      expect(res.status).toBe(0);
+      expect(res.stdout).toMatch(/Usage: secretless-ai scope/);
+      expect(`${res.stdout}${res.stderr}`).not.toMatch(/Unknown scope command/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  itIfBuilt('`scope bogus` (real unknown subcommand) still errors, exit 1', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-scope-bad-'));
+    try {
+      const res = runCliSpawn(['scope', 'bogus'], tmp);
+      expect(res.status).toBe(1);
+      expect(res.stderr).toMatch(/Unknown scope command: bogus/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/commands/scope.ts
+++ b/src/commands/scope.ts
@@ -177,14 +177,25 @@ export async function runScope(args: string[]): Promise<number> {
       return 0;
     }
 
-    default:
-      console.error(`\n  Unknown scope command: ${subcommand ?? '(none)'}`);
-      console.log('  Usage: secretless-ai scope <discover|check|list|reset>\n');
-      console.log('  Commands:');
-      console.log('    discover <name>   Discover permissions and save baseline');
-      console.log('    check <name>      Re-check and compare to baseline');
-      console.log('    list              Show all stored baselines');
-      console.log('    reset <name>      Clear baseline for re-baseline\n');
+    default: {
+      // No subcommand is an exploration, not an error — show usage cleanly and succeed
+      // (mirrors the `secret` fix in #80). Reserve the error for a real unrecognized token.
+      const usage = () => {
+        console.log('  Usage: secretless-ai scope <discover|check|list|reset>\n');
+        console.log('  Commands:');
+        console.log('    discover <name>   Discover permissions and save baseline');
+        console.log('    check <name>      Re-check and compare to baseline');
+        console.log('    list              Show all stored baselines');
+        console.log('    reset <name>      Clear baseline for re-baseline\n');
+      };
+      if (subcommand === undefined) {
+        console.log('');
+        usage();
+        return 0;
+      }
+      console.error(`\n  Unknown scope command: ${subcommand}`);
+      usage();
       return 1;
+    }
   }
 }


### PR DESCRIPTION
Bare `secretless-ai scope` printed `Unknown scope command: (none)` and exited 1 — reads like an error for an empty exploratory invocation. Now prints usage and exits 0, mirroring the `secret` fix in #80. A real unrecognized subcommand (`scope bogus`) still errors and exits 1.

Found by the 0.18.1 release-test fresh-user pass (P2: sibling-command inconsistency). Batching into 0.18.1.

- Regression tests added for both paths (`scope` exit 0 + usage; `scope bogus` exit 1).
- Full suite: 1100 passing.