### PR TITLE
fix(setup): coherent --check output when no manifest exists

### DIFF
--- a/src/commands/env-run.ts
+++ b/src/commands/env-run.ts
@@ -146,6 +146,13 @@ export async function runSetupCommand(args: string[]): Promise<number> {
   try {
     const result = await runSetup(dir, { check: checkOnly });
     if (checkOnly) {
+      // No manifest: runSetup already printed the create-a-manifest hint.
+      // Rendering the satisfied/missing tally here would contradict it
+      // ("Missing: 0 required" followed by FAIL — issue #97).
+      if (!result.manifestFound) {
+        console.log('  FAIL: No .secretless manifest to check against.\n');
+        return 1;
+      }
       console.log(`  Satisfied: ${result.existing} secret(s)`);
       console.log(`  Missing:   ${result.missing} required`);
       console.log(`  Optional:  ${result.skipped} not set\n`);

--- a/src/setup.test.ts
+++ b/src/setup.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -31,6 +31,15 @@ describe('runSetup', () => {
   it('check mode fails when no manifest exists', async () => {
     const result = await runSetup(tmpDir, { backend, check: true });
     expect(result.complete).toBe(false);
+  });
+
+  it('reports manifestFound=false without a manifest, true with one', async () => {
+    const without = await runSetup(tmpDir, { backend, check: true });
+    expect(without.manifestFound).toBe(false);
+
+    fs.writeFileSync(path.join(tmpDir, '.secretless'), 'API_KEY\n');
+    const withManifest = await runSetup(tmpDir, { backend, check: true });
+    expect(withManifest.manifestFound).toBe(true);
   });
 
   it('check mode returns complete when all secrets satisfied', async () => {
@@ -71,5 +80,47 @@ describe('runSetup', () => {
     const result = await runSetup(tmpDir, { backend, check: true });
     expect(result.complete).toBe(true);
     expect(result.existing).toBe(2);
+  });
+});
+
+// Issue #97: `setup --check` in a directory with no manifest printed a
+// contradictory report — "Missing: 0 required", an empty "Missing secrets:"
+// block, and a FAIL telling the user to configure secrets the same output
+// said don't exist. The no-manifest check path must stop after the
+// create-a-manifest hint with a single FAIL line (exit 1 unchanged).
+describe('runSetupCommand --check without a manifest', () => {
+  let tmpDir: string;
+  let savedCwd: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-setup-cmd-'));
+    savedCwd = process.cwd();
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(savedCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('prints one FAIL line, no satisfied/missing tally, exits 1', async () => {
+    const { runSetupCommand } = await import('./commands/env-run');
+    const lines: string[] = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+      lines.push(a.map(String).join(' '));
+    });
+    try {
+      const code = await runSetupCommand(['--check']);
+      const out = lines.join('\n');
+
+      expect(code).toBe(1);
+      expect(out).toContain('FAIL: No .secretless manifest to check against.');
+      expect(out).not.toContain('Satisfied:');
+      expect(out).not.toContain('Missing:');
+      expect(out).not.toContain('Missing secrets:');
+      expect(out).not.toContain('Run `secretless-ai setup`');
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -16,6 +16,9 @@ export interface SetupOptions extends SecretStoreOptions {
 }
 
 export interface SetupResult {
+  /** Whether a .secretless manifest was found. When false, the counts below
+   *  are vacuous — callers must not render a satisfied/missing tally. */
+  manifestFound: boolean;
   /** Number of secrets newly set during setup. */
   set: number;
   /** Number of secrets that already existed. */
@@ -48,9 +51,9 @@ export async function runSetup(
     process.stderr.write('    DATABASE_URL\n');
     // In check mode, missing manifest is a failure (nothing to verify against)
     if (options?.check) {
-      return { set: 0, existing: 0, missing: 0, missingNames: [], skipped: 0, complete: false };
+      return { manifestFound: false, set: 0, existing: 0, missing: 0, missingNames: [], skipped: 0, complete: false };
     }
-    return { set: 0, existing: 0, missing: 0, missingNames: [], skipped: 0, complete: true };
+    return { manifestFound: false, set: 0, existing: 0, missing: 0, missingNames: [], skipped: 0, complete: true };
   }
 
   const check = await checkManifest(dir, options);
@@ -58,6 +61,7 @@ export async function runSetup(
   // Check-only mode: report and exit
   if (options?.check) {
     return {
+      manifestFound: true,
       set: 0,
       existing: check.satisfied.length,
       missing: check.missing.length,
@@ -74,6 +78,7 @@ export async function runSetup(
 
   if (check.missing.length === 0 && check.optional.length === 0) {
     return {
+      manifestFound: true,
       set: 0,
       existing: check.satisfied.length,
       missing: 0,
@@ -121,6 +126,7 @@ export async function runSetup(
   }
 
   return {
+    manifestFound: true,
     set: setCount,
     existing: check.satisfied.length,
     missing: 0,


### PR DESCRIPTION
Closes #97.

`setup --check` in a directory with no `.secretless` manifest printed a contradictory report: "Missing: 0 required", an empty "Missing secrets:" block, then "FAIL: Run \`secretless-ai setup\` to configure missing secrets" — telling the user to configure secrets the same output said don't exist.

`SetupResult` gains `manifestFound`; when false, the check renderer stops after the create-a-manifest hint with a single line: `FAIL: No .secretless manifest to check against.` Exit codes unchanged (still 1 — CI contract intact). The with-manifest path is untouched.

## Testing
- New command-level regression test asserts the FAIL line and the absence of the tally/missing-block; verified it fails on pre-fix code (2 failures) and passes on the fix.
- Full suite: 1101 passing.
- Manual walkthrough of both paths against the built CLI (no-manifest → single FAIL, exit 1; manifest with missing key → unchanged tally + FAIL, exit 1).
