### PR TITLE
feat(status): add --json machine-readable output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -163,10 +163,12 @@ async function dispatch(args: string[], command: string | undefined): Promise<nu
       return runScan(projectDir, { includeTests, explain, noIgnore, minConfidence, json, showPlaceholders });
     }
     case 'status': {
-      const dirArg = args[1];
+      const json = args.includes('--json');
+      const positional = args.slice(1).filter(a => a !== '--json');
+      const dirArg = positional[0];
       if (!rejectUnknownFlagAsDirArg('status', dirArg)) return 2;
       const projectDir = dirArg ? path.resolve(dirArg) : process.cwd();
-      return runStatus(projectDir);
+      return runStatus(projectDir, { json });
     }
     case 'verify': {
       const showAll = args.includes('--all');

--- a/src/commands/core.ts
+++ b/src/commands/core.ts
@@ -284,15 +284,15 @@ async function runScanWithExplanations(findings: ReturnType<typeof scan>): Promi
   return findings.length > 0 ? 1 : 0;
 }
 
-export function runStatus(projectDir: string): number {
-  console.log('\n  Secretless Status\n');
-
+export function runStatus(projectDir: string, options?: { json?: boolean }): number {
   const s = status(projectDir);
   const session = getSessionStatus();
   const brokerStatus = getDaemonStatus();
   const brokerInstalled = isDaemonInstalled();
   const tp = s.transcriptProtection;
   const configuredBackend = readBackendConfig();
+  // Session warmth only matters for backends that trigger OS auth prompts.
+  const sessionRelevant = configuredBackend === '1password' || configuredBackend === 'keychain';
 
   // Build observation rows. Each row: glyph + label + optional → command.
   // Satisfied observations use ✓; needs-action use ⚠. Every ⚠ ends in a
@@ -329,7 +329,6 @@ export function runStatus(projectDir: string): number {
   }
 
   // Session warmth (only relevant when a backend that prompts is configured).
-  const sessionRelevant = configuredBackend === '1password' || configuredBackend === 'keychain';
   if (sessionRelevant) {
     if (session.warm) {
       addRow({ glyph: '✓', label: `Biometric session warm (expires ${formatRemainingTime(session.remainingSeconds)})` });
@@ -363,6 +362,43 @@ export function runStatus(projectDir: string): number {
     addRow({ glyph: '⚠', label: 'Broker daemon not installed', action: 'secretless-ai install' });
   }
 
+  // Verdict facts — shared by the JSON and human paths so both always agree.
+  const warningCount = rows.filter(r => r.glyph === '⚠').length;
+  const verdict = !s.isProtected
+    ? 'not-protected'
+    : warningCount === 0
+      ? 'protected-clean'
+      : 'protected-warnings';
+
+  // --json: emit a single valid JSON document to stdout and nothing else, so
+  // the output is machine-parseable (issue #63 — same contract as `scan --json`).
+  // Exit code stays 0 to match the human view; CI consumers gate on
+  // `summary.verdict` / `summary.warnings`.
+  if (options?.json) {
+    console.log(JSON.stringify({
+      tool: 'secretless-ai',
+      version: VERSION,
+      isProtected: s.isProtected,
+      hookInstalled: s.hookInstalled,
+      denyRuleCount: s.denyRuleCount,
+      configuredTools: s.configuredTools,
+      secretsFound: s.secretsFound,
+      transcriptProtection: tp,
+      backend: configuredBackend ?? null,
+      session: { relevant: sessionRelevant, warm: session.warm },
+      broker: {
+        installed: brokerInstalled,
+        running: !!brokerStatus,
+        pid: brokerStatus?.pid ?? null,
+        uptimeSeconds: brokerStatus?.uptimeSeconds ?? null,
+      },
+      summary: { warnings: warningCount, verdict },
+    }, null, 2));
+    return 0;
+  }
+
+  console.log('\n  Secretless Status\n');
+
   // Render the Observations block. We measure the visible width (glyph +
   // label) so the `→ command` column lines up tidily across rows.
   const headerLine = '──────────────────────────────────────────────────────────';
@@ -386,7 +422,6 @@ export function runStatus(projectDir: string): number {
   // the hook installed; "Clean" requires zero warnings.
   console.log();
   console.log(`  ── Verdict ${headerLine.slice(0, Math.max(0, 49))}`);
-  const warningCount = rows.filter(r => r.glyph === '⚠').length;
   if (!s.isProtected) {
     console.log('  Not protected. Run `secretless-ai init` to install hooks.');
   } else if (warningCount === 0) {

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -16,8 +16,8 @@ ${banner}  Keep secrets out of AI context.
 
   Usage:
     ${CLI} init      Set up protections for your AI tools
-    ${CLI} scan      Scan config and source files for hardcoded secrets
-    ${CLI} status    Show protection status
+    ${CLI} scan      Scan config and source files for hardcoded secrets (--json for CI)
+    ${CLI} status    Show protection status (--json for CI)
     ${CLI} verify    Verify keys are usable but hidden from AI (--all for full list)
     ${CLI} doctor    Diagnose shell profile issues (--fix to auto-fix)
     ${CLI} clean     Scan and redact credentials in transcripts

--- a/src/commands/status-json.test.ts
+++ b/src/commands/status-json.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { runStatus } from './core';
+
+function tmpProject(files: Record<string, string> = {}): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'status-json-'));
+  for (const [rel, content] of Object.entries(files)) {
+    const full = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+  return dir;
+}
+
+// Issue #63: `status --json` must emit a single valid JSON document, not the
+// human report. Assertions stay structural where a value depends on machine
+// state (watcher, broker, transcripts) and exact where it is project-local.
+describe('runStatus --json', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('emits valid parseable JSON with protection facts and a summary verdict', () => {
+    const dir = tmpProject();
+    const lines: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => { lines.push(a.map(String).join(' ')); });
+
+    const code = runStatus(dir, { json: true });
+    const doc = JSON.parse(lines.join('\n')); // throws if not valid JSON
+
+    expect(code).toBe(0);
+    expect(doc.tool).toBe('secretless-ai');
+    expect(typeof doc.version).toBe('string');
+    expect(typeof doc.isProtected).toBe('boolean');
+    expect(typeof doc.hookInstalled).toBe('boolean');
+    expect(typeof doc.denyRuleCount).toBe('number');
+    expect(Array.isArray(doc.configuredTools)).toBe(true);
+    expect(typeof doc.secretsFound).toBe('number');
+    expect(doc.transcriptProtection).toHaveProperty('stopHookInstalled');
+    expect(doc.transcriptProtection).toHaveProperty('watcherRunning');
+    expect(doc.session).toHaveProperty('relevant');
+    expect(doc.broker).toHaveProperty('installed');
+    expect(doc.broker).toHaveProperty('running');
+    expect(typeof doc.summary.warnings).toBe('number');
+    expect(['not-protected', 'protected-clean', 'protected-warnings']).toContain(doc.summary.verdict);
+  });
+
+  it('reports not-protected for an empty project directory', () => {
+    const dir = tmpProject();
+    const lines: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => { lines.push(a.map(String).join(' ')); });
+
+    runStatus(dir, { json: true });
+    const doc = JSON.parse(lines.join('\n'));
+
+    expect(doc.hookInstalled).toBe(false);
+    expect(doc.isProtected).toBe(false);
+    expect(doc.configuredTools).toEqual([]);
+    expect(doc.summary.verdict).toBe('not-protected');
+  });
+
+  it('reports protected when the guard hook is installed', () => {
+    const dir = tmpProject({
+      '.claude/hooks/secretless-guard.sh': '#!/bin/bash\nexit 0\n',
+    });
+    const lines: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => { lines.push(a.map(String).join(' ')); });
+
+    runStatus(dir, { json: true });
+    const doc = JSON.parse(lines.join('\n'));
+
+    expect(doc.hookInstalled).toBe(true);
+    expect(doc.isProtected).toBe(true);
+    expect(doc.summary.verdict).toMatch(/^protected-/);
+  });
+
+  it('does NOT print the human "Secretless Status" banner in JSON mode', () => {
+    const dir = tmpProject();
+    const lines: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => { lines.push(a.map(String).join(' ')); });
+
+    runStatus(dir, { json: true });
+    expect(lines.join('\n')).not.toContain('Secretless Status');
+  });
+
+  it('human mode is unchanged: banner, observations, verdict', () => {
+    const dir = tmpProject();
+    const lines: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => { lines.push(a.map(String).join(' ')); });
+
+    const code = runStatus(dir);
+    const out = lines.join('\n');
+
+    expect(code).toBe(0);
+    expect(out).toContain('Secretless Status');
+    expect(out).toContain('Observations');
+    expect(out).toContain('Verdict');
+  });
+});


### PR DESCRIPTION
## Summary

Completes #63. `scan --json` shipped earlier; this adds the missing half — `status --json` now emits a single JSON document instead of rejecting the flag with exit 2.

- Same envelope convention as `scan --json`: `{tool, version, ...facts, summary}`, camelCase throughout.
- `summary.verdict` is one of `not-protected | protected-clean | protected-warnings`; `summary.warnings` mirrors the human view's warning count — both paths derive from the same rows, so they can never disagree.
- Exit code stays 0 (matching the human view); CI consumers gate on `summary.verdict`.
- Human output unchanged (regression-tested).
- `--help` now mentions `--json` on both `scan` and `status`.

## Testing

- 5 new tests in `src/commands/status-json.test.ts` (valid JSON, not-protected/protected transitions, no banner leak in JSON mode, human mode unchanged). New tests fail on pre-fix code (old `runStatus` ignored options and printed the human report).
- Full suite: 1099 passing.
- Manual walkthrough: empty dir, post-`init` transition, unknown-flag rejection (`status --json --bogus` still exits 2), explicit dir arg, piped output parses with `JSON.parse`/`python3 -m json.tool`.

Closes #63