### PR TITLE
feat(broker): ML-DSA-65 and hybrid Ed25519+ML-DSA-65 assertion minting (RFC 9964)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ npm install -g secretless-ai
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Post-quantum broker assertions (AAP-SPEC 0.4 §8.2/§9.3/§9.4/§9.5, RFC 9964).**
+  The broker now mints ML-DSA-65 (FIPS 204) assertions on two new paths:
+  `mintBrokerAssertionMlDsa65` (compact `ML-DSA-65` JWT, the PQ-interop lane)
+  and `mintHybridBrokerAssertion` (hybrid Ed25519 + ML-DSA-65 as JWS General
+  JSON Serialization — one signature entry per suite over the same payload; a
+  conformant verifier accepts only if every declared entry verifies and both
+  suite families are present). New key surface: `generateBrokerPqcSigningKey`
+  (seed-injectable, the FIPS 204 xi / RFC 9964 AKP `priv` form) and
+  `brokerPublicAkpJwk` (RFC 9964 `AKP` public JWK for the discovery document).
+  Signing is hedged by default and deterministic on request
+  (`PqcMintOptions.deterministic`, required for byte-exact fixtures); tests
+  prove sha256 byte-parity with the AAP spec repo's published fixtures across
+  three independent FIPS 204 implementations. The existing compact EdDSA path
+  is byte-for-byte unchanged. Serialization-profile decision:
+  agent-authorization-protocol `decisions/2026-07-16-mldsa65-serialization-profile.md`.
+
+### Changed
+- **Node engine floor raised from `>=18.0.0` to `>=20.19.0`** — the ML-DSA-65
+  suite loads the ESM-only `@noble/post-quantum` via `require(esm)`, supported
+  since Node 20.19; Node 18 and 20 are both end-of-life. The dependency loads
+  lazily: classical EdDSA minting never touches it, and requesting a PQ mint on
+  an older runtime fails with an actionable error instead of `ERR_REQUIRE_ESM`.
+- New dependency: `@noble/post-quantum` 0.6.1 (exact pin).
+
 ## [0.19.0] - 2026-07-16
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npx secretless-ai init          # run once, no install
 npm install -g secretless-ai    # install globally
 ```
 
-Requires Node.js 18 or later.
+Requires Node.js 20.19 or later.
 
 ### Homebrew
 

--- a/docs/use-cases/migrate-from-dotenv.md
+++ b/docs/use-cases/migrate-from-dotenv.md
@@ -1,7 +1,7 @@
 # I want to migrate from .env files
 
 **Time:** 3 minutes
-**Prerequisites:** Node.js 18+
+**Prerequisites:** Node.js 20.19+
 
 `.env` files are the most common way to manage secrets locally, but they have two problems: they are plaintext files that AI tools can read, and they get accidentally committed to git. Secretless imports your `.env` contents into encrypted storage and blocks AI tools from reading the files.
 

--- a/docs/use-cases/protect-my-credentials.md
+++ b/docs/use-cases/protect-my-credentials.md
@@ -1,7 +1,7 @@
 # I want to keep my API keys out of AI tools
 
 **Time:** 2 minutes
-**Prerequisites:** Node.js 18+
+**Prerequisites:** Node.js 20.19+
 
 AI coding tools like Claude Code, Cursor, and Copilot can read files in your project directory. If your `.env` file or `*.key` files are accessible, the AI tool sees those credentials in its context window.
 

--- a/docs/use-cases/secure-mcp-configs.md
+++ b/docs/use-cases/secure-mcp-configs.md
@@ -1,7 +1,7 @@
 # I want to protect MCP server credentials
 
 **Time:** 3 minutes
-**Prerequisites:** Node.js 18+, at least one MCP client configured
+**Prerequisites:** Node.js 20.19+, at least one MCP client configured
 
 MCP (Model Context Protocol) servers are configured through JSON files that contain plaintext API keys. These configuration files are readable by the AI tool that uses them, which means your credentials are visible in the LLM context window.
 

--- a/docs/use-cases/team-setup.md
+++ b/docs/use-cases/team-setup.md
@@ -1,7 +1,7 @@
 # I want to set up secretless for my team
 
 **Time:** 5 minutes
-**Prerequisites:** Node.js 18+, a shared secret backend (1Password, HashiCorp Vault, or GCP Secret Manager)
+**Prerequisites:** Node.js 20.19+, a shared secret backend (1Password, HashiCorp Vault, or GCP Secret Manager)
 
 When working on a team, each developer needs access to the same secrets without storing them in `.env` files committed to the repo. Secretless connects to a shared backend so every team member resolves secrets from the same source.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.19.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@noble/post-quantum": "0.6.1",
         "@opena2a/atx-verify": "0.3.0",
         "@opena2a/cli-ui": "0.4.0",
         "@opena2a/credential-patterns": "0.1.2",
@@ -24,7 +25,7 @@
         "vitest": "^4.1.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.19.0"
       },
       "optionalDependencies": {
         "@nanomind/engine": "^0.1.1",
@@ -104,6 +105,62 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/post-quantum": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@noble/post-quantum/-/post-quantum-0.6.1.tgz",
+      "integrity": "sha512-+pormrDZwjRw05U8ADK4JpHejo87+gBd+muRBB/ozztH5yhDLMDF4jHQWN3NQQAsu1zBNPWTG0ZwVI0CR29H0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "~2.2.0",
+        "@noble/curves": "~2.2.0",
+        "@noble/hashes": "~2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@opena2a/aim-core": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://github.com/opena2a-org/secretless-ai",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.19.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
@@ -54,6 +54,7 @@
     "@opena2a/aim-core": ">=0.2.0"
   },
   "dependencies": {
+    "@noble/post-quantum": "0.6.1",
     "@opena2a/atx-verify": "0.3.0",
     "@opena2a/cli-ui": "0.4.0",
     "@opena2a/credential-patterns": "0.1.2",

--- a/src/broker/cpi/assertion.pqc.test.ts
+++ b/src/broker/cpi/assertion.pqc.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Post-quantum broker assertion minting (AAP-SPEC §8.2/§9.3/§9.4/§9.5, RFC 9964).
+ *
+ * The byte-parity tests reproduce the AAP spec repo's published fixtures
+ * (agent-authorization-protocol examples/tokens/cgt-v1.mldsa65.jwt and
+ * cgt-v1.hybrid.general.json) from the published test-key seeds and fixed
+ * inputs, and compare sha256 digests — proving the reference broker, the spec
+ * generator (dilithium-py), and the conformance generator (@noble/post-quantum)
+ * mint identical bytes under FIPS 204 deterministic signing.
+ */
+
+import { createHash, createPublicKey, createPrivateKey, verify as cryptoVerify } from 'crypto';
+import { describe, expect, it } from 'vitest';
+import { ml_dsa65 } from '@noble/post-quantum/ml-dsa.js';
+import type { ResolutionContext } from '@opena2a/atx-verify' with { 'resolution-mode': 'import' };
+import {
+  type BrokerSigningKey,
+  brokerPublicAkpJwk,
+  generateBrokerPqcSigningKey,
+  mintBrokerAssertion,
+  mintBrokerAssertionMlDsa65,
+  mintHybridBrokerAssertion,
+} from './assertion';
+import type { ResourceBinding } from './types';
+
+// --- the spec repo's published fixture inputs (TEST values, never production) ----
+
+// broker-key-1 Ed25519 seed (agent-authorization-protocol examples/tokens/test-keys.json).
+const ED_SEED_HEX = '0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20';
+// broker-pqc-1 ML-DSA-65 seed (the FIPS 204 xi input / RFC 9964 AKP priv form).
+const PQC_SEED_HEX = '404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f';
+const PKCS8_ED25519_PREFIX = '302e020100300506032b657004220420';
+
+// 2026-06-01T12:00:00Z — the spec generator's fixed clock.
+const IAT = 1780315200;
+const JTI_CGT = '9f8e7d6c5b4a39281706f5e4d3c2b1a0';
+const JTI_CGT_PQ = 'b1c2d3e4f5a60718293a4b5c6d7e8f90';
+
+// sha256 of the published fixture bytes (examples/tokens/cgt-v1.mldsa65.jwt,
+// trimmed) and of the hybrid container's signed segments
+// (payload + "." + entry0.protected + "." + entry0.signature + ...).
+const COMPACT_PQ_SHA256 = '9c57544f3fc7309710acd2cc9078d2669f7e79b3ab2babe9fd1965291bc95900';
+const HYBRID_SHA256 = '365ac0793d9196f4c03eadf210fb0c1de47a2273ee55c9f986a15610f27163a7';
+
+const ctx = {
+  agentDid: 'did:opena2a:agent:acme/orders-reader',
+  issuerChain: ['did:opena2a:authority:opena2a.org'],
+  trustLevel: 4,
+} as ResolutionContext;
+
+const binding: ResourceBinding = {
+  audience: 'https://api.orders.internal',
+  scope: 'orders.read',
+  trustClass: 'orders:read',
+  ttlSeconds: 300,
+} as ResourceBinding;
+
+function specEdKey(): BrokerSigningKey {
+  return {
+    kid: 'broker-key-1',
+    issuer: 'https://broker.acme.example',
+    privateKey: createPrivateKey({
+      key: Buffer.from(PKCS8_ED25519_PREFIX + ED_SEED_HEX, 'hex'),
+      format: 'der',
+      type: 'pkcs8',
+    }),
+  };
+}
+
+function specPqcKey() {
+  return generateBrokerPqcSigningKey(
+    'https://broker.acme.example',
+    'broker-pqc-1',
+    Buffer.from(PQC_SEED_HEX, 'hex'),
+  );
+}
+
+const sha256 = (s: string) => createHash('sha256').update(s, 'utf8').digest('hex');
+const b64json = (segment: string) =>
+  JSON.parse(Buffer.from(segment, 'base64url').toString('utf8')) as Record<string, unknown>;
+
+describe('broker assertion — ML-DSA-65 suite (AAP §9.3 PQ-interop lane)', () => {
+  it('mints a compact ML-DSA-65 JWT that verifies and matches the published fixture bytes', () => {
+    const token = mintBrokerAssertionMlDsa65(ctx, binding, specPqcKey(), IAT, JTI_CGT_PQ, {
+      deterministic: true,
+    });
+    const [h, p, s] = token.split('.');
+    expect(b64json(h)).toEqual({ alg: 'ML-DSA-65', typ: 'JWT', kid: 'broker-pqc-1' });
+    expect(b64json(p)).toMatchObject({ trust_class: 'orders:read', jti: JTI_CGT_PQ });
+    expect(
+      ml_dsa65.verify(Buffer.from(s, 'base64url'), Buffer.from(`${h}.${p}`), specPqcKey().publicKey),
+    ).toBe(true);
+    // Byte parity with the spec repo's dilithium-py generator.
+    expect(sha256(token)).toBe(COMPACT_PQ_SHA256);
+  });
+
+  it('hedged signing (the production default) still verifies but is non-deterministic', () => {
+    const a = mintBrokerAssertionMlDsa65(ctx, binding, specPqcKey(), IAT, JTI_CGT_PQ);
+    const b = mintBrokerAssertionMlDsa65(ctx, binding, specPqcKey(), IAT, JTI_CGT_PQ);
+    const [h, p, s] = a.split('.');
+    expect(
+      ml_dsa65.verify(Buffer.from(s, 'base64url'), Buffer.from(`${h}.${p}`), specPqcKey().publicKey),
+    ).toBe(true);
+    expect(a).not.toBe(b);
+  });
+
+  it('refuses to mint without trustClass, like the EdDSA path', () => {
+    const bad = { ...binding, trustClass: undefined } as unknown as ResourceBinding;
+    expect(() => mintBrokerAssertionMlDsa65(ctx, bad, specPqcKey(), IAT, JTI_CGT_PQ)).toThrow(
+      /trustClass/,
+    );
+  });
+
+  it('exports the public half as an RFC 9964 AKP JWK (no priv member)', () => {
+    const jwk = brokerPublicAkpJwk(specPqcKey());
+    expect(jwk).toEqual({
+      kty: 'AKP',
+      pub: Buffer.from(specPqcKey().publicKey).toString('base64url'),
+      kid: 'broker-pqc-1',
+      use: 'sig',
+      alg: 'ML-DSA-65',
+    });
+    expect(jwk).not.toHaveProperty('priv');
+    expect(Buffer.from(String(jwk.pub), 'base64url')).toHaveLength(1952);
+  });
+});
+
+describe('broker assertion — hybrid Ed25519 + ML-DSA-65 (AAP §9.4)', () => {
+  it('mints a General JSON token whose every entry verifies, matching the published fixture bytes', () => {
+    const token = mintHybridBrokerAssertion(ctx, binding, specEdKey(), specPqcKey(), IAT, JTI_CGT, {
+      deterministic: true,
+    });
+    expect(token.signatures).toHaveLength(2);
+    const [ed, pq] = token.signatures;
+    expect(b64json(ed.protected)).toEqual({ alg: 'EdDSA', kid: 'broker-key-1' });
+    expect(b64json(pq.protected)).toEqual({ alg: 'ML-DSA-65', kid: 'broker-pqc-1' });
+
+    // Both suite families verify over the same payload — the §8.2 hybrid rule.
+    const edPub = createPublicKey(specEdKey().privateKey);
+    expect(
+      cryptoVerify(
+        null,
+        Buffer.from(`${ed.protected}.${token.payload}`),
+        edPub,
+        Buffer.from(ed.signature, 'base64url'),
+      ),
+    ).toBe(true);
+    expect(
+      ml_dsa65.verify(
+        Buffer.from(pq.signature, 'base64url'),
+        Buffer.from(`${pq.protected}.${token.payload}`),
+        specPqcKey().publicKey,
+      ),
+    ).toBe(true);
+
+    // Byte parity with the spec repo's published hybrid fixture.
+    const concat = `${token.payload}.${token.signatures
+      .map((e) => `${e.protected}.${e.signature}`)
+      .join('.')}`;
+    expect(sha256(concat)).toBe(HYBRID_SHA256);
+
+    // The payload is byte-identical to the compact EdDSA form's payload segment:
+    // one claim set, two serializations (AAP §9.1 serialization is canonicalization).
+    const compact = mintBrokerAssertion(ctx, binding, specEdKey(), IAT, JTI_CGT);
+    expect(token.payload).toBe(compact.split('.')[1]);
+  });
+
+  it('rejects key pairs from different issuers', () => {
+    const foreign = { ...specPqcKey(), issuer: 'https://other.example' };
+    expect(() => mintHybridBrokerAssertion(ctx, binding, specEdKey(), foreign, IAT, JTI_CGT)).toThrow(
+      /same issuer/,
+    );
+  });
+});

--- a/src/broker/cpi/assertion.ts
+++ b/src/broker/cpi/assertion.ts
@@ -14,11 +14,40 @@
  * The assertion is a compact EdDSA JWT. The SAME assertion a broker mints for its own
  * agents is what a peer broker will verify for a foreign agent in v2 federation — which
  * is why the claims carry the ATX issuer chain and trust level, not just a subject.
+ *
+ * Post-quantum profile (AAP-SPEC §8.2/§9.4/§9.5, RFC 9964): the broker can also mint
+ * a compact ML-DSA-65 assertion (the PQ-interop lane) and a hybrid Ed25519 + ML-DSA-65
+ * assertion as JWS General JSON Serialization — one signature entry per suite over the
+ * same payload; a hybrid token verifies only if every declared entry verifies and both
+ * suite families are present. Serialization-profile decision:
+ * agent-authorization-protocol decisions/2026-07-16-mldsa65-serialization-profile.md.
  */
 
 import * as crypto from 'crypto';
 import type { ResolutionContext } from '@opena2a/atx-verify' with { 'resolution-mode': 'import' };
 import type { ResourceBinding } from './types';
+
+// @noble/post-quantum is ESM-only; this package compiles to CommonJS, so the
+// module loads via require(esm) — supported since Node 20.19 (the package
+// engines floor). Lazy + memoized: classical EdDSA minting never touches it.
+type MlDsaModule = typeof import('@noble/post-quantum/ml-dsa.js', {
+  with: { 'resolution-mode': 'import' },
+});
+let mlDsaModule: MlDsaModule | undefined;
+function mlDsa65(): MlDsaModule['ml_dsa65'] {
+  if (!mlDsaModule) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      mlDsaModule = require('@noble/post-quantum/ml-dsa.js') as MlDsaModule;
+    } catch (err) {
+      throw new Error(
+        'ML-DSA-65 minting needs Node >= 20.19 (require() of the ESM-only ' +
+          `@noble/post-quantum). Underlying error: ${(err as Error).message}`,
+      );
+    }
+  }
+  return mlDsaModule.ml_dsa65;
+}
 
 /**
  * The broker's IdP signing key. In production this is the existing short-lived delegated
@@ -58,19 +87,37 @@ export function mintBrokerAssertion(
   nowSeconds: number = Math.floor(Date.now() / 1000),
   jti: string = crypto.randomBytes(16).toString('hex'),
 ): string {
+  const header = { alg: 'EdDSA', typ: 'JWT', kid: key.kid };
+  const signingInput = `${base64url(JSON.stringify(header))}.${base64url(
+    JSON.stringify(buildAssertionClaims(ctx, binding, key.issuer, nowSeconds, jti)),
+  )}`;
+  const signature = crypto.sign(null, Buffer.from(signingInput), key.privateKey);
+  return `${signingInput}.${base64url(signature)}`;
+}
+
+/**
+ * The pinned CGT/DA claim set (AAP-SPEC §4.2) — member order is normative for
+ * the signed bytes, so every mint path derives it from this one builder.
+ */
+function buildAssertionClaims(
+  ctx: ResolutionContext,
+  binding: ResourceBinding,
+  issuer: string,
+  nowSeconds: number,
+  jti: string,
+): Record<string, unknown> {
   // trust_class is the abstract ATX capability from the matched policy clause
   // (AAP-SPEC §4.2), injected by the grant resolver. Refuse to mint without it:
   // a scope-shaped trust_class fails the pinned claim schema, and silently
   // minting a non-conformant token is worse than failing loudly here.
   if (!binding.trustClass) {
     throw new Error(
-      'mintBrokerAssertion: binding.trustClass is required (AAP-SPEC §4.2); ' +
+      'broker assertion minting: binding.trustClass is required (AAP-SPEC §4.2); ' +
         'the grant resolver injects it from the matched policy clause',
     );
   }
-  const header = { alg: 'EdDSA', typ: 'JWT', kid: key.kid };
-  const claims = {
-    iss: key.issuer,
+  return {
+    iss: issuer,
     sub: ctx.agentDid,
     aud: binding.audience,
     scope: binding.scope,
@@ -82,9 +129,6 @@ export function mintBrokerAssertion(
     exp: nowSeconds + binding.ttlSeconds,
     jti,
   };
-  const signingInput = `${base64url(JSON.stringify(header))}.${base64url(JSON.stringify(claims))}`;
-  const signature = crypto.sign(null, Buffer.from(signingInput), key.privateKey);
-  return `${signingInput}.${base64url(signature)}`;
 }
 
 /** Export the public half as a JWK for the broker's discovery document (operator's domain). */
@@ -92,4 +136,140 @@ export function brokerPublicJwk(key: BrokerSigningKey): Record<string, unknown> 
   const pub = crypto.createPublicKey(key.privateKey);
   const jwk = pub.export({ format: 'jwk' }) as Record<string, unknown>;
   return { ...jwk, kid: key.kid, use: 'sig', alg: 'EdDSA' };
+}
+
+// --- post-quantum suite (ML-DSA-65, RFC 9964) -----------------------------------
+
+/**
+ * The broker's ML-DSA-65 signing key (FIPS 204). Same lifecycle as the Ed25519
+ * key: rotates, only the public half (an RFC 9964 AKP JWK) is published.
+ */
+export interface BrokerPqcSigningKey {
+  /** Key id published in the broker's discovery document; lands in the header `kid`. */
+  kid: string;
+  /** ML-DSA-65 secret key bytes (FIPS 204 expanded form). */
+  secretKey: Uint8Array;
+  /** ML-DSA-65 public key bytes (1952 bytes, FIPS 204 §5.3). */
+  publicKey: Uint8Array;
+  /** Issuer identifier for the broker IdP; MUST match the Ed25519 key's issuer. */
+  issuer: string;
+}
+
+/**
+ * Generate a fresh ML-DSA-65 broker signing key. `seed` (the 32-byte FIPS 204
+ * xi input — the same seed form RFC 9964 pins for the AKP `priv` parameter) is
+ * injectable for deterministic tests and fixture generation; the default is a
+ * fresh random seed.
+ */
+export function generateBrokerPqcSigningKey(
+  issuer: string,
+  kid: string,
+  seed: Uint8Array = crypto.randomBytes(32),
+): BrokerPqcSigningKey {
+  const { secretKey, publicKey } = mlDsa65().keygen(seed);
+  return { kid, secretKey, publicKey, issuer };
+}
+
+/** Signing options shared by the PQ mint paths. */
+export interface PqcMintOptions {
+  /**
+   * Use the FIPS 204 deterministic signing variant. Fixture generation REQUIRES
+   * it (AAP-SPEC §9.7: fixed keys + fixed claims = fixed bytes); production
+   * minting defaults to hedged signing, which FIPS 204 prefers for side-channel
+   * resilience. Verification is identical either way.
+   */
+  deterministic?: boolean;
+}
+
+function signMlDsa65(key: BrokerPqcSigningKey, message: Buffer, opts?: PqcMintOptions): Buffer {
+  // Empty context string and pure ML-DSA (no pre-hash), as RFC 9964 requires.
+  return Buffer.from(
+    mlDsa65().sign(message, key.secretKey, opts?.deterministic ? { extraEntropy: false } : {}),
+  );
+}
+
+/**
+ * Mint a compact ML-DSA-65 assertion — the PQ-interop lane of AAP-SPEC §9.3,
+ * for counterparties that advertise RFC 9964 support. Same pinned claim set
+ * and JWS Signing Input as the EdDSA form; only the suite differs.
+ */
+export function mintBrokerAssertionMlDsa65(
+  ctx: ResolutionContext,
+  binding: ResourceBinding,
+  key: BrokerPqcSigningKey,
+  nowSeconds: number = Math.floor(Date.now() / 1000),
+  jti: string = crypto.randomBytes(16).toString('hex'),
+  opts?: PqcMintOptions,
+): string {
+  const header = { alg: 'ML-DSA-65', typ: 'JWT', kid: key.kid };
+  const signingInput = `${base64url(JSON.stringify(header))}.${base64url(
+    JSON.stringify(buildAssertionClaims(ctx, binding, key.issuer, nowSeconds, jti)),
+  )}`;
+  const signature = signMlDsa65(key, Buffer.from(signingInput), opts);
+  return `${signingInput}.${base64url(signature)}`;
+}
+
+/** JWS General JSON Serialization (RFC 7515 §7.2.1) — AAP-SPEC §9.4. */
+export interface JwsGeneralJson {
+  payload: string;
+  signatures: { protected: string; signature: string }[];
+}
+
+/**
+ * Mint a hybrid Ed25519 + ML-DSA-65 assertion (AAP-SPEC §8.2/§9.4): JWS General
+ * JSON Serialization with one signature entry per suite over the same payload,
+ * each protected header exactly {alg, kid}. This is the RECOMMENDED form
+ * wherever both ends implement AAP; a conformant verifier accepts it only if
+ * every declared entry verifies and both suite families are present.
+ */
+export function mintHybridBrokerAssertion(
+  ctx: ResolutionContext,
+  binding: ResourceBinding,
+  edKey: BrokerSigningKey,
+  pqcKey: BrokerPqcSigningKey,
+  nowSeconds: number = Math.floor(Date.now() / 1000),
+  jti: string = crypto.randomBytes(16).toString('hex'),
+  opts?: PqcMintOptions,
+): JwsGeneralJson {
+  if (edKey.issuer !== pqcKey.issuer) {
+    throw new Error(
+      'mintHybridBrokerAssertion: the Ed25519 and ML-DSA-65 keys must belong to ' +
+        `the same issuer (got "${edKey.issuer}" and "${pqcKey.issuer}")`,
+    );
+  }
+  const payload = base64url(
+    JSON.stringify(buildAssertionClaims(ctx, binding, edKey.issuer, nowSeconds, jti)),
+  );
+  const edProtected = base64url(JSON.stringify({ alg: 'EdDSA', kid: edKey.kid }));
+  const pqProtected = base64url(JSON.stringify({ alg: 'ML-DSA-65', kid: pqcKey.kid }));
+  return {
+    payload,
+    signatures: [
+      {
+        protected: edProtected,
+        signature: base64url(
+          crypto.sign(null, Buffer.from(`${edProtected}.${payload}`), edKey.privateKey),
+        ),
+      },
+      {
+        protected: pqProtected,
+        signature: base64url(signMlDsa65(pqcKey, Buffer.from(`${pqProtected}.${payload}`), opts)),
+      },
+    ],
+  };
+}
+
+/**
+ * Export the ML-DSA-65 public half as an RFC 9964 AKP JWK for the broker's
+ * discovery document. `alg` is REQUIRED on AKP keys; the private `priv`
+ * member (the 32-byte seed) is never exported.
+ */
+export function brokerPublicAkpJwk(key: BrokerPqcSigningKey): Record<string, unknown> {
+  return {
+    kty: 'AKP',
+    pub: base64url(Buffer.from(key.publicKey)),
+    kid: key.kid,
+    use: 'sig',
+    alg: 'ML-DSA-65',
+  };
 }

--- a/src/broker/cpi/index.ts
+++ b/src/broker/cpi/index.ts
@@ -30,7 +30,14 @@ export {
   mintBrokerAssertion,
   generateBrokerSigningKey,
   brokerPublicJwk,
+  mintBrokerAssertionMlDsa65,
+  mintHybridBrokerAssertion,
+  generateBrokerPqcSigningKey,
+  brokerPublicAkpJwk,
   type BrokerSigningKey,
+  type BrokerPqcSigningKey,
+  type PqcMintOptions,
+  type JwsGeneralJson,
 } from './assertion';
 
 // Declared-but-not-implemented seams (v1).

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,8 @@ export {
   GrantPolicy, EphemeralWorker, HttpsDownstreamCaller, GrantResolver,
   ExchangeProvider, HttpsTokenExchangeTransport, createOktaExchangeProvider,
   MapProviderRegistry, mintBrokerAssertion, generateBrokerSigningKey, brokerPublicJwk,
+  mintBrokerAssertionMlDsa65, mintHybridBrokerAssertion, generateBrokerPqcSigningKey,
+  brokerPublicAkpJwk,
   RetrieveProvider, AssumeProvider,
   TOKEN_EXCHANGE_GRANT_TYPE, SUBJECT_TOKEN_TYPE_JWT, REQUESTED_TOKEN_TYPE_ACCESS,
   type Atx, type AtxSignature, type AtxPublicKey, type AtxTrustAnchors,
@@ -103,6 +105,7 @@ export {
   type CredentialProvider, type ProviderRegistry,
   type ExchangeProviderConfig, type TokenExchangeRequest, type TokenExchangeResponse,
   type TokenExchangeTransport, type OktaAdapterOptions, type BrokerSigningKey,
+  type BrokerPqcSigningKey, type PqcMintOptions, type JwsGeneralJson,
 } from './broker';
 
 // Identity Vault (requires @opena2a/aim-core)


### PR DESCRIPTION
AAP-SPEC 0.4.0-draft activated the ML-DSA-65 suite (RFC 9964, May 2026, registered the JOSE `ML-DSA-65` alg and `AKP` key type — the exact condition §9.5 named). This makes the reference broker mint what the spec now claims. Companion changes already merged: opena2a-standards/agent-authorization-protocol#9 (spec + fixtures) and opena2a-standards/aap-conformance#1 (verifier pair, 24 fixtures, parity + spec-pin green).

- `mintBrokerAssertionMlDsa65` — compact `ML-DSA-65` JWT (the §9.3 PQ-interop lane).
- `mintHybridBrokerAssertion` — hybrid Ed25519 + ML-DSA-65 as JWS General JSON (§9.4): one signature entry per suite over the same payload; a conformant verifier accepts only if every declared entry verifies and both suite families are present. Issuer mismatch between the two keys throws.
- `generateBrokerPqcSigningKey` (seed-injectable — the FIPS 204 xi / RFC 9964 AKP `priv` form) and `brokerPublicAkpJwk` (AKP public JWK for the discovery document; `priv` never exported).
- Signing hedged by default, deterministic on request (`PqcMintOptions.deterministic`, required for byte-exact fixtures). Empty context, no pre-hash, per RFC 9964.
- Tests pin sha256 byte-parity with the spec repo's published fixture bytes — three independent FIPS 204 implementations (dilithium-py, @noble/post-quantum, OpenSSL via Node ≥25) agree byte-for-byte. Existing compact EdDSA path byte-for-byte unchanged (1117/1117 tests).
- Engines floor `>=18` → `>=20.19.0` (require(esm) for the ESM-only @noble/post-quantum, lazily loaded — classical minting never touches it; Node 18/20 are EOL). README + use-case docs updated to match.
- New dependency: `@noble/post-quantum` 0.6.1, exact pin.

Serialization-profile decision + rationale: agent-authorization-protocol `decisions/2026-07-16-mldsa65-serialization-profile.md`. Not part of any npm release yet — rides the next version (0.19.0 shipped today without it).