### PR TITLE
broker: strict-parse grant request bodies; atx-verify 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.18.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opena2a/atx-verify": "0.2.0",
+        "@opena2a/atx-verify": "0.3.0",
         "@opena2a/cli-ui": "0.4.0",
         "@opena2a/credential-patterns": "0.1.2",
         "@opena2a/telemetry": "0.1.2"
@@ -121,9 +121,9 @@
       }
     },
     "node_modules/@opena2a/atx-verify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@opena2a/atx-verify/-/atx-verify-0.2.0.tgz",
-      "integrity": "sha512-tq1mZTgDLhEm0Gyhh0jqtcon1iBQbwYNxGPly3uT/SQoRVHXMRNCx8b9zmBFKgSwe8Q7NBrLjOHySGuKCX/ucg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@opena2a/atx-verify/-/atx-verify-0.3.0.tgz",
+      "integrity": "sha512-2kRybBSfQv128jhcmfgZSpG0y9uK989pdgL86dCIiqEnj5/YXLpoYjrF0ijHgtpfJdhPekwaprnUbDXi1htqhw==",
       "license": "Apache-2.0",
       "dependencies": {
         "canonicalize": "2.1.0"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@opena2a/aim-core": ">=0.2.0"
   },
   "dependencies": {
-    "@opena2a/atx-verify": "0.2.0",
+    "@opena2a/atx-verify": "0.3.0",
     "@opena2a/cli-ui": "0.4.0",
     "@opena2a/credential-patterns": "0.1.2",
     "@opena2a/telemetry": "0.1.2"

--- a/src/broker/aap-conformance.test.ts
+++ b/src/broker/aap-conformance.test.ts
@@ -115,7 +115,9 @@ function brokerPost(
   body: unknown,
 ): Promise<{ status: number; text: string; json: any }> {
   return new Promise((resolve, reject) => {
-    const data = JSON.stringify(body);
+    // A string body is sent verbatim (raw-wire tests: duplicate-member smuggles
+    // must reach the broker byte-exact; JSON.stringify would collapse them).
+    const data = typeof body === 'string' ? body : JSON.stringify(body);
     const req = http.request(
       {
         socketPath,
@@ -321,6 +323,34 @@ describe('AAP v1 conformance: no credential or backend identifier in the agent c
     expect(res.status).toBe(403);
     expect(res.json).toEqual({ error: 'denied' });
     expect(ordersApi.sawAuthorization).toBeUndefined();
+  });
+
+  it('refuses a grant body carrying a duplicate-member smuggle inside the ATX', async () => {
+    const atx = (globalThis as any).__aapTestAtx;
+    const agentRequest = {
+      agentId: 'aim_orders_reader',
+      atx,
+      grant: 'grant://orders-db',
+      operation: { method: 'GET', path: '/orders', query: { customer: 'c-123' } },
+    };
+    // Inject a fold-colliding decoy BEFORE the signed trustLevel, byte-level:
+    // JSON.parse is last-wins, so without the raw strict parse the broker would
+    // see only the signed value and verify a credential whose bytes mean
+    // something else to a case-insensitive first-wins consumer (the RFC 8259
+    // §4 divergence the atx-conformance suite pins).
+    const rawBody = JSON.stringify(agentRequest).replace('"trustLevel":', '"TRUSTLEVEL":9,"trustLevel":');
+    expect(rawBody).toContain('"TRUSTLEVEL":9'); // the smuggle really is in the bytes
+
+    const res = await brokerPost(socketPath, '/grant', brokerToken, rawBody);
+
+    expect(res.status).toBe(400);
+    // The scan reports the SECOND colliding name (the signed trustLevel; the
+    // decoy TRUSTLEVEL came first) — same convention as the Go/Java verifiers.
+    expect(res.json.error).toContain('Duplicate member "trustLevel"');
+    // And the same request WITHOUT the smuggle still resolves, so the strict
+    // parse is the only thing standing between the two outcomes.
+    const clean = await brokerPost(socketPath, '/grant', brokerToken, agentRequest);
+    expect(clean.status).toBe(200);
   });
 
   it('rejects an unauthenticated caller', async () => {

--- a/src/broker/server.ts
+++ b/src/broker/server.ts
@@ -388,6 +388,30 @@ export class BrokerServer {
     }
 
     this.readBody(req).then(async (body) => {
+      // Strict-parse the raw body before JSON.parse can collapse it: the grant
+      // request carries the signed ATX credential verbatim, and every member of
+      // the body (agentId, grant, atx, operation) feeds an authorization
+      // decision, so there is no layer with sanctioned RFC 8259 §4 last-wins
+      // semantics. A duplicate member at any depth — exact-name or a
+      // fold-colliding case variant — refuses the request. Dynamic import:
+      // @opena2a/atx-verify is ESM-only and this package is CJS (same pattern
+      // as the cli-ui/telemetry consumers in src/cli.ts).
+      try {
+        const { firstDuplicateMember } = await import('@opena2a/atx-verify');
+        const dup = firstDuplicateMember(body);
+        if (dup !== null) {
+          this.sendJson(res, 400, {
+            error: `Duplicate member "${dup}" in request body (duplicate JSON names are parser-divergent and refused)`,
+          });
+          return;
+        }
+      } catch {
+        // StrictParseError: body is not a single well-formed JSON value. Same
+        // rejection parseGrantResolveInput would produce — fail closed here.
+        this.sendJson(res, 400, { error: 'Invalid JSON' });
+        return;
+      }
+
       let input: GrantResolveInput;
       try {
         input = parseGrantResolveInput(body);


### PR DESCRIPTION
Propagation of @opena2a/atx-verify 0.3.0 (opena2a-org/opena2a#230) into the broker.

- **Exact pin 0.2.0 → 0.3.0.** Brings the declaredPurpose v1.1 TBS coverage fix into `GrantResolver`'s verify path: 0.2.0's projection omitted the field, so unsigned purpose content appended to a signed credential rode a valid signature.
- **Wire-boundary strict parse.** `handleGrant` is the one place raw credential bytes exist before `JSON.parse` collapses them; it now runs atx-verify's fold-aware `firstDuplicateMember` over the raw body and refuses the request on the first duplicate member at any depth (exact-name or case-variant). Every member of the AAP §6 grant body feeds an authorization decision, so the whole body is strict-parsed, not just the `atx` member. Reject-side only. CJS↔ESM via the repo's established dynamic-import pattern.
- New conformance test injects a byte-level `TRUSTLEVEL`/`trustLevel` smuggle into the ATX and pins the 400 refusal, plus pins that the identical clean request still resolves.

No publish with this PR — rides the next secretless release window (with #92) under the full release-test gate. 1094 tests green.