### PR TITLE
fix(init,env): migrate existing configs on re-run; skip non-identifier secret names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.2] - 2026-06-01
+
+### Fixed
+- **`init` now migrates an existing config instead of only appending to it.** Older `init` was additive-only: it appended new deny rules and wrote the guard hook only when absent, so upgrading the CLI did **not** propagate template/hook fixes to an already-initialized project — the broad `Read(.env*)` / `Grep(*.env*)` globs and a stale `secretless-guard.sh` survived, re-blocking `.env.example` while `init` reported "Already up to date". `init` now (1) prunes a known deprecated-rule list (`DEPRECATED_DENY_RULES`) after re-adding the current enumerated rules, so a real env file is never left unprotected, and (2) regenerates the managed guard hook and rewrites it in place when its content is stale. Output reports `removed N deprecated patterns` and `~ .claude/hooks/secretless-guard.sh (refreshed to current version)`; an already-current config is still a clean no-op (no churn on re-run).
+- **`secretless-ai env` skips secret names that aren't valid shell variables instead of breaking the whole shell.** Stored secret names allow `-` (e.g. `vault-name`), but a shell identifier cannot — so `export vault-name='…'` made the shell reject the entire `eval "$(secretless-ai env)"`, printing `export: not valid in this context` on **every** command in profiles that use the eval hook, and silently dropping all the other secrets too. `env` now skips names that aren't valid POSIX shell identifiers (matching the validation `import` already applies), exports the rest normally, and reports the skipped names as a leading shell comment (a no-op inside `eval`, visible on direct invocation) that names them and how to fix — no secret value is exposed. Public API: `isValidShellIdentifier`.
+
 ## [0.18.1] - 2026-06-01
 
 ### Fixed

--- a/src/commands/core.ts
+++ b/src/commands/core.ts
@@ -52,14 +52,22 @@ export function runInit(projectDir: string): number {
     console.log();
     console.log('  Modified:');
     if (settingsModified) {
+      const changes: string[] = [];
       if (result.denyRulesAdded > 0) {
-        console.log(`    ~ .claude/settings.json (added ${result.denyRulesAdded} deny pattern${result.denyRulesAdded === 1 ? '' : 's'})`);
+        changes.push(`added ${result.denyRulesAdded} deny pattern${result.denyRulesAdded === 1 ? '' : 's'}`);
+      }
+      if (result.denyRulesRemoved > 0) {
+        changes.push(`removed ${result.denyRulesRemoved} deprecated pattern${result.denyRulesRemoved === 1 ? '' : 's'}`);
+      }
+      if (changes.length > 0) {
+        console.log(`    ~ .claude/settings.json (${changes.join(', ')})`);
       } else {
         console.log(`    ~ .claude/settings.json`);
       }
     }
     for (const f of otherModified) {
-      console.log(`    ~ ${f}`);
+      const suffix = (f === '.claude/hooks/secretless-guard.sh' && result.hookRefreshed) ? ' (refreshed to current version)' : '';
+      console.log(`    ~ ${f}${suffix}`);
     }
   }
 

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { generateEnvExports, getShellHookLine, SHELL_HOOK_MARKER } from './env';
+import { generateEnvExports, getShellHookLine, SHELL_HOOK_MARKER, isValidShellIdentifier } from './env';
 import type { WritableSecretBackend } from './backends/types';
 
 function createMockBackend(secrets: Record<string, string>): WritableSecretBackend {
@@ -58,6 +58,50 @@ describe('generateEnvExports', () => {
     expect(output).toContain("export NPM_TOKEN='npm_abc'");
     expect(output).not.toContain('GITHUB_TOKEN');
     expect(output).not.toContain('STRIPE_KEY');
+  });
+
+  // Stored secret names allow `-` (SAFE_NAME in secret-store), but a shell
+  // variable name cannot. Emitting `export vault-name=...` makes the shell
+  // reject the entire `eval "$(secretless-ai env)"`, which broke every command
+  // in profiles using the eval hook. A non-identifier name must be skipped, not
+  // emitted, and must not take valid secrets down with it.
+  it('skips secret names that are not valid shell identifiers instead of emitting an invalid export', async () => {
+    const backend = createMockBackend({
+      'secret/vault-name': 'oops',
+      'secret/GOOD_TOKEN': 'ghp_ok',
+    });
+
+    const output = await generateEnvExports({ backend });
+    // The bad name never becomes an `export` line.
+    expect(output).not.toContain('export vault-name');
+    // The valid secret still exports — one bad name does not break the rest.
+    expect(output).toContain("export GOOD_TOKEN='ghp_ok'");
+    // The skip is surfaced as a shell comment (no-op inside eval, visible direct).
+    expect(output).toMatch(/^# secretless: skipped 1 secret .*vault-name/m);
+    // Every non-comment line is a valid `export` of a valid identifier.
+    for (const line of output.split('\n').filter(l => l && !l.startsWith('#'))) {
+      expect(line).toMatch(/^export [A-Za-z_][A-Za-z0-9_]*=/);
+    }
+  });
+
+  it('the whole eval output parses as a shell no-op when only bad names exist', async () => {
+    const backend = createMockBackend({ 'secret/bad-name': 'x', 'secret/9starts': 'y' });
+    const output = await generateEnvExports({ backend });
+    expect(output).not.toMatch(/^export /m); // no export lines at all
+    expect(output.split('\n').every(l => l === '' || l.startsWith('#'))).toBe(true);
+  });
+});
+
+describe('isValidShellIdentifier', () => {
+  it('accepts POSIX shell identifiers', () => {
+    for (const n of ['FOO', '_foo', 'foo_bar', 'A1', 'supabase_registry_db']) {
+      expect(isValidShellIdentifier(n)).toBe(true);
+    }
+  });
+  it('rejects names with dashes, leading digits, dots, or spaces', () => {
+    for (const n of ['vault-name', '9lives', 'a.b', 'a b', '', '-x']) {
+      expect(isValidShellIdentifier(n)).toBe(false);
+    }
   });
 });
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -24,19 +24,54 @@ export interface EnvOptions extends SecretStoreOptions {
 }
 
 /**
+ * A POSIX shell variable name: a letter or underscore followed by letters,
+ * digits, or underscores. Stored secret names are more permissive than this
+ * (they also allow `-`), so a name like `vault-name` is a valid secret but an
+ * invalid shell identifier. Exporting it as `export vault-name=...` makes the
+ * shell reject the whole `eval`, which breaks every command in profiles that
+ * run `eval "$(secretless-ai env)"`. We skip such names instead.
+ */
+const SHELL_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export function isValidShellIdentifier(name: string): boolean {
+  return SHELL_IDENTIFIER.test(name);
+}
+
+/**
  * Generate shell export statements for stored secrets.
  * Returns the export script as a string.
+ *
+ * Secret names that are not valid shell identifiers (e.g. they contain a `-`)
+ * are skipped — one such name would otherwise make the entire `eval` fail and
+ * break every shell command. The skipped names are reported as a leading shell
+ * comment, which is a no-op inside `eval` but visible on direct invocation, so
+ * the secret stays loadable via `secretless-ai run` / `--only` and the user is
+ * told how to fix it without any secret value being exposed.
  */
 export async function generateEnvExports(options?: EnvOptions): Promise<string> {
   const store = new SecretStore(options);
   const secrets = await store.loadSecrets(options?.only);
 
   const lines: string[] = [];
+  const skipped: string[] = [];
   for (const [name, value] of Object.entries(secrets)) {
+    if (!isValidShellIdentifier(name)) {
+      skipped.push(name);
+      continue;
+    }
     // Single-quote the value and escape any embedded single quotes
     // using the standard shell pattern: replace ' with '\''
     const escaped = value.replace(/'/g, "'\\''");
     lines.push(`export ${name}='${escaped}'`);
+  }
+
+  if (skipped.length > 0) {
+    // A shell comment: harmless inside `eval`, visible on direct invocation.
+    lines.unshift(
+      `# secretless: skipped ${skipped.length} secret${skipped.length === 1 ? '' : 's'} ` +
+        `with a name that is not a valid shell variable: ${skipped.join(', ')}. ` +
+        `Rename to export (e.g. secretless-ai secret set NEW_NAME), or use secretless-ai run -- <cmd>.`,
+    );
   }
 
   return lines.join('\n');

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -3,7 +3,7 @@ import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { init } from './init';
+import { init, DEPRECATED_DENY_RULES } from './init';
 import { scan } from './scan';
 import { status } from './status';
 import { detectAITools } from './detect';
@@ -159,6 +159,92 @@ describe('init', () => {
       for (const neg of ['!.env.example', '!.env.sample', '!.env.template', '!.env.dist']) {
         expect(ignore, `expected ${neg}`).toContain(neg);
       }
+    });
+  });
+
+  // Older `init` was additive-only: it appended new deny rules and only wrote
+  // the guard hook when absent. So upgrading the CLI did NOT migrate an existing
+  // `.claude/settings.json` — the broad `.env*` glob and a stale hook survived,
+  // re-blocking `.env.example` while `init` reported "Already up to date". These
+  // tests pin the migration: prune deprecated rules + refresh the hook on re-run.
+  describe('migration: re-running init upgrades an older config', () => {
+    function runHook(hookPath: string, filePath: string): boolean {
+      const input = JSON.stringify({ tool_name: 'Read', tool_input: { file_path: filePath } });
+      const out = execSync(`bash ${JSON.stringify(hookPath)}`, { input, encoding: 'utf-8' });
+      return /"permissionDecision":"deny"/.test(out);
+    }
+
+    function seedStaleConfig(): void {
+      const claudeDir = path.join(dir, '.claude');
+      fs.mkdirSync(path.join(claudeDir, 'hooks'), { recursive: true });
+      fs.writeFileSync(path.join(claudeDir, 'settings.json'), JSON.stringify({
+        permissions: { deny: ['Read(.env*)', 'Grep(*.env*)', 'Read(*.key)'] },
+      }, null, 2));
+      // A stale managed hook: real content but missing the template-exempt arm.
+      fs.writeFileSync(path.join(claudeDir, 'hooks', 'secretless-guard.sh'),
+        '#!/usr/bin/env bash\n# old stale guard hook\nexit 0\n', { mode: 0o755 });
+    }
+
+    it('prunes deprecated broad-glob deny rules and reports the count', () => {
+      seedStaleConfig();
+      const result = init(dir);
+
+      const deny: string[] = JSON.parse(
+        fs.readFileSync(path.join(dir, '.claude', 'settings.json'), 'utf-8'),
+      ).permissions.deny;
+
+      for (const dep of DEPRECATED_DENY_RULES) {
+        expect(deny, `deprecated rule ${dep} should be pruned`).not.toContain(dep);
+      }
+      // Enumerated replacements are present (prune never leaves env unprotected).
+      expect(deny).toContain('Read(.env)');
+      expect(deny).toContain('Read(*.env)');
+      expect(result.denyRulesRemoved).toBe(2);
+      expect(result.filesModified).toContain('.claude/settings.json');
+    });
+
+    it('refreshes a stale managed guard hook in place', () => {
+      seedStaleConfig();
+      const hookPath = path.join(dir, '.claude', 'hooks', 'secretless-guard.sh');
+      const before = fs.readFileSync(hookPath, 'utf-8');
+
+      const result = init(dir);
+
+      const after = fs.readFileSync(hookPath, 'utf-8');
+      expect(after).not.toBe(before);
+      expect(result.hookRefreshed).toBe(true);
+      expect(result.filesModified).toContain('.claude/hooks/secretless-guard.sh');
+      // The refreshed hook now exempts templates and still blocks real env files.
+      expect(runHook(hookPath, '.env.example')).toBe(false);
+      expect(runHook(hookPath, '.env')).toBe(true);
+    });
+
+    it('migrated config equals a config initialized fresh', () => {
+      seedStaleConfig();
+      init(dir);
+      const migrated = new Set<string>(
+        JSON.parse(fs.readFileSync(path.join(dir, '.claude', 'settings.json'), 'utf-8')).permissions.deny,
+      );
+
+      const fresh = tmpDir();
+      try {
+        init(fresh);
+        const pristine = new Set<string>(
+          JSON.parse(fs.readFileSync(path.join(fresh, '.claude', 'settings.json'), 'utf-8')).permissions.deny,
+        );
+        expect(migrated).toEqual(pristine);
+      } finally {
+        cleanup(fresh);
+      }
+    });
+
+    it('is a no-op on an already-current config (no churn on re-run)', () => {
+      init(dir);                 // first run: now current
+      const result = init(dir);  // second run
+      expect(result.denyRulesRemoved).toBe(0);
+      expect(result.denyRulesAdded).toBe(0);
+      expect(result.hookRefreshed).toBe(false);
+      expect(result.filesModified).not.toContain('.claude/settings.json');
     });
   });
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -69,7 +69,36 @@ interface InitResult {
    * "Added 21 deny patterns" vs "Already up to date".
    */
   denyRulesAdded: number;
+  /**
+   * Deprecated deny rules pruned during this `init` invocation (migration).
+   * Non-zero when an older config carried a broad glob (e.g. `Read(.env*)`)
+   * that newer versions replaced with enumerated rules. Lets `runInit` report
+   * "removed N deprecated pattern(s)" so a re-run isn't a silent no-op.
+   */
+  denyRulesRemoved: number;
+  /**
+   * True when the managed guard hook (`.claude/hooks/secretless-guard.sh`) was
+   * rewritten this run because its content was stale relative to the version
+   * `init` generates. Older `init` only wrote the hook when absent, so an
+   * outdated hook would persist across upgrades.
+   */
+  hookRefreshed: boolean;
 }
+
+/**
+ * Deny rules that older versions of `init` generated but newer versions no
+ * longer do — `init` prunes these on every run so an upgrade actually migrates
+ * an existing `.claude/settings.json` instead of leaving stale rules in place.
+ *
+ * `Read(.env*)` / `Grep(*.env*)`: broad globs replaced (0.18.1, #82) by an
+ * enumerated real-env-file list so committed templates (`.env.example` etc.)
+ * are no longer blocked. The enumerated replacements are re-added in the same
+ * run, so pruning here never leaves a real env file unprotected.
+ */
+export const DEPRECATED_DENY_RULES: readonly string[] = [
+  'Read(.env*)',
+  'Grep(*.env*)',
+];
 
 /**
  * Initialize Secretless protections for the project.
@@ -84,6 +113,8 @@ export function init(projectDir: string): InitResult {
     secretsFound: 0,
     denyRulesTotal: 0,
     denyRulesAdded: 0,
+    denyRulesRemoved: 0,
+    hookRefreshed: false,
   };
 
   // Detect AI tools
@@ -148,11 +179,20 @@ function configureClaudeCode(projectDir: string, result: InitResult): void {
     projectCustomRules = loadCustomRules(projectDir);
   } catch { /* handled later in deny rules section */ }
 
-  // 1. Install PreToolUse hook
+  // 1. Install (or refresh) the PreToolUse guard hook. The hook is a managed
+  // file we own — older `init` only wrote it when absent, so an outdated hook
+  // (e.g. one without the template-exempt arm shipped in 0.18.1) would survive
+  // an upgrade. Regenerate and compare: write only when the content differs, so
+  // a fresh project Creates it and an upgraded project Modifies it in place.
   const hookPath = path.join(hooksDir, 'secretless-guard.sh');
+  const desiredHook = generateClaudeHookScript(projectCustomRules);
   if (!fs.existsSync(hookPath)) {
-    fs.writeFileSync(hookPath, generateClaudeHookScript(projectCustomRules), { mode: 0o755 });
+    fs.writeFileSync(hookPath, desiredHook, { mode: 0o755 });
     result.filesCreated.push('.claude/hooks/secretless-guard.sh');
+  } else if (fs.readFileSync(hookPath, 'utf-8') !== desiredHook) {
+    fs.writeFileSync(hookPath, desiredHook, { mode: 0o755 });
+    result.filesModified.push('.claude/hooks/secretless-guard.sh');
+    result.hookRefreshed = true;
   }
 
   // 2. Update settings.json with hook config and deny rules
@@ -316,7 +356,29 @@ function configureClaudeCode(projectDir: string, result: InitResult): void {
       added++;
     }
   }
+
+  // Migration: prune deprecated rules an older `init` generated but the current
+  // version no longer does (e.g. the broad `Read(.env*)` glob replaced above by
+  // the enumerated list). Done AFTER the add loop so the enumerated replacements
+  // are already present — pruning never leaves a real env file unprotected. Skip
+  // a deprecated rule if it's somehow also a current rule (none are today).
+  const deprecated = new Set(
+    DEPRECATED_DENY_RULES.filter(r => !allDenyRules.includes(r)),
+  );
+  let removed = 0;
+  if (deprecated.size > 0) {
+    const before = settings.permissions.deny.length;
+    settings.permissions.deny = settings.permissions.deny.filter(
+      (r: string) => !deprecated.has(r),
+    );
+    removed = before - settings.permissions.deny.length;
+  }
+
+  if ((added > 0 || removed > 0) && !result.filesModified.includes('.claude/settings.json')) {
+    result.filesModified.push('.claude/settings.json');
+  }
   result.denyRulesAdded += added;
+  result.denyRulesRemoved += removed;
   result.denyRulesTotal = settings.permissions.deny.length;
 
   writeJsonFile(settingsPath, settings);


### PR DESCRIPTION
Two "Fix Our Own Tools First" bugs surfaced while propagating the 0.18.1 env-template fix across the workspace.

## 1. `init` was additive-only (no migration)
Re-running `init` after a CLI upgrade appended new deny rules and wrote the guard hook only when absent — so an already-initialized project kept the broad `Read(.env*)` / `Grep(*.env*)` globs and a stale `secretless-guard.sh`, re-blocking `.env.example` while `init` reported "Already up to date". (Discovered when 4 workspace repos didn't migrate via `init` and had to be hand-fixed.)

**Fix:** `init` prunes a `DEPRECATED_DENY_RULES` list *after* re-adding the enumerated rules (never leaves a real env file unprotected), and regenerates the managed guard hook in place when stale. Output reports `removed N deprecated patterns` + `(refreshed to current version)`; an already-current config is still a clean no-op. Migrated config is asserted equal to a fresh `init`.

## 2. `secretless-ai env` could break the whole shell
Stored names allow `-` (e.g. `vault-name`), but a shell identifier can't — so `export vault-name='…'` made the shell reject the entire `eval "$(secretless-ai env)"`, printing `export: not valid in this context` on **every** command in profiles using the eval hook, and dropping all other secrets with it.

**Fix:** `env` skips names that aren't valid POSIX shell identifiers (matching the validation `import` already applies), exports the rest, and surfaces skipped names as a harmless leading shell comment. No secret value is exposed. New API: `isValidShellIdentifier`.

+8 regression tests (1100 → 1108). Build clean.