### PR TITLE
Guard: stop failing open on pretty JSON, check every candidate path, fix custom-rule hook generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,19 @@
 
 ### Security
 
-- **The guard hook no longer fails open on a pretty-printed payload.** `tool_name` and `file_path` were extracted with greps that match only compact JSON (`"tool_name":"Bash"`, no space after the colon). A client that pretty-prints its hook payload left both empty, which skipped the entire Bash-command branch and the file-path guard, so every guard silently permitted the call. This is the same dead-branch class as the 2026-07-16 `FILE_PATH` regression, reached through payload formatting rather than through `set -euo pipefail`. Both fields are now parsed with `python3`'s JSON module (as the `command` field already was), with the greps kept as the fallback for hosts without python3. Regression tests drive the hook with pretty-printed payloads and assert the deny still fires; both fail against the previous hook.
+- **The guard hook no longer fails open on a pretty-printed payload.** `tool_name` and `file_path` were extracted with greps that match only compact JSON (`"tool_name":"Bash"`, no space after the colon). A client that pretty-prints its hook payload left both empty, which skipped the entire Bash-command branch and the file-path guard, so every guard silently permitted the call. This is the same dead-branch class as the 2026-07-16 `FILE_PATH` regression, reached through payload formatting rather than through `set -euo pipefail`. Both fields are now parsed with `python3`'s JSON module (as the `command` field already was), with the greps kept as the fallback for hosts without python3 — where python3 is absent, the pretty-printed payload still fails open, so this closes the hole only on hosts that have it.
 
-### Fixed
+  Only non-empty strings are accepted from the parser. `str()` of a number, boolean, or object produced a non-empty WRONG value (`'123'`, `'True'`), which suppressed the grep fallback and left the guard reading a field that was not there.
 
-- **The command guard and the file-path guard now agree about template files.** `Read(.env.example)` was allowed while `cat .env.example` was refused, so committed placeholder files were readable by one layer and blocked by the other. The command guard now drops path tokens whose FINAL suffix is a template suffix (`.example`, `.sample`, `.template`, `.dist`) before applying the secret-file patterns.
+- **The file guard now checks every candidate path in the payload, not just the first.** The structured parse reads the documented top-level fields, so on its own it would have narrowed the older whole-payload grep: a secret path nested below the top level (MultiEdit-style edit lists, MCP tool payloads) was no longer seen once a benign top-level path satisfied the extraction. Candidates from the structured walk and from the greps are now unioned and each one is checked, so a benign `path` cannot mask a nested secret `file_path`.
 
-  The suffix is anchored at the end of the token, which is what keeps this an exemption rather than an evasion: `.env.example.real`, `.env.example.bak`, and `.env.exampleX` all end in something else, survive the scrub, and still block. The scrub also works per path token rather than per command, and the token character class holds only path characters, so a token cannot span a separator — `cat .env.example && cat .env`, `cat .env.template | cat .env`, and `cat .env;.example` all still block on the real secret. Verified with a 50-command differential corpus run against the old and new hooks: 17 template reads unblocked, 0 security regressions.
+### Known limitation (deliberate, documented in the hook)
+
+- **The command guard still refuses to read committed template files**, while the file-path guard allows them. The two layers disagree on purpose.
+
+  The obvious fix — subtracting template-suffixed path tokens from the command before matching — was implemented, tested against a 50-command corpus, and then reverted, because it is a credential bypass. The guard is a denylist over command TEXT whose only evidence is the literal secret path appearing after a verb; removing that literal hands the attacker the deletion. `cat "$(basename <name>.env.example .example)"` reconstructs the real path from the very token the scrub erased, needs no preconditions, and was measured reading a real secret file that the previous hook blocked. Requiring the extension match at the end of the token fails identically, because the template token still never matches.
+
+  Closing the disagreement safely requires resolving the path a command would actually open rather than pattern-matching its text. Until then, over-blocking a placeholder file is the correct trade against leaking a real one.
 
 All notable changes to [secretless-ai](https://www.npmjs.com/package/secretless-ai) are documented in this file.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+### Security
+
+- **The guard hook no longer fails open on a pretty-printed payload.** `tool_name` and `file_path` were extracted with greps that match only compact JSON (`"tool_name":"Bash"`, no space after the colon). A client that pretty-prints its hook payload left both empty, which skipped the entire Bash-command branch and the file-path guard, so every guard silently permitted the call. This is the same dead-branch class as the 2026-07-16 `FILE_PATH` regression, reached through payload formatting rather than through `set -euo pipefail`. Both fields are now parsed with `python3`'s JSON module (as the `command` field already was), with the greps kept as the fallback for hosts without python3. Regression tests drive the hook with pretty-printed payloads and assert the deny still fires; both fail against the previous hook.
+
+### Fixed
+
+- **The command guard and the file-path guard now agree about template files.** `Read(.env.example)` was allowed while `cat .env.example` was refused, so committed placeholder files were readable by one layer and blocked by the other. The command guard now drops path tokens whose FINAL suffix is a template suffix (`.example`, `.sample`, `.template`, `.dist`) before applying the secret-file patterns.
+
+  The suffix is anchored at the end of the token, which is what keeps this an exemption rather than an evasion: `.env.example.real`, `.env.example.bak`, and `.env.exampleX` all end in something else, survive the scrub, and still block. The scrub also works per path token rather than per command, and the token character class holds only path characters, so a token cannot span a separator — `cat .env.example && cat .env`, `cat .env.template | cat .env`, and `cat .env;.example` all still block on the real secret. Verified with a 50-command differential corpus run against the old and new hooks: 17 template reads unblocked, 0 security regressions.
+
 All notable changes to [secretless-ai](https://www.npmjs.com/package/secretless-ai) are documented in this file.
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
   Only non-empty strings are accepted from the parser. `str()` of a number, boolean, or object produced a non-empty WRONG value (`'123'`, `'True'`), which suppressed the grep fallback and left the guard reading a field that was not there.
 
+- **Custom `env:` or `bash:` rules no longer generate a broken hook.** `customRulesToHookBlocks` returned its blocks without a trailing newline, and the caller interpolates that directly ahead of `  exit 0`, so the last block's `fi` collided with it (`  fi  exit 0`). The generated script was not valid bash, and the hook exited 2 on every tool call, for every tool, in any project defining those rules. It failed closed, but a guard that blocks `ls -la` gets uninstalled. `files:`-only rules produce an empty block string and never hit it, which is why the existing `bash -n` coverage — written against a `files:` rule — never caught it. The new test asserts the rules actually reach the generated hook before checking it parses, so a fixture rejected by the pattern validator cannot report a false pass.
+
 - **The file guard now checks every candidate path in the payload, not just the first.** The structured parse reads the documented top-level fields, so on its own it would have narrowed the older whole-payload grep: a secret path nested below the top level (MultiEdit-style edit lists, MCP tool payloads) was no longer seen once a benign top-level path satisfied the extraction. Candidates from the structured walk and from the greps are now unioned and each one is checked, so a benign `path` cannot mask a nested secret `file_path`.
 
 ### Known limitation (deliberate, documented in the hook)

--- a/src/custom-rules.ts
+++ b/src/custom-rules.ts
@@ -216,7 +216,15 @@ export function customRulesToHookBlocks(rules: CustomRules): string {
     );
   }
 
-  return blocks.join('\n');
+  // Trailing newline is REQUIRED. The caller interpolates this directly ahead of
+  // `  exit 0`, so without it the last block's `fi` and that `exit 0` collide on
+  // one line (`  fi  exit 0`) and the generated hook is not valid bash. The hook
+  // then exits 2 on EVERY tool call, for every tool, in any project that defines
+  // `env:` or `bash:` rules. It fails closed, but a guard that blocks `ls -la`
+  // gets uninstalled. `files:`-only rules produce an empty string here and so
+  // never hit it, which is why this survived: the existing `bash -n` coverage
+  // only exercised a `files:` rule.
+  return blocks.length > 0 ? blocks.join('\n') + '\n' : '';
 }
 
 /**

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -273,12 +273,27 @@ describe('init', () => {
         ).toBe(true);
       });
 
-      it('still allows a template read when the payload is pretty-printed', () => {
+      it('allows a benign command when the payload is pretty-printed', () => {
         init(dir);
         const hookPath = path.join(dir, '.claude', 'hooks', 'secretless-guard.sh');
 
         const pretty = JSON.stringify(
-          { tool_name: 'Bash', tool_input: { command: 'cat .env.example' } },
+          { tool_name: 'Bash', tool_input: { command: 'ls -la' } },
+          null,
+          2,
+        );
+        expect(runHookRaw(hookPath, pretty)).toBe(false);
+      });
+
+      it('allows a template file read through the FILE guard when pretty-printed', () => {
+        init(dir);
+        const hookPath = path.join(dir, '.claude', 'hooks', 'secretless-guard.sh');
+
+        // The file guard exempts templates; the COMMAND guard deliberately does
+        // not (see the revert note in init.ts). This asserts the file-guard half
+        // still works once the payload parses.
+        const pretty = JSON.stringify(
+          { tool_name: 'Read', tool_input: { file_path: '/p/.env.example' } },
           null,
           2,
         );
@@ -286,59 +301,100 @@ describe('init', () => {
       });
     });
 
-    describe('command guard agrees with the file-path guard about template files', () => {
-      it('allows reading committed template files', () => {
-        init(dir);
-        const hookPath = path.join(dir, '.claude', 'hooks', 'secretless-guard.sh');
-
-        const mustAllow = [
-          'cat .env.example',
-          'cat .env.sample',
-          'cat .env.template',
-          'cat .env.dist',
-          'head .env.example',
-          'tail -5 .env.example',
-          'grep DATABASE_URL .env.example',
-          'sed -n 1,5p .env.example',
-          "awk '{print}' .env.example",
-          'cat ./config/.env.example',
-          'cat config.env.sample',
-          'cat app.env.template',
-          'node -e "require(\'fs\').readFileSync(\'.env.example\')"',
-          'python3 -c "open(\'.env.example\').read()"',
-        ];
-        for (const c of mustAllow) {
-          expect(runHookCmd(hookPath, c), `expected hook to ALLOW template read: ${c}`).toBe(false);
-        }
-      });
-
-      it('still blocks real secret files, and every near-miss of the template suffix', () => {
+    // A template exemption in the COMMAND guard was implemented, then reverted:
+    // subtracting template-suffixed tokens from the command text is a credential
+    // bypass, because the command can rebuild the real path from the token that
+    // was deleted. These cases lock that the guard stays closed.
+    describe('the command guard must not be weakened by template names', () => {
+      it('blocks a command that derives a real secret path from a template name', () => {
         init(dir);
         const hookPath = path.join(dir, '.claude', 'hooks', 'secretless-guard.sh');
 
         const mustBlock = [
-          // real secrets, unchanged
+          'cat "$(basename .env.example .example)"',
+          'cat "$(printf %s .env.example | cut -d. -f1-2)"',
+          'head "$(basename .env.example .example)"',
+          'cat "$(basename server.key.example .example)"',
+          'python3 -c "print(open(\'.env.example\'.replace(\'.example\',\'\')).read())"',
+        ];
+        for (const c of mustBlock) {
+          expect(
+            runHookCmd(hookPath, c),
+            `a command that reconstructs a real secret path must stay BLOCKED: ${c}`,
+          ).toBe(true);
+        }
+      });
+
+      it('still blocks direct secret reads', () => {
+        init(dir);
+        const hookPath = path.join(dir, '.claude', 'hooks', 'secretless-guard.sh');
+
+        for (const c of [
           'cat .env',
           'cat .env.local',
           'cat .env.production',
           'cat prod.env',
           'cat server.key',
           'cat id_rsa.pem',
-          // the suffix must be ANCHORED at the end of the token, or the
-          // exemption becomes an evasion
-          'cat .env.example.real',
-          'cat .env.example.bak',
-          'cat .env.exampleX',
-          // a template elsewhere in the command must not whitelist a real read
           'cat .env.example && cat .env',
-          'cat .env.example; cat .env',
-          'cat .env.template | cat .env',
-          // a token must not span a separator
           'cat .env;.example',
-        ];
-        for (const c of mustBlock) {
+        ]) {
           expect(runHookCmd(hookPath, c), `expected hook to BLOCK: ${c}`).toBe(true);
         }
+      });
+    });
+
+    // The structured parse must not NARROW the older whole-payload grep: a
+    // secret path nested below the documented top-level fields (MultiEdit-style
+    // edit lists, MCP tool payloads) has to be seen too.
+    describe('every candidate path in the payload is checked', () => {
+      function runHookRaw(hookPath: string, input: string): boolean {
+        const out = execSync(`bash ${JSON.stringify(hookPath)}`, { input, encoding: 'utf-8' });
+        return /"permissionDecision":"deny"/.test(out);
+      }
+
+      it('blocks a secret path nested under a benign top-level path', () => {
+        init(dir);
+        const hookPath = path.join(dir, '.claude', 'hooks', 'secretless-guard.sh');
+
+        const nested = JSON.stringify({
+          tool_name: 'Edit',
+          tool_input: { path: 'README.md', edits: [{ file_path: '/project/.env' }] },
+        });
+        expect(
+          runHookRaw(hookPath, nested),
+          'a nested secret path must not be masked by a benign top-level path',
+        ).toBe(true);
+      });
+
+      it('does not block when every candidate is benign', () => {
+        init(dir);
+        const hookPath = path.join(dir, '.claude', 'hooks', 'secretless-guard.sh');
+
+        const benign = JSON.stringify({
+          tool_name: 'Edit',
+          tool_input: { path: 'README.md', edits: [{ file_path: '/project/src/index.ts' }] },
+        });
+        expect(runHookRaw(hookPath, benign)).toBe(false);
+      });
+
+      it('does not block when the only candidate is a template file', () => {
+        init(dir);
+        const hookPath = path.join(dir, '.claude', 'hooks', 'secretless-guard.sh');
+
+        const tpl = JSON.stringify({ tool_name: 'Read', tool_input: { file_path: '/p/.env.example' } });
+        expect(runHookRaw(hookPath, tpl)).toBe(false);
+      });
+
+      it('blocks a non-string field without letting it suppress the real path', () => {
+        init(dir);
+        const hookPath = path.join(dir, '.claude', 'hooks', 'secretless-guard.sh');
+
+        const odd = JSON.stringify({
+          tool_name: 'Read',
+          tool_input: { path: 123, edits: [{ file_path: '/project/.env' }] },
+        });
+        expect(runHookRaw(hookPath, odd)).toBe(true);
       });
     });
   });

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -88,6 +88,33 @@ describe('init', () => {
     // Regression: a custom wildcard file rule (`private*`) must keep glob semantics in the
     // generated hook. Single-quoting the fragment turned `*` literal and silently neutered
     // the rule, so `private_key.txt` was allowed despite the user asking to block it.
+    // Any project with `env:` or `bash:` rules generated a hook whose last
+    // custom block ended `  fi  exit 0` on one line — not valid bash. The hook
+    // exited 2 on every tool call, for every tool. `files:`-only rules produce
+    // an empty block string and so never hit it, which is exactly why the
+    // pre-existing `bash -n` test below never caught it.
+    it('generates valid bash for env: and bash: custom rules, not just files:', () => {
+      fs.writeFileSync(
+        path.join(dir, '.secretless-rules.yaml'),
+        'env:\n  - MY_CUSTOM_TOKEN\nbash:\n  - mytool-dump\n',
+      );
+      init(dir);
+      const hookPath = path.join(dir, '.claude', 'hooks', 'secretless-guard.sh');
+
+      // Guard the fixture itself: if the rules were rejected by the validator
+      // they never reach the hook and this test proves nothing.
+      const script = fs.readFileSync(hookPath, 'utf-8');
+      expect(script, 'custom rules must actually reach the generated hook').toContain('MY_CUSTOM_TOKEN');
+      expect(script).toContain('mytool-dump');
+
+      execSync(`bash -n ${JSON.stringify(hookPath)}`);
+
+      // And it must actually run: a benign command exits 0, not 2.
+      const input = JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'ls -la' } });
+      const out = execSync(`bash ${JSON.stringify(hookPath)}`, { input, encoding: 'utf-8' });
+      expect(/"permissionDecision":"deny"/.test(out)).toBe(false);
+    });
+
     it('honors custom wildcard file rules (private*) in the generated case glob', () => {
       fs.writeFileSync(path.join(dir, '.secretless-rules.yaml'), 'files:\n  - "private*"\n');
       init(dir);

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -219,6 +219,128 @@ describe('init', () => {
       expect(runHookCmd(hookPath, 'cat .env'), 'expected hook to BLOCK `cat .env`').toBe(true);
       expect(runHookCmd(hookPath, 'ls -la'), 'expected hook to ALLOW `ls -la`').toBe(false);
     });
+
+    // The command guard and the file-path guard disagreed about template files:
+    // `Read(.env.example)` was allowed while `cat .env.example` was refused, so
+    // ordinary work on committed placeholder files was blocked by one layer and
+    // permitted by the other. The command guard now drops path tokens whose FINAL
+    // suffix is a template suffix before applying the secret-file patterns.
+    //
+    // The anchoring is the whole security argument. `.env.example.real` ends in
+    // `.real`, not a template suffix, so it survives the scrub and still blocks;
+    // and because the scrub works per path token rather than per command, a
+    // template mentioned anywhere in the command cannot whitelist a real secret
+    // read elsewhere in the same command.
+    // The hook extracted tool_name / file_path with greps that require COMPACT
+    // JSON ('"tool_name":"Bash"'). A pretty-printed payload left both empty, so
+    // the Bash branch and the file guard were skipped and every guard failed
+    // OPEN. Same dead-branch class as the 2026-07-16 FILE_PATH regression,
+    // reached through payload formatting instead of `set -euo pipefail`.
+    describe('guards do not depend on the payload being compact JSON', () => {
+      function runHookRaw(hookPath: string, input: string): boolean {
+        const out = execSync(`bash ${JSON.stringify(hookPath)}`, { input, encoding: 'utf-8' });
+        return /"permissionDecision":"deny"/.test(out);
+      }
+
+      it('blocks a secret read when the payload is pretty-printed', () => {
+        init(dir);
+        const hookPath = path.join(dir, '.claude', 'hooks', 'secretless-guard.sh');
+
+        const pretty = JSON.stringify(
+          { tool_name: 'Bash', tool_input: { command: 'cat .env' } },
+          null,
+          2,
+        );
+        expect(pretty, 'fixture must actually be pretty-printed').toMatch(/"tool_name": "Bash"/);
+        expect(
+          runHookRaw(hookPath, pretty),
+          'a pretty-printed payload must not bypass the command guard',
+        ).toBe(true);
+      });
+
+      it('blocks a secret file read when the payload is pretty-printed', () => {
+        init(dir);
+        const hookPath = path.join(dir, '.claude', 'hooks', 'secretless-guard.sh');
+
+        const pretty = JSON.stringify(
+          { tool_name: 'Read', tool_input: { file_path: '/tmp/project/.env' } },
+          null,
+          2,
+        );
+        expect(
+          runHookRaw(hookPath, pretty),
+          'a pretty-printed payload must not bypass the file-path guard',
+        ).toBe(true);
+      });
+
+      it('still allows a template read when the payload is pretty-printed', () => {
+        init(dir);
+        const hookPath = path.join(dir, '.claude', 'hooks', 'secretless-guard.sh');
+
+        const pretty = JSON.stringify(
+          { tool_name: 'Bash', tool_input: { command: 'cat .env.example' } },
+          null,
+          2,
+        );
+        expect(runHookRaw(hookPath, pretty)).toBe(false);
+      });
+    });
+
+    describe('command guard agrees with the file-path guard about template files', () => {
+      it('allows reading committed template files', () => {
+        init(dir);
+        const hookPath = path.join(dir, '.claude', 'hooks', 'secretless-guard.sh');
+
+        const mustAllow = [
+          'cat .env.example',
+          'cat .env.sample',
+          'cat .env.template',
+          'cat .env.dist',
+          'head .env.example',
+          'tail -5 .env.example',
+          'grep DATABASE_URL .env.example',
+          'sed -n 1,5p .env.example',
+          "awk '{print}' .env.example",
+          'cat ./config/.env.example',
+          'cat config.env.sample',
+          'cat app.env.template',
+          'node -e "require(\'fs\').readFileSync(\'.env.example\')"',
+          'python3 -c "open(\'.env.example\').read()"',
+        ];
+        for (const c of mustAllow) {
+          expect(runHookCmd(hookPath, c), `expected hook to ALLOW template read: ${c}`).toBe(false);
+        }
+      });
+
+      it('still blocks real secret files, and every near-miss of the template suffix', () => {
+        init(dir);
+        const hookPath = path.join(dir, '.claude', 'hooks', 'secretless-guard.sh');
+
+        const mustBlock = [
+          // real secrets, unchanged
+          'cat .env',
+          'cat .env.local',
+          'cat .env.production',
+          'cat prod.env',
+          'cat server.key',
+          'cat id_rsa.pem',
+          // the suffix must be ANCHORED at the end of the token, or the
+          // exemption becomes an evasion
+          'cat .env.example.real',
+          'cat .env.example.bak',
+          'cat .env.exampleX',
+          // a template elsewhere in the command must not whitelist a real read
+          'cat .env.example && cat .env',
+          'cat .env.example; cat .env',
+          'cat .env.template | cat .env',
+          // a token must not span a separator
+          'cat .env;.example',
+        ];
+        for (const c of mustBlock) {
+          expect(runHookCmd(hookPath, c), `expected hook to BLOCK: ${c}`).toBe(true);
+        }
+      });
+    });
   });
 
   // Issue #99: two guard-hook / deny-rule gaps found by adversarial review of the

--- a/src/init.ts
+++ b/src/init.ts
@@ -672,9 +672,13 @@ INPUT=$(cat)
 # fallback for hosts without python3.
 TOOL_NAME=""
 if command -v python3 >/dev/null 2>&1; then
+  # Emit ONLY a non-empty string. str() of a number, bool or dict would produce
+  # a non-empty WRONG value ('123', 'True', "{'a': 1}"), which suppresses the
+  # grep fallback below and leaves the guard reading a field that isn't there.
   TOOL_NAME=$(printf '%s' "$INPUT" | python3 -c 'import json,sys
 try:
-    sys.stdout.write(str(json.load(sys.stdin).get("tool_name") or ""))
+    v = json.load(sys.stdin).get("tool_name")
+    sys.stdout.write(v if isinstance(v, str) else "")
 except Exception:
     pass' 2>/dev/null || true)
 fi
@@ -686,21 +690,36 @@ fi
 # Same compact-JSON brittleness as TOOL_NAME above: a pretty-printed payload
 # leaves FILE_PATH empty and the file guard never runs. Parse properly when
 # python3 is available, keep the greps as the fallback.
-FILE_PATH=""
+# Collect EVERY candidate path, not just the first. The structured parse reads
+# the documented top-level fields; the greps additionally sweep the whole
+# payload, so a nested shape (MultiEdit-style edit lists, MCP tool payloads)
+# whose secret path is not at the top level is still seen. Checking the union
+# is what keeps the structured parse from NARROWING the older grep behaviour.
+# Only non-empty strings are emitted, for the same reason as TOOL_NAME above.
+FILE_PATH_CANDIDATES=""
 if command -v python3 >/dev/null 2>&1; then
-  FILE_PATH=$(printf '%s' "$INPUT" | python3 -c 'import json,sys
+  FILE_PATH_CANDIDATES=$(printf '%s' "$INPUT" | python3 -c 'import json,sys
+def walk(o):
+    if isinstance(o, dict):
+        for k, v in o.items():
+            if k in ("file_path", "path") and isinstance(v, str) and v:
+                yield v
+            else:
+                yield from walk(v)
+    elif isinstance(o, list):
+        for v in o:
+            yield from walk(v)
 try:
-    ti = (json.load(sys.stdin).get("tool_input") or {})
-    sys.stdout.write(str(ti.get("file_path") or ti.get("path") or ""))
+    sys.stdout.write("\\n".join(walk(json.load(sys.stdin))))
 except Exception:
     pass' 2>/dev/null || true)
 fi
-if [ -z "$FILE_PATH" ]; then
-  FILE_PATH=$(echo "$INPUT" | grep -o '"file_path":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
-fi
-if [ -z "$FILE_PATH" ]; then
-  FILE_PATH=$(echo "$INPUT" | grep -o '"path":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
-fi
+FILE_PATH_CANDIDATES=$(printf '%s\\n%s\\n%s\\n' \
+  "$FILE_PATH_CANDIDATES" \
+  "$(echo "$INPUT" | grep -o '"file_path":"[^"]*"' | cut -d'"' -f4 || true)" \
+  "$(echo "$INPUT" | grep -o '"path":"[^"]*"' | cut -d'"' -f4 || true)" \
+  | grep -v '^$' | sort -u || true)
+FILE_PATH=$(printf '%s' "$FILE_PATH_CANDIDATES" | head -1 || true)
 
 # For Bash tool, check the command for secret access patterns
 if [ "$TOOL_NAME" = "Bash" ]; then
@@ -730,28 +749,38 @@ except Exception:
   if [ -z "$COMMAND" ]; then
     COMMAND=$(echo "$INPUT" | grep -o '"command":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
   fi
-  # Committed template files (.env.example, .env.sample, .env.template, .env.dist)
-  # hold placeholders, not secrets. The file-path guard below already allows
-  # reading and editing them; without this the two layers disagree and
-  # \`cat .env.example\` is refused while \`Read(.env.example)\` succeeds.
+  # NOTE ON TEMPLATE FILES. The command guard refuses \`cat <name>.env.example\`
+  # even though the file-path guard below allows template files, so the two
+  # layers disagree about committed placeholders. That is a known, deliberate
+  # over-block, NOT an oversight.
   #
-  # Drop ONLY path tokens whose FINAL suffix is a template suffix, then run the
-  # secret-file guards on what remains. Two properties make this an exemption
-  # rather than an evasion:
-  #   - Anchored at the end of the token: \`.env.example\` is dropped, but
-  #     \`.env.example.real\` ends in \`.real\`, survives the scrub, and still blocks.
-  #   - Scrubbed per token, not per command: the token class holds only path
-  #     characters, so a token cannot span a separator. \`cat .env.example && cat .env\`
-  #     and \`cat .env;.example\` both still block on the real \`.env\`.
-  # The scrubbed copy is used only for matching, never for execution.
-  COMMAND_SANS_TEMPLATES=$(printf '%s' "$COMMAND" | sed -E 's#[A-Za-z0-9._/@+~-]*\\.(example|sample|template|dist)($|[^A-Za-z0-9._/-])# #g')
+  # The obvious fix — subtract template-suffixed tokens from the command before
+  # matching — was implemented, tested against a 50-command corpus, and then
+  # REVERTED, because it is a credential bypass. This guard is a denylist over
+  # command TEXT, and its only evidence is the literal secret path appearing
+  # after a verb. Removing that literal hands the attacker the deletion:
+  #
+  #     cat "$(basename <name>.env.example .example)"
+  #
+  # reconstructs the real path from the very token the scrub erased, needs no
+  # preconditions (basename is pure string manipulation, the template need not
+  # exist), and was measured reading a real secret. Requiring the extension
+  # match at the end of the token fails the same way, because the template token
+  # still never matches. Any textual exemption for the template NAME permits
+  # deriving the real name from it.
+  #
+  # Closing the disagreement safely needs the guard to resolve the path a
+  # command would actually open, rather than pattern-matching its text. Until
+  # then, over-blocking a placeholder file is the correct trade against leaking
+  # a real one.
+  #
   # Block commands that dump secret files (expanded to cover grep, awk, sed, strings, xxd)
-  if echo "$COMMAND_SANS_TEMPLATES" | grep -qiE '(cat|head|tail|less|more|type|grep|awk|sed|strings|xxd)\\s+.*${SECRET_FILE_EXT}'; then
+  if echo "$COMMAND" | grep -qiE '(cat|head|tail|less|more|type|grep|awk|sed|strings|xxd)\\s+.*${SECRET_FILE_EXT}'; then
     echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Secretless: blocked command that reads secret files"}}'
     exit 0
   fi
   # Block python/node one-liners that read secret files
-  if echo "$COMMAND_SANS_TEMPLATES" | grep -qiE '(python3?|node)\\s+-(c|e).*${SECRET_FILE_EXT}'; then
+  if echo "$COMMAND" | grep -qiE '(python3?|node)\\s+-(c|e).*${SECRET_FILE_EXT}'; then
     echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Secretless: blocked script command that reads secret files"}}'
     exit 0
   fi
@@ -821,38 +850,48 @@ ${customRules ? customRulesToHookBlocks(customRules) : ''}  exit 0
 fi
 
 # Skip if no file path found
-if [ -z "$FILE_PATH" ]; then
+if [ -z "$FILE_PATH_CANDIDATES" ]; then
   exit 0
 fi
 
-# Normalize path for matching (case-insensitive: server.KEY and prod.ENV must match too)
-BASENAME=$(basename "$FILE_PATH")
-LOWER_BASENAME=$(echo "$BASENAME" | tr '[:upper:]' '[:lower:]')
-LOWER_PATH=$(echo "$FILE_PATH" | tr '[:upper:]' '[:lower:]')
+# Check EVERY candidate path. A payload carrying both a benign top-level path
+# and a secret one nested deeper must block on the secret one, so the loop only
+# skips a template candidate rather than exiting on it.
+while IFS= read -r CANDIDATE; do
+  [ -z "$CANDIDATE" ] && continue
 
-# Allow committed template/example files (.env.example, config.sample, etc.) — these
-# hold placeholders, not real secrets, and are meant to be read/edited/committed.
-# Checked BEFORE any block logic so it wins over the .env extension/dotfile rules below.
-case "$LOWER_BASENAME" in
-  *.example|*.sample|*.template|*.dist) exit 0 ;;
-esac
+  # Normalize path for matching (case-insensitive: server.KEY and prod.ENV must match too)
+  BASENAME=$(basename "$CANDIDATE")
+  LOWER_BASENAME=$(echo "$BASENAME" | tr '[:upper:]' '[:lower:]')
+  LOWER_PATH=$(echo "$CANDIDATE" | tr '[:upper:]' '[:lower:]')
 
-# Block by secret file extension as a suffix: server.key, prod.env, id_rsa.pem, terraform.tfstate
-if echo "$LOWER_BASENAME" | grep -qE '\\.(${extAlternation})$'; then BLOCKED=1; REASON="secret file extension"; fi
-# Block .env dotfile families (.env, .env.local, .envrc, .env.production)
-case "$LOWER_BASENAME" in
-  .env|.env.*|.envrc) BLOCKED=1; REASON=".env" ;;
-  ${dotfileCases}) BLOCKED=1; REASON="$LOWER_BASENAME" ;;
-esac
-# Block by path fragment anywhere in the path (credentials, .ssh/, secrets/, ...)
-case "$LOWER_PATH" in
-  ${fragmentCases}) BLOCKED=1; REASON="secret path" ;;
-esac
+  # Allow committed template/example files (.env.example, config.sample, etc.) — these
+  # hold placeholders, not real secrets, and are meant to be read/edited/committed.
+  # Checked BEFORE any block logic so it wins over the .env extension/dotfile rules below.
+  case "$LOWER_BASENAME" in
+    *.example|*.sample|*.template|*.dist) continue ;;
+  esac
 
-if [ "\${BLOCKED:-0}" = "1" ]; then
-  echo "{\\"hookSpecificOutput\\":{\\"hookEventName\\":\\"PreToolUse\\",\\"permissionDecision\\":\\"deny\\",\\"permissionDecisionReason\\":\\"Secretless: blocked access to secret file matching pattern '$REASON'\\"}}"
-  exit 0
-fi
+  BLOCKED=0
+  # Block by secret file extension as a suffix: server.key, prod.env, id_rsa.pem, terraform.tfstate
+  if echo "$LOWER_BASENAME" | grep -qE '\\.(${extAlternation})$'; then BLOCKED=1; REASON="secret file extension"; fi
+  # Block .env dotfile families (.env, .env.local, .envrc, .env.production)
+  case "$LOWER_BASENAME" in
+    .env|.env.*|.envrc) BLOCKED=1; REASON=".env" ;;
+    ${dotfileCases}) BLOCKED=1; REASON="$LOWER_BASENAME" ;;
+  esac
+  # Block by path fragment anywhere in the path (credentials, .ssh/, secrets/, ...)
+  case "$LOWER_PATH" in
+    ${fragmentCases}) BLOCKED=1; REASON="secret path" ;;
+  esac
+
+  if [ "\${BLOCKED:-0}" = "1" ]; then
+    echo "{\\"hookSpecificOutput\\":{\\"hookEventName\\":\\"PreToolUse\\",\\"permissionDecision\\":\\"deny\\",\\"permissionDecisionReason\\":\\"Secretless: blocked access to secret file matching pattern '$REASON'\\"}}"
+    exit 0
+  fi
+done <<EOF
+$FILE_PATH_CANDIDATES
+EOF
 
 exit 0
 `;

--- a/src/init.ts
+++ b/src/init.ts
@@ -662,10 +662,42 @@ INPUT=$(cat)
 # \`set -euo pipefail\` — without it the whole Bash-command branch below was dead:
 # every Bash call died at the FILE_PATH line (grep found no file_path) before any
 # command guard ran. Regression: release-test 2026-07-16.
-TOOL_NAME=$(echo "$INPUT" | grep -o '"tool_name":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
+# Parse tool_name with a real JSON parser when one is available, for the same
+# reason the command extraction below does. The grep form requires COMPACT JSON:
+# it matches '"tool_name":"…"' with no space after the colon, so a client that
+# pretty-prints its hook payload yields an empty TOOL_NAME, the Bash branch below
+# is skipped entirely, and every command guard silently fails OPEN. That is the
+# same dead-branch class as the 2026-07-16 FILE_PATH regression, reached through
+# formatting rather than through \`set -euo pipefail\`. The grep remains as the
+# fallback for hosts without python3.
+TOOL_NAME=""
+if command -v python3 >/dev/null 2>&1; then
+  TOOL_NAME=$(printf '%s' "$INPUT" | python3 -c 'import json,sys
+try:
+    sys.stdout.write(str(json.load(sys.stdin).get("tool_name") or ""))
+except Exception:
+    pass' 2>/dev/null || true)
+fi
+if [ -z "$TOOL_NAME" ]; then
+  TOOL_NAME=$(echo "$INPUT" | grep -o '"tool_name":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
+fi
 
-# Extract file path from tool input (handles Read, Grep, Glob, Edit, Write)
-FILE_PATH=$(echo "$INPUT" | grep -o '"file_path":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
+# Extract file path from tool input (handles Read, Grep, Glob, Edit, Write).
+# Same compact-JSON brittleness as TOOL_NAME above: a pretty-printed payload
+# leaves FILE_PATH empty and the file guard never runs. Parse properly when
+# python3 is available, keep the greps as the fallback.
+FILE_PATH=""
+if command -v python3 >/dev/null 2>&1; then
+  FILE_PATH=$(printf '%s' "$INPUT" | python3 -c 'import json,sys
+try:
+    ti = (json.load(sys.stdin).get("tool_input") or {})
+    sys.stdout.write(str(ti.get("file_path") or ti.get("path") or ""))
+except Exception:
+    pass' 2>/dev/null || true)
+fi
+if [ -z "$FILE_PATH" ]; then
+  FILE_PATH=$(echo "$INPUT" | grep -o '"file_path":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
+fi
 if [ -z "$FILE_PATH" ]; then
   FILE_PATH=$(echo "$INPUT" | grep -o '"path":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
 fi
@@ -698,13 +730,28 @@ except Exception:
   if [ -z "$COMMAND" ]; then
     COMMAND=$(echo "$INPUT" | grep -o '"command":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
   fi
+  # Committed template files (.env.example, .env.sample, .env.template, .env.dist)
+  # hold placeholders, not secrets. The file-path guard below already allows
+  # reading and editing them; without this the two layers disagree and
+  # \`cat .env.example\` is refused while \`Read(.env.example)\` succeeds.
+  #
+  # Drop ONLY path tokens whose FINAL suffix is a template suffix, then run the
+  # secret-file guards on what remains. Two properties make this an exemption
+  # rather than an evasion:
+  #   - Anchored at the end of the token: \`.env.example\` is dropped, but
+  #     \`.env.example.real\` ends in \`.real\`, survives the scrub, and still blocks.
+  #   - Scrubbed per token, not per command: the token class holds only path
+  #     characters, so a token cannot span a separator. \`cat .env.example && cat .env\`
+  #     and \`cat .env;.example\` both still block on the real \`.env\`.
+  # The scrubbed copy is used only for matching, never for execution.
+  COMMAND_SANS_TEMPLATES=$(printf '%s' "$COMMAND" | sed -E 's#[A-Za-z0-9._/@+~-]*\\.(example|sample|template|dist)($|[^A-Za-z0-9._/-])# #g')
   # Block commands that dump secret files (expanded to cover grep, awk, sed, strings, xxd)
-  if echo "$COMMAND" | grep -qiE '(cat|head|tail|less|more|type|grep|awk|sed|strings|xxd)\\s+.*${SECRET_FILE_EXT}'; then
+  if echo "$COMMAND_SANS_TEMPLATES" | grep -qiE '(cat|head|tail|less|more|type|grep|awk|sed|strings|xxd)\\s+.*${SECRET_FILE_EXT}'; then
     echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Secretless: blocked command that reads secret files"}}'
     exit 0
   fi
   # Block python/node one-liners that read secret files
-  if echo "$COMMAND" | grep -qiE '(python3?|node)\\s+-(c|e).*${SECRET_FILE_EXT}'; then
+  if echo "$COMMAND_SANS_TEMPLATES" | grep -qiE '(python3?|node)\\s+-(c|e).*${SECRET_FILE_EXT}'; then
     echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Secretless: blocked script command that reads secret files"}}'
     exit 0
   fi


### PR DESCRIPTION
Three fixes to the generated guard hook, plus one exemption that was implemented and then deliberately reverted.

## Fails open on a pretty-printed payload

`tool_name` and `file_path` were extracted with greps matching only compact JSON (`"tool_name":"Bash"`, no space after the colon). A client that pretty-prints its hook payload left both empty, which skipped the entire Bash-command branch and the file-path guard, so every guard silently permitted the call.

This is the same dead-branch class as the 2026-07-16 `FILE_PATH` regression, reached through payload formatting rather than through `set -euo pipefail`. Both fields now go through `python3`'s JSON parser, as the `command` field already did, and only non-empty strings are accepted — `str()` of a number or object produced a non-empty *wrong* value that suppressed the grep fallback.

Where python3 is absent the greps remain, so pretty-printed payloads still fail open on those hosts. That limit is stated in the CHANGELOG rather than papered over.

## The file guard only checked one candidate path

The structured parse reads the documented top-level fields, so on its own it would have *narrowed* the older whole-payload grep: a secret path nested below the top level (MultiEdit-style edit lists, MCP tool payloads) stopped being seen once a benign top-level path satisfied the extraction. Candidates from the structured walk and from the greps are now unioned and every one is checked.

## Custom `env:`/`bash:` rules generated a hook that would not parse

`customRulesToHookBlocks` returned its blocks without a trailing newline, and the caller interpolates that directly ahead of `  exit 0`, so the last block's `fi` collided with it (`  fi  exit 0`). Any project defining those rules got a hook that was not valid bash and exited 2 on **every tool call, for every tool**. It fails closed, but a guard that blocks `ls -la` gets uninstalled.

`files:`-only rules produce an empty block string and never reach the collision, which is why the existing `bash -n` coverage — written against a `files:` rule — never caught it. The new test asserts the rules actually reach the generated hook before checking that it parses, so a fixture rejected by the pattern validator cannot report a false pass. That mattered here: the first fixture used a rule containing a space, was silently rejected by the validator, and produced a clean result that meant nothing.

## Reverted: the template-file exemption

The original goal was to make the command guard agree with the file-path guard about committed placeholders, since `Read(.env.example)` is allowed while the equivalent shell read is refused. That was implemented, tested against a 50-command corpus, and then reverted, because it is a credential bypass.

The guard is a denylist over command **text**, and its only evidence is the literal secret path appearing after a verb. Subtracting template-suffixed tokens hands the attacker that deletion:

```
cat "$(basename <name>.env.example .example)"
```

reconstructs the real path from the very token the scrub erased. No preconditions — `basename` is pure string manipulation, so the template file need not exist. Measured reading a real secret file that the previous hook blocked. Requiring the extension match at the end of the token fails identically, because the template token still never matches.

Closing the disagreement safely needs the guard to resolve the path a command would actually open rather than pattern-matching its text. Until then, over-blocking a placeholder is the correct trade against leaking a real credential. The reasoning is recorded in the generated hook so the next person does not re-derive it.

## Verification

- 1172 tests green.
- 50-command differential corpus against the old and new generated hooks: **0 security regressions**, no behaviour change in the command guard.
- The derived-path bypass blocks again, confirmed by executing each command in a sandbox holding a marker secret and checking the marker was not printed.
- The differential harness carries an instrument self-check that refuses to report unless it first observes the old hook blocking a canary read. Added after an early run reported a clean sweep that was really the harness sending JSON the hook could not parse.
