### PR TITLE
docs: secrets workflow in README; expand release-smoke to command-surface parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Keep API keys and other secrets invisible to AI coding tools. Works with Claude 
 
 [![npm version](https://img.shields.io/npm/v/secretless-ai.svg)](https://www.npmjs.com/package/secretless-ai)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-988%20passing-brightgreen)](https://github.com/opena2a-org/secretless-ai)
+[![Tests](https://img.shields.io/badge/tests-1099%20passing-brightgreen)](https://github.com/opena2a-org/secretless-ai)
 
 [Website](https://opena2a.org/secretless) · [Demos](https://opena2a.org/demos) · [Discord](https://discord.gg/uRZa3KXgEn)
 
@@ -19,7 +19,7 @@ npx secretless-ai init
 ```
 
 ```
-  Secretless v0.17.1
+  Secretless v0.18.3
   Keeping secrets out of AI
 
   Configured: Claude Code (1 of 1 detected)
@@ -29,7 +29,7 @@ npx secretless-ai init
     + CLAUDE.md
 
   Modified:
-    ~ .claude/settings.json (added 69 deny patterns)
+    ~ .claude/settings.json (added 85 deny patterns)
 
   Next steps:
     Verify: secretless-ai verify
@@ -79,10 +79,44 @@ Secretless never reads or transmits credential values it manages. Backends (OS k
 
 ## How it works
 
-1. **Scans** your project for hardcoded credentials in config files and source code. 56 credential patterns from [`@opena2a/credential-patterns@0.1.1`](https://www.npmjs.com/package/@opena2a/credential-patterns), lockstep-asserted, across `.js`, `.ts`, `.py`, `.go`, `.java`, `.rb`, and more. Suppresses fixture-path false positives via `.secretlessignore` defaults (`test/`, `__tests__/`, `examples/`, `e2e/`, `docs/vhs/`, `node_modules/`, etc.).
+1. **Scans** your project for hardcoded credentials in config files and source code. 57 credential patterns from [`@opena2a/credential-patterns@0.1.2`](https://www.npmjs.com/package/@opena2a/credential-patterns), lockstep-asserted, across `.js`, `.ts`, `.py`, `.go`, `.java`, `.rb`, and more. Suppresses fixture-path false positives via `.secretlessignore` defaults (`test/`, `__tests__/`, `examples/`, `e2e/`, `docs/vhs/`, `node_modules/`, etc.).
 2. **Migrates** them to secure storage: OS keychain, 1Password, HashiCorp Vault, GCP Secret Manager, or AES-256-GCM encrypted file.
 3. **Blocks** AI tools from reading credential files. 21 file patterns enforced at the AI-tool hook layer.
 4. **Brokers** access through environment variables. Secrets never enter AI context.
+
+## Store secrets and use them in AI sessions
+
+Move keys out of files and into a storage backend, then use them by name. Values never enter AI context, transcripts, or shell history.
+
+```bash
+npx secretless-ai secret set STRIPE_SECRET_KEY   # value read from stdin, never echoed
+npx secretless-ai import .env                    # or migrate an existing .env in one step
+npx secretless-ai secret list                    # names only, values are never printed
+```
+
+`secret set` also installs a shell hook (`eval "$(secretless-ai env)"` in `~/.zshenv` or `~/.bashrc`), so new terminals export stored secrets as environment variables automatically. To inject into a single command instead of the whole shell:
+
+```bash
+npx secretless-ai run --only STRIPE_SECRET_KEY -- node charge.js
+```
+
+Reading a value back is TTY-gated: `secret get NAME` prints it in an interactive terminal, but is blocked in piped or AI-driven contexts unless `--force` is passed — and `init` installs deny rules so AI tools cannot run the `--force` form or dump an injected environment (`run -- env`).
+
+### Ask your AI assistant to use a secret
+
+After `init`, the assistant's instruction file (`CLAUDE.md`, `.cursorrules`, ...) lists which keys are available as environment variables and tells the tool to reference them as `$VAR_NAME` without reading values. So this works in Claude Code:
+
+> Call the Stripe API and list the last 5 charges.
+
+Claude writes the command with a variable reference. The shell substitutes the value inside the subprocess; nothing enters the model's context:
+
+```bash
+curl -s "https://api.stripe.com/v1/charges?limit=5" -H "Authorization: Bearer $STRIPE_SECRET_KEY"
+```
+
+For a key stored after `init`, or one `init` doesn't recognize, name the variable in your prompt ("use `$GAMMA_API_KEY` for auth") or add a row to the key table in `CLAUDE.md`. To keep the assistant away from raw values entirely, ask it to run commands under the injector:
+
+> Run the deploy script with `secretless-ai run --only DEPLOY_TOKEN -- ./deploy.sh`.
 
 ## MCP server protection
 
@@ -121,6 +155,8 @@ npx secretless-ai scan --min-confidence 0.85   # high-confidence findings only
 npx secretless-ai ignore docs/migration.md     # append a path to .secretlessignore
 npx secretless-ai ignore --pattern '*.golden.txt'
 npx secretless-ai diff main                    # audit secretless-managed file changes vs a git ref
+npx secretless-ai scan --json                  # machine-readable findings for CI
+npx secretless-ai status --json                # protection state for CI (gate on summary.verdict)
 ```
 
 `scan` renders a `Confidence: high (0.92)` line under every finding. The score combines pattern specificity, value entropy, value length, and path tier. With `--no-ignore`, findings whose path matches the default-ignore list are tagged `(looks like a test fixture)` so they stay visible without being re-suppressed.

--- a/docs/testing/release-smoke.md
+++ b/docs/testing/release-smoke.md
@@ -1,52 +1,247 @@
 # secretless-ai release smoke test
 
-**Run before every tag push to `v*`. ~10 minutes by hand.**
+**Run before every tag push to `v*`. ~20 minutes by hand.**
 
 Every item came from a real bug or regression. Don't skip without writing down why.
 
-## 0. Build + tests
+Run every command from the local build (`node dist/cli.js`), not the global
+install. Several commands operate on **machine-global state** (the secret
+store, `~/.zshenv`, shell history, MCP configs) — the steps below flag each
+one and use throwaway names or isolated `$HOME` so a smoke run never damages
+the operator's real setup.
+
+---
+
+## 0. Build + tests (2 min)
 
 ```bash
 cd secretless-ai
 git status                 # clean, or only the branch you intend to ship
 npm ci                     # lockfile valid
 npm run build              # zero output, zero errors
-npm test                   # all green (current baseline: ~809 tests)
+npm test                   # all green (baseline: 1099 tests)
 ```
 
 Fail the release if any step is red.
 
-## 1. Help and version
+---
+
+## 1. Help and version (1 min)
 
 ```bash
-node dist/cli.js --help     # prints the help block; no telemetry line here
+node dist/cli.js --help     # prints the full help block; no telemetry line here
 node dist/cli.js --version  # prints two lines: version + telemetry disclosure
 ```
 
 The `--version` output must be exactly two lines:
+
 ```
-secretless-ai 0.16.0
+secretless-ai 0.x.x
 Telemetry: on (opt-out: OPENA2A_TELEMETRY=off  •  details: opena2a.org/telemetry)
 ```
 
-If the second line is missing, the `versionLine()` helper isn't wired or the SDK init failed silently.
+If the second line is missing, the `versionLine()` helper isn't wired or the
+SDK init failed silently.
 
-## 2. Core commands work end-to-end (3 min)
+`--help` anywhere in the args must short-circuit to top-level help — `scan
+--help` must NOT run the scanner and `init --help` must NOT create files
+(regression: release-test 2026-04-14).
+
+---
+
+## 2. Core protection walkthrough (3 min)
+
+Build the planted credential at runtime — a literal real-shaped key in this
+doc would trip GitHub push protection and our own scanners, and short "fake"
+strings like `sk-fake-deadbeef` do NOT match the patterns (verified 2026-07-16:
+scan correctly ignores them, so they make this walkthrough fail spuriously):
 
 ```bash
+SL="node /path/to/secretless-ai/dist/cli.js"
 TMP=$(mktemp -d) && cd "$TMP"
-echo 'OPENAI_API_KEY=sk-fake-deadbeef' > .env
-node /path/to/secretless-ai/dist/cli.js init .         # creates .secretless/
-node /path/to/secretless-ai/dist/cli.js scan .         # detects fake credential
-node /path/to/secretless-ai/dist/cli.js status .       # reports Clean or N findings
-node /path/to/secretless-ai/dist/cli.js verify .       # verify pass
+PLANT="sk-ant-api03-$(openssl rand -base64 48 | tr -d '/+=' | head -c 51)"
+echo "const k = \"$PLANT\";" > config.js
+
+$SL status .        # "Not protected" verdict; every ⚠ row ends in a → command
+$SL init .          # Configured: Claude Code; Created: hook + CLAUDE.md; Modified: settings.json (~85 deny patterns)
+$SL scan .          # 1 credential found: HIGH Anthropic API Key, config.js:1, value REDACTED in preview; exit 1
+$SL status .        # verdict flips to "Protected (...)"
+$SL verify .        # scope disclosure line + PASS/WARN with next steps
 ```
 
-Fail if any command panics or returns the wrong status.
+Fail if any command crashes, prints a stack trace, or the verdict does not
+flip after `init`.
 
-## 3. Telemetry disclosure surfaces and opt-out (2 min)
+### 2a. JSON contracts (issue #63)
 
-**Do NOT point at the production endpoint while smoking** — set `OPENA2A_TELEMETRY_URL=http://127.0.0.1:1/never` so events go to a port that refuses connections (proves fire-and-forget tolerance) instead of polluting prod aggregates.
+```bash
+$SL scan . --json | python3 -m json.tool >/dev/null && echo scan-json-ok
+$SL status --json . | python3 -m json.tool >/dev/null && echo status-json-ok
+$SL status --json . | python3 -c "import sys,json; d=json.load(sys.stdin); \
+  assert d['tool']=='secretless-ai'; \
+  assert d['summary']['verdict'] in ('not-protected','protected-clean','protected-warnings'); \
+  print('verdict:', d['summary']['verdict'])"
+```
+
+- `scan --json`: single JSON document on stdout — `{tool, version, findings,
+  summary}`. Exit 1 when findings exist (CI gating), 0 when clean.
+- `status --json`: single JSON document — `{tool, version, isProtected,
+  hookInstalled, denyRuleCount, configuredTools, secretsFound,
+  transcriptProtection, backend, session, broker, summary}`. Exit 0; CI
+  consumers gate on `summary.verdict`.
+- Neither may print the human banner or any ANSI color in JSON mode.
+
+### 2b. Unknown-flag rejection (issues #62 / #74 / #81 / #83)
+
+```bash
+$SL init --dry-run; echo "exit=$?"    # "Unknown option: --dry-run", exit 2, NO --dry-run/ dir created
+$SL status --bogus; echo "exit=$?"    # rejected, exit 2
+$SL scan --show-placeholder .         # WARNS about the unknown flag (typo of --show-placeholders), still scans
+$SL bogus-command; echo "exit=$?"     # "Unknown command", help block, exit 1
+```
+
+`init`/`status` reject unknown flags (filesystem footgun — pre-fix, `init
+--ci` created a literal `--ci/` directory). `scan` warns-but-runs so a typo'd
+flag never hides scan results.
+
+---
+
+## 3. Secret lifecycle (3 min)
+
+**Machine-global state.** The store is one per machine, shared across
+projects. Use the throwaway name below and remove it at the end.
+
+```bash
+echo "smoke-value-123" | $SL secret set SMOKE_TEST_KEY_DELETEME   # "Stored: SMOKE_TEST_KEY_DELETEME"
+$SL secret list                        # name appears; "Scope: global (<backend> backend)" note; values never printed
+$SL run --only SMOKE_TEST_KEY_DELETEME -- node -e \
+  "console.log('injected:', !!process.env.SMOKE_TEST_KEY_DELETEME)"   # injected: true
+$SL env --only SMOKE_TEST_KEY_DELETEME # emits: export SMOKE_TEST_KEY_DELETEME=...
+$SL secret get SMOKE_TEST_KEY_DELETEME | cat; echo "exit=$?"
+# BLOCKED (non-TTY): "secret values cannot be read in non-interactive contexts", exit 1
+$SL secret rm SMOKE_TEST_KEY_DELETEME  # "Removed: SMOKE_TEST_KEY_DELETEME"
+```
+
+Also verify import parses without keeping anything:
+
+```bash
+echo 'SMOKE_IMPORT_KEY_DELETEME=fake-import-value' > "$TMP/.env.smoke"
+$SL import "$TMP/.env.smoke"           # imports 1 secret
+$SL secret rm SMOKE_IMPORT_KEY_DELETEME
+```
+
+Fail the release if:
+- `secret get` piped (non-TTY) prints the value without `--force`
+- `secret list` or any command prints a stored secret VALUE
+- `run --only` fails to inject, or injects keys outside the `--only` set
+- `secret set` does not install the shell hook on first use (check
+  `~/.zshenv` / `~/.bashrc` for `eval "$(secretless-ai env 2>/dev/null)"`)
+
+---
+
+## 4. Manifest + doctor (1 min)
+
+```bash
+cd "$TMP"
+$SL setup --check; echo "exit=$?"   # no .secretless manifest -> hint + exit 1 (CI contract)
+printf 'SMOKE_TEST_KEY_DELETEME\n' > .secretless
+$SL setup --check; echo "exit=$?"   # missing required secret -> FAIL, exit 1
+$SL doctor                          # Platform/Shell + per-profile key counts + health verdict
+```
+
+`doctor` must label exactly one profile RECOMMENDED and end with a
+HEALTHY/DEGRADED/BROKEN verdict line. `--fix` is only exercised when a
+DEGRADED verdict appears (it edits real shell profiles).
+
+---
+
+## 5. Git integration (2 min)
+
+```bash
+cd "$TMP" && git init -q
+$SL hook status                     # "Pre-commit hook: not installed" + install hint
+$SL hook install                    # "Pre-commit hook installed."; .git/hooks/pre-commit exists
+echo "const s = \"$PLANT\";" > staged.js && git add staged.js
+$SL scan-staged; echo "exit=$?"     # finds the planted credential, "Remove the secrets and try again.", non-zero exit
+git rm --cached staged.js -q && rm staged.js
+$SL diff main 2>&1 | head -3        # in a repo with no secretless-managed changes: clean/empty audit
+cd / && $SL diff 2>&1 | head -3     # outside a repo: friendly "Not a git repository" + git init hint, no stack trace
+```
+
+---
+
+## 6. Shell history (1 min)
+
+Read-only / dry-run against the operator's real history — safe, but do NOT
+run the destructive form during smoke.
+
+```bash
+$SL scan-history                    # Files scanned: N; findings show [service] + file:line, values masked
+$SL clean-history --dry-run         # "(dry run)" in header; Lines redacted count; file NOT modified
+```
+
+Fail if `scan-history` prints raw credential values (previews must be masked)
+or `--dry-run` modifies the history file (compare mtime).
+
+---
+
+## 7. MCP protection (1 min)
+
+**Read-only during smoke.** Do NOT round-trip `protect-mcp` by hand, and do
+NOT try to sandbox it with an isolated `$HOME`: `createBackend('local')`
+silently upgrades to the OS keychain when the platform supports it
+(`src/backends/factory.ts`), and macOS `security` resolves the default
+keychain via `$HOME` — so an isolated `$HOME` pops a blocking "Keychain Not
+Found" GUI dialog and hangs an unattended smoke (verified 2026-07-16). There
+is no CLI flag that forces the pure file backend on macOS.
+
+The protect → wrapper-injection → unprotect round-trip (including
+byte-identical config restore and non-secret env vars staying untouched) is
+covered by `src/mcp/e2e.test.ts` in the unit suite, which §0 already ran.
+
+```bash
+$SL mcp-status      # enumerates real clients without errors; exit 0
+                    # unprotected servers show "! <name>: EXPOSED (N plaintext secret(s))" + a → command
+```
+
+Only exercise `protect-mcp`/`mcp-unprotect` manually (on the real `$HOME`,
+against a client you actually use) when the diff touches `src/mcp/` — and
+check the restored config with `git diff`-style comparison before and after.
+
+---
+
+## 8. Daemons + cache (1 min)
+
+```bash
+$SL broker status        # "Broker daemon is not running." (or PID + uptime if it is)
+$SL install status       # "LaunchAgent: not installed" + install hint (macOS)
+$SL cache                # Backend/TTL/Status; local backend says "Not needed"
+```
+
+Do not exercise `warm` in an unattended smoke — it triggers a Touch ID
+prompt. `broker start`/`stop` round-trip is covered by unit tests; only
+exercise it manually when the diff touches `src/broker/`.
+
+---
+
+## 9. Usage surfaces — no dead ends (1 min)
+
+Each bare command must print usage/help with a runnable next step and exit
+cleanly — no stack traces, no silent exits:
+
+```bash
+for c in rules scope vault ignore secret; do $SL $c; done
+$SL feedback             # prints repo / issues / discussions links
+```
+
+---
+
+## 10. Telemetry disclosure surfaces and opt-out (2 min)
+
+**Do NOT point at the production endpoint while smoking** — set
+`OPENA2A_TELEMETRY_URL=http://127.0.0.1:1/never` so events go to a port that
+refuses connections (proves fire-and-forget tolerance) instead of polluting
+prod aggregates.
 
 ```bash
 export OPENA2A_TELEMETRY_URL=http://127.0.0.1:1/never
@@ -56,25 +251,50 @@ rm -f ~/.config/opena2a/telemetry.json   # start clean
 
 | # | Command | Expected |
 |---|---------|----------|
-| 3.1 | `secretless-ai --version` | Two lines: `secretless-ai 0.16.0` then `Telemetry: on (opt-out: ...)` |
-| 3.2 | `secretless-ai telemetry status` | Prints `state: on`, install_id, config path, policy URL, toggle hint |
-| 3.3 | `secretless-ai telemetry off` | Prints `Telemetry disabled for secretless-ai.` Then `--version` shows `Telemetry: off`. `~/.config/opena2a/telemetry.json` has `"enabled": false`. |
-| 3.4 | `secretless-ai telemetry on` | Re-enables persistently. |
-| 3.5 | `OPENA2A_TELEMETRY=off secretless-ai telemetry status` | Shows `state: off` even though file says `on` (env wins). |
-| 3.6 | `OPENA2A_TELEMETRY_DEBUG=print secretless-ai status .` | Stderr contains a `[opena2a:telemetry]` line with the JSON payload (`tool: "secretless-ai"`, `event: "command"`, `name: "status"`, `success: true`, `duration_ms: <int>`, no PII fields). |
-| 3.7 | `secretless-ai status .` (with the unreachable URL) | Command completes normally. Telemetry endpoint unreachable must not slow the command perceptibly (≤2s timeout). |
+| 10.1 | `secretless-ai --version` | Two lines: `secretless-ai 0.x.x` then `Telemetry: on (opt-out: ...)` |
+| 10.2 | `secretless-ai telemetry status` | Prints `state: on`, install_id, config path, policy URL, toggle hint |
+| 10.3 | `secretless-ai telemetry off` | Prints `Telemetry disabled for secretless-ai.` Then `--version` shows `Telemetry: off`. `~/.config/opena2a/telemetry.json` has `"enabled": false`. |
+| 10.4 | `secretless-ai telemetry on` | Re-enables persistently. |
+| 10.5 | `OPENA2A_TELEMETRY=off secretless-ai telemetry status` | Shows `state: off` even though file says `on` (env wins). |
+| 10.6 | `OPENA2A_TELEMETRY_DEBUG=print secretless-ai status .` | Stderr contains a `[opena2a:telemetry]` line with the JSON payload (`tool: "secretless-ai"`, `event: "command"`, `name: "status"`, `success: true`, `duration_ms: <int>`, no PII fields). |
+| 10.7 | `secretless-ai status .` (with the unreachable URL) | Command completes normally. Telemetry endpoint unreachable must not slow the command perceptibly (≤2s timeout). |
 
 Fail the release if:
 - any disclosure line is omitted
 - the persisted config file leaks anything beyond `enabled` and `installId`
-- the debug-print payload contains scanned secrets, file paths, env-var values, rule contents, or any field outside the locked schema (tool, version, install_id, event, name, success, duration_ms, platform, node_major)
-- a command blocks more than 2 seconds when the telemetry endpoint is unreachable
+- the debug-print payload contains scanned secrets, file paths, env-var
+  values, rule contents, or any field outside the locked schema (tool,
+  version, install_id, event, name, success, duration_ms, platform,
+  node_major)
+- a command blocks more than 2 seconds when the telemetry endpoint is
+  unreachable
 
-## 4. Cleanup
+---
+
+## 11. Cleanup
 
 ```bash
 unset OPENA2A_TELEMETRY_URL
 rm -rf "$TMP"
+$SL secret list   # confirm no SMOKE_* names remain
 # Restore your real telemetry config if you had one — the tests above
 # overwrite ~/.config/opena2a/telemetry.json.
 ```
+
+---
+
+## When this checklist isn't enough
+
+- Diff touches `src/patterns.ts` or bumps `@opena2a/credential-patterns`:
+  re-run the lockstep tests and re-verify the pattern count claimed in
+  README.md ("N credential patterns from @opena2a/credential-patterns@x.y.z").
+- Diff touches `src/broker/` or `src/grant/`: exercise the broker
+  round-trip manually (`broker start` → grant flow → `broker stop`) — the
+  daemon lifecycle is not covered above.
+- Diff touches `src/mcp/` or `mcp-wrapper.ts`: also smoke the `secretless-mcp`
+  bin entry against a real MCP client config in isolated `$HOME`.
+- Diff touches AIM / identity-vault integration (`src/vault-core.ts`,
+  `vault` command): run the BYOV use-case doc
+  (`docs/use-cases/bring-your-own-vault.md`) end to end.
+- If a regression ships that would have been caught by an item NOT on this
+  list: add the item here as part of the fix.


### PR DESCRIPTION
## Summary

Two documentation gaps closed:

**README** — the store-a-secret / use-it-in-an-AI-session workflow was entirely missing. Users had no way to discover `secret set`, `import`, `run --only`, or how to ask an AI assistant to use a stored key. New section covers:
- `secret set` (stdin, never echoed), `import .env`, `secret list` (names only)
- the shell hook `secret set` installs and the `run --only` per-command injector
- `secret get` TTY-gating and the deny rules `init` installs against `--force` / `run -- env` dumps
- how the generated CLAUDE.md key table lets an assistant reference `$VAR_NAME` without reading values, with concrete prompt examples

Also refreshed stale facts: example output now v0.18.3 with 85 deny patterns (was 0.17.1 / 69), 57 patterns @ credential-patterns 0.1.2 (was 56 @ 0.1.1), test badge 1099 (was 988), and documented `scan --json` / `status --json` for CI.

**release-smoke.md** (closes #60) — 80 → 300 lines, peer parity with ai-trust/hackmyagent. Adds: secret lifecycle (throwaway-name protocol for the machine-global store), manifest + doctor, git integration (hook install, scan-staged block), shell history (dry-run only), MCP (read-only — see below), daemons + cache, no-dead-end usage surfaces, JSON contracts, and the #62/#74/#81/#83 unknown-flag regression checks.

## Verification notes

Every expected output was executed against the 0.18.3 build before being written down. Two draft expectations turned out wrong and were corrected:
- `sk-fake-deadbeef` values do NOT match the scanner patterns — the doc now builds a real-shaped synthetic key at runtime (`openssl rand`), which also keeps real-looking literals out of the repo.
- `protect-mcp` under an isolated $HOME pops a blocking macOS "Keychain Not Found" GUI dialog, because `createBackend('local')` silently prefers the OS keychain and `security` resolves the default keychain via $HOME. The smoke is now read-only (`mcp-status`); the round-trip is covered by `src/mcp/e2e.test.ts`.

Closes #60