### PR TITLE
docs: cross-link aicomply in Links section

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Security issues: `security@opena2a.org` (coordinated disclosure, response within
 - [Demos](https://opena2a.org/demos)
 - [OpenA2A CLI](https://github.com/opena2a-org/opena2a)
 - [Credential patterns library](https://www.npmjs.com/package/@opena2a/credential-patterns)
+- [aicomply](https://github.com/opena2a-org/aicomply) — inline PII and credential classification for agent I/O at runtime, the complement to protecting credentials at rest
 
 Part of the [OpenA2A](https://opena2a.org) security platform.
 


### PR DESCRIPTION
Adds a one-line cross-link to [aicomply](https://github.com/opena2a-org/aicomply) in the README `## Links` section.

aicomply is the inline PII / credential / regulated-data classifier for agent I/O (shipped on npm `@opena2a/aicomply`, PyPI `aicomply`, and as `opena2a comply`). Framing for the secretless audience: Secretless protects credentials **at rest** (keychain/vault/encrypted file, decrypt at spawn); aicomply classifies PII and credentials **in the live I/O stream** before it reaches an LLM — the runtime complement.

Docs-only, progressive-disclosure (bottom-of-README Links). No code, no version bump.

Part of the aicomply visibility work (org plan `todo/2026-06-18-aicomply-adoption-and-pypi-port.md`, Step 2 cross-links).