### PR TITLE
feat: disclose scope on 'secret list' and 'verify'

### DIFF
--- a/src/commands/core.ts
+++ b/src/commands/core.ts
@@ -405,6 +405,12 @@ export function runStatus(projectDir: string): number {
 export function runVerify(projectDir: string, showAll = false): number {
   console.log(`\n  ${c.boldWhite('Secretless Verify')}\n`);
 
+  // Scope disclosure: verify spans more than the current project — it reads the
+  // current shell's env vars (process-global) and your global AI config under
+  // ~/.claude, not just files in this directory. State that so a green PASS is
+  // never mistaken for "this project only".
+  console.log(`  ${c.dim('Scope: this project + global AI config (~/.claude) + current-shell env vars')}\n`);
+
   const result = verify(projectDir);
 
   // Show env var availability

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -115,8 +115,14 @@ export async function runSecret(args: string[]): Promise<number> {
       const store = new SecretStore();
       try {
         const names = await store.listSecrets();
+        // Scope disclosure: the store is machine-global (one backend per machine
+        // config), not project-scoped — running `secret list` in any directory
+        // shows the same secrets. Say so, and name the backend, so a user is
+        // never unsure whether they are looking at project or global state.
+        const scopeNote = `  Scope: global (${store.backendName} backend) — shared across all projects on this machine`;
         if (names.length === 0) {
           console.log('\n  No secrets stored.');
+          console.log(scopeNote);
           console.log(`  Store one:    ${CLI} secret set MY_KEY=my_value`);
           console.log(`  Import .env:  ${CLI} import .env\n`);
           return 0;
@@ -125,6 +131,8 @@ export async function runSecret(args: string[]): Promise<number> {
         for (const n of names) {
           console.log(`    ${n}`);
         }
+        console.log();
+        console.log(scopeNote);
         console.log();
         return 0;
       } catch (err) {

--- a/src/secret-store.test.ts
+++ b/src/secret-store.test.ts
@@ -111,4 +111,22 @@ describe('SecretStore', () => {
     const mcpResolved = await backend.resolve('mcp');
     expect(Object.keys(mcpResolved)).toHaveLength(0);
   });
+
+  describe('backendName (scope disclosure)', () => {
+    it('exposes the active backend name', () => {
+      expect(store.backendName).toBe('local');
+    });
+
+    it('unwraps the cache decorator so disclosure shows the real backend', () => {
+      const cached = new SecretStore({
+        backend: {
+          name: 'cached(keychain-macos)',
+          resolve: async () => ({}),
+          store: async () => {},
+          delete: async () => false,
+        },
+      });
+      expect(cached.backendName).toBe('keychain-macos');
+    });
+  });
 });

--- a/src/secret-store.ts
+++ b/src/secret-store.ts
@@ -36,6 +36,17 @@ export class SecretStore {
     this.backend = createBackend(backendType);
   }
 
+  /**
+   * Human-readable name of the active backend (e.g. `local`, `keychain-macos`,
+   * `1password`). Surfaced so commands can disclose WHERE secrets live — the
+   * store is machine-global (one backend per machine config), not per-project.
+   */
+  get backendName(): string {
+    // Unwrap the cache decorator's `cached(<inner>)` name — the in-memory cache
+    // layer is an implementation detail, not a backend the user chose.
+    return this.backend.name.replace(/^cached\((.*)\)$/, '$1');
+  }
+
   /** Store a secret by name. */
   async setSecret(name: string, value: string): Promise<void> {
     validateSecretName(name);


### PR DESCRIPTION
## What

Both commands operate beyond the current directory without saying so (`todo/2026-06-08-release-test-cosmetics-cli-cross-tool.md` item 3):

- **`secret list`** reads a machine-global store (one backend per machine config), so the same secrets appear in any directory. Adds `Scope: global (<backend> backend) — shared across all projects on this machine`, naming the backend via a new `SecretStore.backendName` getter (unwraps the `cached(<inner>)` decorator so the disclosure shows the real backend, e.g. `keychain-macos` not `cached(keychain-macos)`).
- **`verify`** also reads the current shell's env vars and the global AI config under `~/.claude`, not just this project. Adds `Scope: this project + global AI config (~/.claude) + current-shell env vars` under the header so a green PASS is not mistaken for project-only.

## Safety

Purely additive output; no detection/scoring change. The disclosure prints only the backend **type** name — never secret values, names, or paths (verified in the walkthrough).

## Testing

tsc clean; 1125 tests pass (incl. new `backendName` unit tests for the clean name + cache-decorator unwrap); new-user walkthrough confirms both notes render, exit 0, no value leak. Rides next secretless publish.