### PR TITLE
feat(cli): honor SECRETLESS_CLI_PREFIX in help, banner, hints, and secret/scope usage (#191)

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -14,11 +14,12 @@ import * as os from 'os';
 
 const CLI_PATH = path.resolve(__dirname, '..', 'dist', 'cli.js');
 
-function runCli(args: string[], opts: { cwd?: string } = {}): string {
+function runCli(args: string[], opts: { cwd?: string; env?: NodeJS.ProcessEnv } = {}): string {
   return execFileSync(process.execPath, [CLI_PATH, ...args], {
     encoding: 'utf-8',
     stdio: ['pipe', 'pipe', 'pipe'],
     cwd: opts.cwd,
+    env: opts.env ?? process.env,
   });
 }
 
@@ -64,6 +65,54 @@ describe('cli --help handling', () => {
     try {
       const out = runCli(['scan', '-h'], { cwd: tmp });
       expect(out).toMatch(/Secretless v/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('SECRETLESS_CLI_PREFIX rebrands citations + suppresses banner (#191)', () => {
+  const hasBuild = fs.existsSync(CLI_PATH);
+  const itIfBuilt = hasBuild ? it : it.skip;
+
+  itIfBuilt('UNSET: help shows native `npx secretless-ai` citations + banner', () => {
+    // Default behavior must be identical to before the env var existed.
+    const env = { ...process.env };
+    delete env.SECRETLESS_CLI_PREFIX;
+    const out = runCli(['--help'], { env });
+    expect(out).toMatch(/Secretless v/);
+    expect(out).toMatch(/npx secretless-ai scan/);
+  });
+
+  itIfBuilt('SET: help rebrands citations to the prefix and drops the banner', () => {
+    const env = { ...process.env, SECRETLESS_CLI_PREFIX: 'opena2a secrets' };
+    const out = runCli(['--help'], { env });
+    // Citations now read as the host command path.
+    expect(out).toMatch(/opena2a secrets scan/);
+    expect(out).toMatch(/opena2a secrets init/);
+    // No standalone secretless command citations leak through. The
+    // `https://opena2a.org/secretless-ai` URL is a product link, not a command
+    // citation, so we match the command forms specifically: `npx secretless-ai`
+    // and bare `secretless-ai <verb>`.
+    expect(out).not.toMatch(/npx secretless-ai/);
+    expect(out).not.toMatch(/^\s*secretless-ai\s/m);
+    // Brand+version banner is suppressed under the host umbrella; tagline stays.
+    expect(out).not.toMatch(/Secretless v/);
+    expect(out).toMatch(/Keep secrets out of AI context\./);
+  });
+
+  itIfBuilt('SET: error hint rebrands to the prefix', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-prefix-hint-'));
+    try {
+      const res = spawnSync(process.execPath, [CLI_PATH, 'init', '--unknown'], {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        cwd: tmp,
+        env: { ...process.env, SECRETLESS_CLI_PREFIX: 'opena2a secrets' },
+      });
+      expect(res.status).toBe(2);
+      expect(res.stderr).toMatch(/Run `opena2a secrets init --help` for usage/);
+      expect(res.stderr).not.toMatch(/secretless-ai/);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -117,6 +117,78 @@ describe('SECRETLESS_CLI_PREFIX rebrands citations + suppresses banner (#191)', 
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });
+
+  itIfBuilt('SET: `secret` no-arg usage rebrands to the prefix, no bare citations', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-secret-prefix-'));
+    try {
+      const res = spawnSync(process.execPath, [CLI_PATH, 'secret'], {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        cwd: tmp,
+        env: { ...process.env, SECRETLESS_CLI_PREFIX: 'opena2a secrets' },
+      });
+      expect(res.status).toBe(0);
+      expect(res.stdout).toMatch(/Usage: opena2a secrets secret <set\|list\|get\|rm>/);
+      expect(`${res.stdout}${res.stderr}`).not.toMatch(/npx secretless-ai/);
+      expect(`${res.stdout}${res.stderr}`).not.toMatch(/(^|\s)secretless-ai\s/m);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  itIfBuilt('SET: `secret set` usage hint rebrands to the prefix, no bare citations', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-secret-set-prefix-'));
+    try {
+      const res = spawnSync(process.execPath, [CLI_PATH, 'secret', 'set'], {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        cwd: tmp,
+        env: { ...process.env, SECRETLESS_CLI_PREFIX: 'opena2a secrets' },
+      });
+      expect(res.status).toBe(1);
+      expect(`${res.stdout}${res.stderr}`).toMatch(/Usage: opena2a secrets secret set/);
+      expect(`${res.stdout}${res.stderr}`).not.toMatch(/npx secretless-ai/);
+      expect(`${res.stdout}${res.stderr}`).not.toMatch(/(^|\s)secretless-ai\s/m);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  itIfBuilt('SET: `scope` no-arg usage rebrands to the prefix, no bare citations', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-scope-prefix-'));
+    try {
+      const res = spawnSync(process.execPath, [CLI_PATH, 'scope'], {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        cwd: tmp,
+        env: { ...process.env, SECRETLESS_CLI_PREFIX: 'opena2a secrets' },
+      });
+      expect(res.status).toBe(0);
+      expect(res.stdout).toMatch(/Usage: opena2a secrets scope <discover\|check\|list\|reset>/);
+      expect(`${res.stdout}${res.stderr}`).not.toMatch(/npx secretless-ai/);
+      expect(`${res.stdout}${res.stderr}`).not.toMatch(/(^|\s)secretless-ai\s/m);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  itIfBuilt('SET: `scope reset` usage hint rebrands to the prefix, no bare citations', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-scope-reset-prefix-'));
+    try {
+      const res = spawnSync(process.execPath, [CLI_PATH, 'scope', 'reset'], {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        cwd: tmp,
+        env: { ...process.env, SECRETLESS_CLI_PREFIX: 'opena2a secrets' },
+      });
+      expect(res.status).toBe(1);
+      expect(`${res.stdout}${res.stderr}`).toMatch(/Usage: opena2a secrets scope reset/);
+      expect(`${res.stdout}${res.stderr}`).not.toMatch(/npx secretless-ai/);
+      expect(`${res.stdout}${res.stderr}`).not.toMatch(/(^|\s)secretless-ai\s/m);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('init / status reject unknown flags as dir path (regression: release-test 2026-05-12 P1)', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,7 @@
 
 import * as path from 'path';
 import type { TelemetryAction } from '@opena2a/cli-ui' with { 'resolution-mode': 'import' };
-import { VERSION } from './commands/utils';
+import { VERSION, CLI_BARE } from './commands/utils';
 // @opena2a/telemetry and @opena2a/cli-ui are pure ESM; this CLI is CommonJS,
 // so they're loaded via dynamic import() inside the async main().
 import { runInit, runScan, runStatus, runVerify, runDoctor } from './commands/core';
@@ -101,7 +101,7 @@ function rejectUnknownFlagAsDirArg(command: string, dirArg: string | undefined):
   if (dirArg && dirArg.startsWith('-')) {
     console.error(`  Unknown option: ${dirArg}`);
     console.error(`  \`${command}\` takes an optional directory path, not flags.`);
-    console.error(`  Run \`secretless-ai ${command} --help\` for usage.`);
+    console.error(`  Run \`${CLI_BARE} ${command} --help\` for usage.`);
     return false;
   }
   return true;
@@ -156,7 +156,7 @@ async function dispatch(args: string[], command: string | undefined): Promise<nu
       }
       if (unknownFlags.length > 0) {
         console.error(`  Warning: ignoring unknown flag${unknownFlags.length > 1 ? 's' : ''} ${unknownFlags.join(', ')}.`);
-        console.error('  Run `secretless-ai scan` for supported flags (--json, --show-placeholders, --min-confidence, --no-ignore, --include-tests, --explain).');
+        console.error(`  Run \`${CLI_BARE} scan\` for supported flags (--json, --show-placeholders, --min-confidence, --no-ignore, --include-tests, --explain).`);
       }
       const dirArg = positionalArgs[0];
       const projectDir = dirArg ? path.resolve(dirArg) : process.cwd();

--- a/src/commands/core.ts
+++ b/src/commands/core.ts
@@ -9,12 +9,17 @@ import { readBackendConfig } from '../backends/config';
 import { getDaemonStatus } from '../broker/daemon';
 import { getSessionStatus } from '../session/session-state';
 import { isDaemonInstalled } from '../session/install';
-import { VERSION, formatUptime, formatRemainingTime } from './utils';
+import { VERSION, IS_EMBEDDED, formatUptime, formatRemainingTime } from './utils';
 import { explainFinding, isEngineAvailable } from '../nanomind';
 import { c, divider } from './colors';
 
 export function runInit(projectDir: string): number {
-  console.log('\n  Secretless v' + VERSION);
+  // Suppress the standalone brand+version banner when embedded under a host CLI
+  // (SECRETLESS_CLI_PREFIX set) — it shows secretless's own version, which is
+  // misleading under the host's umbrella. Keep the tagline.
+  if (!IS_EMBEDDED) {
+    console.log('\n  Secretless v' + VERSION);
+  }
   console.log('  Keeping secrets out of AI\n');
 
   const result = init(projectDir);

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,107 +1,111 @@
-import { VERSION } from './utils';
+import { VERSION, CLI, IS_EMBEDDED } from './utils';
 
 export function printHelp(): void {
+  // When embedded under a host CLI (SECRETLESS_CLI_PREFIX set), suppress the
+  // standalone `Secretless v<version>` brand+version line — it shows
+  // secretless's own version, which is misleading under the host's umbrella.
+  // The tagline stays. Standalone keeps the banner exactly as before.
+  const banner = IS_EMBEDDED ? '' : `  Secretless v${VERSION}\n`;
   console.log(`
-  Secretless v${VERSION}
-  Keep secrets out of AI context.
+${banner}  Keep secrets out of AI context.
 
   Quick start:
-    npx secretless-ai scan       Find hardcoded credentials
-    npx secretless-ai init       Set up AI tool protections
-    npx secretless-ai verify     Confirm secrets are hidden from AI
+    ${CLI} scan       Find hardcoded credentials
+    ${CLI} init       Set up AI tool protections
+    ${CLI} verify     Confirm secrets are hidden from AI
 
   Usage:
-    npx secretless-ai init      Set up protections for your AI tools
-    npx secretless-ai scan      Scan config and source files for hardcoded secrets
-    npx secretless-ai status    Show protection status
-    npx secretless-ai verify    Verify keys are usable but hidden from AI (--all for full list)
-    npx secretless-ai doctor    Diagnose shell profile issues (--fix to auto-fix)
-    npx secretless-ai clean     Scan and redact credentials in transcripts
-    npx secretless-ai watch     Monitor transcripts in real-time
-    npx secretless-ai warm      Warm biometric session (Touch ID on macOS)
-    npx secretless-ai install   Install broker as login daemon (macOS)
+    ${CLI} init      Set up protections for your AI tools
+    ${CLI} scan      Scan config and source files for hardcoded secrets
+    ${CLI} status    Show protection status
+    ${CLI} verify    Verify keys are usable but hidden from AI (--all for full list)
+    ${CLI} doctor    Diagnose shell profile issues (--fix to auto-fix)
+    ${CLI} clean     Scan and redact credentials in transcripts
+    ${CLI} watch     Monitor transcripts in real-time
+    ${CLI} warm      Warm biometric session (Touch ID on macOS)
+    ${CLI} install   Install broker as login daemon (macOS)
 
   Secret Management:
-    npx secretless-ai secret set <NAME[=VALUE]>  Store a secret
-    npx secretless-ai secret list                List stored secret names
-    npx secretless-ai secret get <NAME>          Retrieve a secret value
-    npx secretless-ai secret get --force <NAME>  Retrieve in non-interactive contexts
-    npx secretless-ai secret rm <NAME>           Remove a secret
-    npx secretless-ai import <file>              Import secrets from .env file
-    npx secretless-ai import --detect            Auto-find and import .env files
-    npx secretless-ai run [--only K1,K2] -- <cmd>  Run with secrets injected
-    npx secretless-ai env [--only K1,K2]         Output export statements for shell
+    ${CLI} secret set <NAME[=VALUE]>  Store a secret
+    ${CLI} secret list                List stored secret names
+    ${CLI} secret get <NAME>          Retrieve a secret value
+    ${CLI} secret get --force <NAME>  Retrieve in non-interactive contexts
+    ${CLI} secret rm <NAME>           Remove a secret
+    ${CLI} import <file>              Import secrets from .env file
+    ${CLI} import --detect            Auto-find and import .env files
+    ${CLI} run [--only K1,K2] -- <cmd>  Run with secrets injected
+    ${CLI} env [--only K1,K2]         Output export statements for shell
 
   Project Setup:
-    npx secretless-ai setup              Set up secrets from .secretless manifest
-    npx secretless-ai setup --check      Check for missing required secrets (CI)
+    ${CLI} setup              Set up secrets from .secretless manifest
+    ${CLI} setup --check      Check for missing required secrets (CI)
 
   Custom Rules:
-    npx secretless-ai rules              List custom deny rules
-    npx secretless-ai rules init         Create .secretless-rules.yaml template
-    npx secretless-ai rules test <pat>   Test a pattern (see generated deny rules)
+    ${CLI} rules              List custom deny rules
+    ${CLI} rules init         Create .secretless-rules.yaml template
+    ${CLI} rules test <pat>   Test a pattern (see generated deny rules)
 
   Git Protection:
-    npx secretless-ai hook install       Install pre-commit secret scanner
-    npx secretless-ai hook uninstall     Remove pre-commit hook
-    npx secretless-ai hook status        Check hook installation status
+    ${CLI} hook install       Install pre-commit secret scanner
+    ${CLI} hook uninstall     Remove pre-commit hook
+    ${CLI} hook status        Check hook installation status
 
   MCP Protection:
-    npx secretless-ai protect-mcp [--backend TYPE]  Encrypt MCP server secrets
-    npx secretless-ai mcp-status     Show MCP protection status
-    npx secretless-ai mcp-unprotect  Restore original MCP configs
+    ${CLI} protect-mcp [--backend TYPE]  Encrypt MCP server secrets
+    ${CLI} mcp-status     Show MCP protection status
+    ${CLI} mcp-unprotect  Restore original MCP configs
 
   Backend Management:
-    npx secretless-ai backend             Show current backend status
-    npx secretless-ai backend set <type>  Set backend (local, keychain, 1password, vault, or gcp-sm)
-    npx secretless-ai backend list        List all entries in current backend
-    npx secretless-ai backend purge       Delete all entries (--prefix mcp|secret, --yes)
-    npx secretless-ai migrate             Migrate secrets between backends
+    ${CLI} backend             Show current backend status
+    ${CLI} backend set <type>  Set backend (local, keychain, 1password, vault, or gcp-sm)
+    ${CLI} backend list        List all entries in current backend
+    ${CLI} backend purge       Delete all entries (--prefix mcp|secret, --yes)
+    ${CLI} migrate             Migrate secrets between backends
 
   Scope Discovery:
-    npx secretless-ai scope discover <name>  Discover permissions and save baseline
-    npx secretless-ai scope check <name>     Re-check and compare to baseline
-    npx secretless-ai scope list             Show all stored baselines
-    npx secretless-ai scope reset <name>     Clear baseline for re-baseline
+    ${CLI} scope discover <name>  Discover permissions and save baseline
+    ${CLI} scope check <name>     Re-check and compare to baseline
+    ${CLI} scope list             Show all stored baselines
+    ${CLI} scope reset <name>     Clear baseline for re-baseline
 
   Shell History:
-    npx secretless-ai scan --history         Scan shell history for credentials
-    npx secretless-ai scan-history           Scan shell history for credentials
-    npx secretless-ai clean-history          Redact credentials in shell history
-    npx secretless-ai clean-history --dry-run  Preview without modifying
+    ${CLI} scan --history         Scan shell history for credentials
+    ${CLI} scan-history           Scan shell history for credentials
+    ${CLI} clean-history          Redact credentials in shell history
+    ${CLI} clean-history --dry-run  Preview without modifying
 
   Identity Vault (requires @opena2a/aim-core):
-    npx secretless-ai vault init                    Initialize vault with agent identity
-    npx secretless-ai vault register <ns> [opts]    Register a credential in a namespace
-    npx secretless-ai vault list                    List stored credentials (metadata only)
-    npx secretless-ai vault rotate <ns> [opts]      Rotate a credential to a new value
-    npx secretless-ai vault revoke <ns>             Revoke a namespace and delete credential
-    npx secretless-ai vault exec <ns> -- <cmd>      Run command with vault credential injected
-    npx secretless-ai vault audit                   Show vault audit log
-    npx secretless-ai vault scan [dir]              Scan for credentials to migrate
-    npx secretless-ai vault test                    Run vault self-test
-    npx secretless-ai vault migrate [opts]          Migrate from SecretStore or .env file
+    ${CLI} vault init                    Initialize vault with agent identity
+    ${CLI} vault register <ns> [opts]    Register a credential in a namespace
+    ${CLI} vault list                    List stored credentials (metadata only)
+    ${CLI} vault rotate <ns> [opts]      Rotate a credential to a new value
+    ${CLI} vault revoke <ns>             Revoke a namespace and delete credential
+    ${CLI} vault exec <ns> -- <cmd>      Run command with vault credential injected
+    ${CLI} vault audit                   Show vault audit log
+    ${CLI} vault scan [dir]              Scan for credentials to migrate
+    ${CLI} vault test                    Run vault self-test
+    ${CLI} vault migrate [opts]          Migrate from SecretStore or .env file
 
   Credential Broker:
-    npx secretless-ai broker start        Start the credential broker daemon
-    npx secretless-ai broker stop         Stop the running broker daemon
-    npx secretless-ai broker status       Show broker daemon status
+    ${CLI} broker start        Start the credential broker daemon
+    ${CLI} broker stop         Stop the running broker daemon
+    ${CLI} broker status       Show broker daemon status
 
   Session Management:
-    npx secretless-ai warm                Warm biometric session (Touch ID)
-    npx secretless-ai warm --ttl 10m      Set session TTL (300, 5m, 1h, 1d)
-    npx secretless-ai warm --no-broker    Skip auto-starting the broker daemon
-    npx secretless-ai install             Install broker as macOS login daemon
-    npx secretless-ai install uninstall   Remove login daemon
-    npx secretless-ai install status      Check daemon installation status
+    ${CLI} warm                Warm biometric session (Touch ID)
+    ${CLI} warm --ttl 10m      Set session TTL (300, 5m, 1h, 1d)
+    ${CLI} warm --no-broker    Skip auto-starting the broker daemon
+    ${CLI} install             Install broker as macOS login daemon
+    ${CLI} install uninstall   Remove login daemon
+    ${CLI} install status      Check daemon installation status
 
   Claude Code Integration:
-    npx secretless-ai hook --check-only   Session check (for PreToolUse hooks)
+    ${CLI} hook --check-only   Session check (for PreToolUse hooks)
 
   Cache (reduces OS auth prompts for keychain/1password):
-    npx secretless-ai cache               Show cache status
-    npx secretless-ai cache ttl <dur>     Set TTL (5m, 1h, 1d, off)
-    npx secretless-ai cache clear         Clear cached secrets
+    ${CLI} cache               Show cache status
+    ${CLI} cache ttl <dur>     Set TTL (5m, 1h, 1d, off)
+    ${CLI} cache clear         Clear cached secrets
 
   Clean options:
     --dry-run     Report findings without redacting
@@ -116,10 +120,10 @@ export function printHelp(): void {
     uninstall     Remove LaunchAgent
 
   Other:
-    npx secretless-ai feedback        Star, file an issue, or join the discussion
-    npx secretless-ai ignore <path>   Append a path or glob to .secretlessignore
-    npx secretless-ai ignore --pattern '*.golden.txt'
-    npx secretless-ai diff [<ref>]    Show how secretless-managed files have changed
+    ${CLI} feedback        Star, file an issue, or join the discussion
+    ${CLI} ignore <path>   Append a path or glob to .secretlessignore
+    ${CLI} ignore --pattern '*.golden.txt'
+    ${CLI} diff [<ref>]    Show how secretless-managed files have changed
                                        vs a git ref (default HEAD)
     .secretlessignore                  gitignore-style file at repo root; default-ignore
                                        covers test/, __tests__/, examples/, e2e/, etc.

--- a/src/commands/scope.ts
+++ b/src/commands/scope.ts
@@ -1,6 +1,7 @@
 import { SecretStore } from '../secret-store';
 import { resolveBackendType } from '../backends/config';
 import { discoverScope, listBaselines, resetBaseline, loadBaseline, detectProvider } from '../scope';
+import { CLI_BARE } from './utils';
 
 export async function runScope(args: string[]): Promise<number> {
   const subcommand = args[0];
@@ -9,7 +10,7 @@ export async function runScope(args: string[]): Promise<number> {
     case 'discover': {
       const credentialName = args[1];
       if (!credentialName) {
-        console.error('\n  Usage: secretless-ai scope discover <credential-name>\n');
+        console.error(`\n  Usage: ${CLI_BARE} scope discover <credential-name>\n`);
         console.log('  Reads the credential value from the secret store and discovers its scope.\n');
         return 1;
       }
@@ -84,7 +85,7 @@ export async function runScope(args: string[]): Promise<number> {
     case 'check': {
       const credentialName = args[1];
       if (!credentialName) {
-        console.error('\n  Usage: secretless-ai scope check <credential-name>\n');
+        console.error(`\n  Usage: ${CLI_BARE} scope check <credential-name>\n`);
         console.log('  Re-checks scope and compares to stored baseline.\n');
         return 1;
       }
@@ -92,7 +93,7 @@ export async function runScope(args: string[]): Promise<number> {
       const baseline = loadBaseline(credentialName);
       if (!baseline) {
         console.error(`\n  No baseline found for "${credentialName}".`);
-        console.log('  Run "secretless-ai scope discover" first to create a baseline.\n');
+        console.log(`  Run "${CLI_BARE} scope discover" first to create a baseline.\n`);
         return 1;
       }
 
@@ -124,7 +125,7 @@ export async function runScope(args: string[]): Promise<number> {
             console.log(`    + ${p}`);
           }
           console.log(`\n  WARNING: Credential scope has expanded since baseline.`);
-          console.log(`  Run 'secretless-ai scope discover ${credentialName}' to update baseline.\n`);
+          console.log(`  Run '${CLI_BARE} scope discover ${credentialName}' to update baseline.\n`);
         } else if (result.removed.length > 0) {
           console.log(`  Contracted: -${result.removed.length} removed permissions`);
           for (const p of result.removed) {
@@ -145,7 +146,7 @@ export async function runScope(args: string[]): Promise<number> {
       const baselines = listBaselines();
       if (baselines.length === 0) {
         console.log('\n  No scope baselines stored.\n');
-        console.log('  Run "secretless-ai scope discover <credential-name>" to create one.\n');
+        console.log(`  Run "${CLI_BARE} scope discover <credential-name>" to create one.\n`);
         return 0;
       }
 
@@ -163,7 +164,7 @@ export async function runScope(args: string[]): Promise<number> {
     case 'reset': {
       const credentialName = args[1];
       if (!credentialName) {
-        console.error('\n  Usage: secretless-ai scope reset <credential-name>\n');
+        console.error(`\n  Usage: ${CLI_BARE} scope reset <credential-name>\n`);
         return 1;
       }
 
@@ -181,7 +182,7 @@ export async function runScope(args: string[]): Promise<number> {
       // No subcommand is an exploration, not an error — show usage cleanly and succeed
       // (mirrors the `secret` fix in #80). Reserve the error for a real unrecognized token.
       const usage = () => {
-        console.log('  Usage: secretless-ai scope <discover|check|list|reset>\n');
+        console.log(`  Usage: ${CLI_BARE} scope <discover|check|list|reset>\n`);
         console.log('  Commands:');
         console.log('    discover <name>   Discover permissions and save baseline');
         console.log('    check <name>      Re-check and compare to baseline');

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import { SecretStore } from '../secret-store';
 import { getShellHookLine, SHELL_HOOK_MARKER } from '../env';
+import { CLI, CLI_BARE } from './utils';
 
 /**
  * Ensure the shell profile has the eval hook for auto-loading secrets.
@@ -51,7 +52,7 @@ export async function runSecret(args: string[]): Promise<number> {
     case 'set': {
       const nameArg = args[1];
       if (!nameArg) {
-        console.error('\n  Usage: secretless-ai secret set <NAME[=VALUE]>\n');
+        console.error(`\n  Usage: ${CLI_BARE} secret set <NAME[=VALUE]>\n`);
         return 1;
       }
 
@@ -65,7 +66,7 @@ export async function runSecret(args: string[]): Promise<number> {
         const value = nameArg.slice(eqIdx + 1);
         if (!value) {
           console.error('  Error: no value provided.');
-          console.error('  Usage: secretless-ai secret set NAME=VALUE\n');
+          console.error(`  Usage: ${CLI_BARE} secret set NAME=VALUE\n`);
           return 1;
         }
         if (!SECRET_NAME_RE.test(name)) {
@@ -94,8 +95,8 @@ export async function runSecret(args: string[]): Promise<number> {
       const value = await readSecretFromStdin(name);
       if (value === null) {
         console.error('  Error: no value provided.');
-        console.error('  Usage: secretless-ai secret set NAME=VALUE');
-        console.error('  Or:    echo "value" | secretless-ai secret set NAME\n');
+        console.error(`  Usage: ${CLI_BARE} secret set NAME=VALUE`);
+        console.error(`  Or:    echo "value" | ${CLI_BARE} secret set NAME\n`);
         return 1;
       }
       const store = new SecretStore();
@@ -116,8 +117,8 @@ export async function runSecret(args: string[]): Promise<number> {
         const names = await store.listSecrets();
         if (names.length === 0) {
           console.log('\n  No secrets stored.');
-          console.log('  Store one:    npx secretless-ai secret set MY_KEY=my_value');
-          console.log('  Import .env:  npx secretless-ai import .env\n');
+          console.log(`  Store one:    ${CLI} secret set MY_KEY=my_value`);
+          console.log(`  Import .env:  ${CLI} import .env\n`);
           return 0;
         }
         console.log(`\n  ${names.length} secret(s):\n`);
@@ -136,7 +137,7 @@ export async function runSecret(args: string[]): Promise<number> {
       const positional = args.slice(1).filter(a => !a.startsWith('--'));
       const name = positional[0];
       if (!name) {
-        console.error('\n  Usage: secretless-ai secret get <NAME>\n');
+        console.error(`\n  Usage: ${CLI_BARE} secret get <NAME>\n`);
         return 1;
       }
 
@@ -146,10 +147,10 @@ export async function runSecret(args: string[]): Promise<number> {
         console.error('  AI tools capture stdout, which would expose the secret in their context.');
         console.error('');
         console.error('  To inject secrets into a command:');
-        console.error('    npx secretless-ai run -- <command>');
+        console.error(`    ${CLI} run -- <command>`);
         console.error('');
         console.error('  To force output (e.g. piping to clipboard):');
-        console.error('    npx secretless-ai secret get <NAME> --force');
+        console.error(`    ${CLI} secret get <NAME> --force`);
         return 1;
       }
 
@@ -177,7 +178,7 @@ export async function runSecret(args: string[]): Promise<number> {
     case 'delete': {
       const name = args[1];
       if (!name) {
-        console.error('\n  Usage: secretless-ai secret rm <NAME>\n');
+        console.error(`\n  Usage: ${CLI_BARE} secret rm <NAME>\n`);
         return 1;
       }
       const store = new SecretStore();
@@ -199,11 +200,11 @@ export async function runSecret(args: string[]): Promise<number> {
       // No subcommand is an exploration, not an error — show usage cleanly and succeed
       // (#80). Reserve the "Unknown secret command" error for a real unrecognized token.
       if (subcommand === undefined) {
-        console.log('\n  Usage: secretless-ai secret <set|list|get|rm> [args]\n');
+        console.log(`\n  Usage: ${CLI_BARE} secret <set|list|get|rm> [args]\n`);
         return 0;
       }
       console.error(`\n  Unknown secret command: ${subcommand}`);
-      console.log('  Usage: secretless-ai secret <set|list|get|rm> [args]\n');
+      console.log(`  Usage: ${CLI_BARE} secret <set|list|get|rm> [args]\n`);
       return 1;
   }
 }

--- a/src/commands/utils.ts
+++ b/src/commands/utils.ts
@@ -1,6 +1,31 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 export const VERSION: string = require('../../package.json').version;
 
+/**
+ * Command-invocation prefix used in all user-facing citations (help text,
+ * error hints). Defaults to `npx secretless-ai` — the canonical standalone
+ * invocation. When secretless is embedded under another CLI (e.g. opena2a-cli
+ * exposes it as `opena2a secrets <verb>`), that host sets SECRETLESS_CLI_PREFIX
+ * to its own full command path so citations render natively (`opena2a secrets
+ * scan`) instead of leaking the standalone `npx secretless-ai scan`.
+ */
+export const CLI: string = process.env.SECRETLESS_CLI_PREFIX ?? 'npx secretless-ai';
+
+/**
+ * Bare form of the prefix for terse error hints (no `npx` wrapper). When
+ * SECRETLESS_CLI_PREFIX is set we reuse it verbatim; otherwise we fall back to
+ * the bare binary name `secretless-ai`.
+ */
+export const CLI_BARE: string = process.env.SECRETLESS_CLI_PREFIX ?? 'secretless-ai';
+
+/**
+ * True when secretless is running embedded under a host CLI. Used to suppress
+ * the standalone `Secretless v<version>` brand+version banner, which would be
+ * misleading under the host's umbrella (it shows secretless's own version, not
+ * the host's).
+ */
+export const IS_EMBEDDED: boolean = process.env.SECRETLESS_CLI_PREFIX != null;
+
 /** Format seconds into a human-readable uptime string. */
 export function formatUptime(seconds: number): string {
   if (seconds < 60) return `${seconds}s`;


### PR DESCRIPTION
Part of upstream #191 (opena2a-org/opena2a). secretless is reached as `opena2a secrets <verb>`, but `opena2a secrets --help` leaked `npx secretless-ai <verb>` citations and the `Secretless v<version>` banner. secretless didn't read any prefix env var.

## Changes
- New `SECRETLESS_CLI_PREFIX` env var. Helper (`CLI` / `CLI_BARE` / `IS_EMBEDDED`) is the single source of truth: when set, all `npx secretless-ai <verb>` and bare `secretless-ai <verb>` command citations render `${prefix} <verb>` (e.g. `opena2a secrets scan`); when unset, byte-identical to today.
- Covers `commands/help.ts`, `commands/core.ts` (init banner), `cli.ts` error hints, and the `secret` / `scope` subcommand usage strings.
- The decorative `Secretless v<version>` banner is suppressed when embedded (it would show secretless's own version under the opena2a umbrella); the tagline stays.

## Verification
`SECRETLESS_CLI_PREFIX='opena2a secrets' node dist/cli.js --help` → `opena2a secrets …`, zero `secretless-ai` citations, no `Secretless v` banner. Unset is identical to before (existing banner tests still pass). Full suite green (1123). Written-file content (git hook script, settings allowlist globs) intentionally keeps the real binary name so it resolves standalone.