### PR TITLE
Stop corrupting 32-hex secrets on read: ask macOS, do not guess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 
   Content cannot answer the question, so the decision no longer comes from content. `security ... -g` states the encoding explicitly — `password: "…"` for text, `password: 0x…` for encoded bytes — and that marker is now what decides. The exact bytes still come from `-w`; `-g` is consulted only when the value is ambiguously shaped, so the common case still costs one `security` call. Anything unclear (probe fails, Keychain locked, no `0x` marker) returns the raw value undecoded: handing back a secret verbatim is always safe, decoding one that was never encoded is the bug.
 
-  No re-entry is needed. Values already in the Keychain were stored correctly and read back intact once this is in.
+  No re-entry is needed. Values already in the Keychain were stored correctly and read back intact once this is in — confirmed against a real affected key, which read back byte-identical to what `security` reports.
+
+  One upgrade note: resolved values are cached for five minutes in `~/.secretless-ai/store/.secret-cache`, so a corrupted value read by the previous version can still be served briefly after upgrading. It expires on its own; the cache is keyed on write time, not on access, so it cannot be held alive by reads. If a credential still looks wrong immediately after upgrading, wait out the TTL rather than re-entering the secret. This is also worth knowing when diagnosing: while the old CLI is still installed alongside a new build, running either one repopulates the shared cache for the other.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Most 32-hex-character secrets were silently corrupted on read (macOS Keychain).** A HIBP Pro API key stored with `secret set` came back from `secret get` as 16 bytes of binary, and the same corrupted value was injected by `secret run`, so every consumer of that credential authenticated with garbage. The key in the Keychain was never wrong; only the read path was, which is why nothing looked broken until an API rejected the request.
+
+  `security find-generic-password -w` hex-encodes a password it will not print literally (an embedded newline, for example), and the value has to be decoded back. But its output is genuinely ambiguous — the text `d259cc9961fbd259cc9961fbd259cc99` and the bytes `line1\nline2` both come back as an even-length run of hex digits, and nothing in the output distinguishes them. The old code decided from content: decode when the decoded bytes contain a control character, a rule meant to spare hex-looking passwords such as `deadbeef`.
+
+  A 32-hex-character key is 16 random bytes, and the control ranges that rule tested cover 32 of 256 values, so `1 - (224/256)^16` = **88%** of such keys tripped it. That shape is ordinary: HIBP keys, MD5-form tokens, and many other API keys are exactly 32 hex characters. The remaining 12% round-tripped fine, which is what made the failure look intermittent.
+
+  Content cannot answer the question, so the decision no longer comes from content. `security ... -g` states the encoding explicitly — `password: "…"` for text, `password: 0x…` for encoded bytes — and that marker is now what decides. The exact bytes still come from `-w`; `-g` is consulted only when the value is ambiguously shaped, so the common case still costs one `security` call. Anything unclear (probe fails, Keychain locked, no `0x` marker) returns the raw value undecoded: handing back a secret verbatim is always safe, decoding one that was never encoded is the bug.
+
+  No re-entry is needed. Values already in the Keychain were stored correctly and read back intact once this is in.
+
 ### Security
 
 - **The guard hook no longer fails open on a pretty-printed payload.** `tool_name` and `file_path` were extracted with greps that match only compact JSON (`"tool_name":"Bash"`, no space after the colon). A client that pretty-prints its hook payload left both empty, which skipped the entire Bash-command branch and the file-path guard, so every guard silently permitted the call. This is the same dead-branch class as the 2026-07-16 `FILE_PATH` regression, reached through payload formatting rather than through `set -euo pipefail`. Both fields are now parsed with `python3`'s JSON module (as the `command` field already was), with the greps kept as the fallback for hosts without python3 — where python3 is absent, the pretty-printed payload still fails open, so this closes the hole only on hosts that have it.

--- a/src/backends/keychain-macos.test.ts
+++ b/src/backends/keychain-macos.test.ts
@@ -3,13 +3,19 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import * as child_process from 'child_process';
-import { MacOSKeychainBackend } from './keychain-macos';
+import {
+  MacOSKeychainBackend,
+  decodeKeychainValue,
+  keychainOutputIsHexEncoded,
+} from './keychain-macos';
 
 vi.mock('child_process', () => ({
   execFileSync: vi.fn(),
+  spawnSync: vi.fn(),
 }));
 
 const mockExecFileSync = vi.mocked(child_process.execFileSync);
+const mockSpawnSync = vi.mocked(child_process.spawnSync);
 
 function tmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-keychain-macos-test-'));
@@ -25,6 +31,7 @@ describe('MacOSKeychainBackend', () => {
   beforeEach(() => {
     dir = tmpDir();
     mockExecFileSync.mockReset();
+    mockSpawnSync.mockReset();
   });
 
   afterEach(() => {
@@ -209,5 +216,139 @@ describe('MacOSKeychainBackend', () => {
       const health = await backend.healthCheck();
       expect(health.healthy).toBe(false);
     });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Hex round-trip. `security -w` output is ambiguous between "a hex-looking
+// password" and "a password macOS hex-encoded", and the decision used to be
+// made from content: decode when the decoded bytes hold a control character.
+//
+// That silently corrupted most 32-hex API keys. 32 hex chars is 16 random
+// bytes, and the control ranges tested cover 32 of 256 values, so
+// 1 - (224/256)^16 = 88% of such keys tripped it. The fixture below is the MD5
+// of the empty string, an entirely ordinary token, whose bytes include 0x00,
+// 0x04 and 0x09.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Ordinary 32-hex token. Decodes to bytes containing 0x00 / 0x04 / 0x09. */
+const HEX32_TOKEN = 'd41d8cd98f00b204e9800998ecf8427e';
+
+describe('decodeKeychainValue', () => {
+  it('returns a 32-hex token unchanged when macOS did not encode it', () => {
+    // The regression. Against the old content heuristic this returned 16 bytes
+    // of binary, so this assertion is red on the pre-fix code.
+    const out = decodeKeychainValue(HEX32_TOKEN, () => false);
+    expect(out).toBe(HEX32_TOKEN);
+    expect(out).toHaveLength(32);
+  });
+
+  it('decodes when macOS says it encoded the value', () => {
+    // "line1\nline2" is the case the encoding exists for.
+    const encoded = Buffer.from('line1\nline2', 'utf-8').toString('hex');
+    expect(decodeKeychainValue(encoded, () => true)).toBe('line1\nline2');
+  });
+
+  it('fails closed when the encoding cannot be established', () => {
+    // No probe available, and a probe that throws, both leave the value alone.
+    expect(decodeKeychainValue(HEX32_TOKEN, undefined)).toBe(HEX32_TOKEN);
+    expect(
+      decodeKeychainValue(HEX32_TOKEN, () => {
+        throw new Error('security unavailable');
+      }),
+    ).toBe(HEX32_TOKEN);
+  });
+
+  it('never probes a value that is not shaped like hex output', () => {
+    // Odd length, non-hex characters, and empty all skip the extra call.
+    const probe = vi.fn(() => true);
+    for (const v of ['not-hex-at-all', 'abc', '', 'zzzz']) {
+      expect(decodeKeychainValue(v, probe)).toBe(v);
+    }
+    expect(probe).not.toHaveBeenCalled();
+  });
+});
+
+describe('keychainOutputIsHexEncoded', () => {
+  it('reads the 0x marker on the password line', () => {
+    expect(
+      keychainOutputIsHexEncoded('password: 0x6C696E65310A6C696E6532  "line1\\012line2"'),
+    ).toBe(true);
+  });
+
+  it('does not treat a quoted hex-looking password as encoded', () => {
+    expect(keychainOutputIsHexEncoded(`password: "${HEX32_TOKEN}"`)).toBe(false);
+  });
+
+  it('ignores 0x appearing anywhere but the password line', () => {
+    // `-g` also dumps attributes; a 0x in one of them is not the marker.
+    const out = [
+      'keychain: "/Users/x/Library/Keychains/login.keychain-db"',
+      '    "cdat"<timedate>=0x32303236  "20260805"',
+      `password: "${HEX32_TOKEN}"`,
+    ].join('\n');
+    expect(keychainOutputIsHexEncoded(out)).toBe(false);
+  });
+});
+
+describe('resolve() hex handling', () => {
+  it('does not corrupt a stored 32-hex token', async () => {
+    const hexDir = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-keychain-hex-'));
+    try {
+      const backend = new MacOSKeychainBackend({ storeDir: hexDir });
+      fs.writeFileSync(
+        path.join(hexDir, 'keychain-index.json'),
+        JSON.stringify(['secret/TOKEN']),
+      );
+
+      mockExecFileSync.mockReset();
+      mockSpawnSync.mockReset();
+      mockExecFileSync.mockImplementation((_cmd, args) => {
+        if (Array.isArray(args) && args[0] === 'find-generic-password') {
+          return HEX32_TOKEN as unknown as Buffer;
+        }
+        throw new Error('not found');
+      });
+      // macOS reports it as plain text (quoted, no 0x), so it must not decode.
+      mockSpawnSync.mockReturnValue({
+        stdout: '',
+        stderr: `password: "${HEX32_TOKEN}"`,
+      } as unknown as ReturnType<typeof child_process.spawnSync>);
+
+      const out = await backend.resolve('secret/TOKEN');
+      expect(out['secret/TOKEN']).toBe(HEX32_TOKEN);
+    } finally {
+      fs.rmSync(hexDir, { recursive: true, force: true });
+    }
+  });
+
+  it('decodes a stored value macOS actually hex-encoded', async () => {
+    const hexDir = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-keychain-hex-'));
+    try {
+      const backend = new MacOSKeychainBackend({ storeDir: hexDir });
+      fs.writeFileSync(
+        path.join(hexDir, 'keychain-index.json'),
+        JSON.stringify(['secret/MULTILINE']),
+      );
+
+      const encoded = Buffer.from('line1\nline2', 'utf-8').toString('hex');
+      mockExecFileSync.mockReset();
+      mockSpawnSync.mockReset();
+      mockExecFileSync.mockImplementation((_cmd, args) => {
+        if (Array.isArray(args) && args[0] === 'find-generic-password') {
+          return encoded as unknown as Buffer;
+        }
+        throw new Error('not found');
+      });
+      mockSpawnSync.mockReturnValue({
+        stdout: '',
+        stderr: `password: 0x${encoded.toUpperCase()}  "line1\\012line2"`,
+      } as unknown as ReturnType<typeof child_process.spawnSync>);
+
+      const out = await backend.resolve('secret/MULTILINE');
+      expect(out['secret/MULTILINE']).toBe('line1\nline2');
+    } finally {
+      fs.rmSync(hexDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/backends/keychain-macos.ts
+++ b/src/backends/keychain-macos.ts
@@ -11,7 +11,7 @@
  * Uses execFileSync (no shell) to prevent injection via secret values.
  */
 
-import { execFileSync } from 'child_process';
+import { execFileSync, spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { WritableSecretBackend, BackendHealth } from './types';
@@ -36,21 +36,63 @@ function serviceNameFor(key: string): string {
  * macOS `security find-generic-password -w` hex-encodes passwords that contain
  * non-printable characters (e.g. newlines). Detect and decode hex output.
  *
- * Hex output: even-length string matching /^[0-9a-fA-F]+$/.
- * To avoid false positives on normal hex-like passwords (e.g. "deadbeef"),
- * only decode if the hex bytes contain at least one non-printable character.
+ * **`-w` output cannot tell you which happened.** Measured:
+ *
+ *   stored text  "d259cc9961fbd259cc9961fbd259cc99" -> d259cc9961fbd259cc99...
+ *   stored bytes  line1\nline2                      -> 6c696e65310a6c696e6532
+ *
+ * Identical shape. No content-based rule separates them, and the one this code
+ * used to apply (decode if the decoded bytes hold a control character) silently
+ * corrupted most 32-hex-character API keys. Those decode to 16 random bytes and
+ * the control ranges it tested cover 32 of 256 values, so
+ * `1 - (224/256)^16` = **88%** of such keys tripped it. A real HIBP key read
+ * back as 16 bytes of binary. The keychain was never wrong; the read path was.
+ *
+ * `-g` settles it without guessing, because macOS states the encoding:
+ *
+ *   plain   -> password: "d259cc9961fbd259cc9961fbd259cc99"
+ *   binary  -> password: 0x6C696E65310A6C696E6532  "line1\012line2"
+ *
+ * So: take the exact bytes from `-w`, and consult `-g` only when the shape is
+ * ambiguous, which leaves the common case at one `security` call.
+ *
+ * Fails CLOSED on any doubt: if `-g` cannot be read, or does not clearly say
+ * `0x`, the raw `-w` value is returned unchanged. Handing back a secret verbatim
+ * is always safe; decoding one that was never encoded is the bug being fixed.
  */
-function decodeKeychainValue(raw: string): string {
-  if (raw.length >= 2 && raw.length % 2 === 0 && /^[0-9a-fA-F]+$/.test(raw)) {
-    const buf = Buffer.from(raw, 'hex');
-    const decoded = buf.toString('utf-8');
-    // Only use decoded value if it contains a non-printable char (newline, tab, etc.)
-    // This prevents false-positive decoding of passwords that happen to look like hex
-    if (/[\x00-\x08\x0a-\x1f\x7f]/.test(decoded)) {
-      return decoded;
-    }
+function looksLikeKeychainHex(raw: string): boolean {
+  return raw.length >= 2 && raw.length % 2 === 0 && /^[0-9a-fA-F]+$/.test(raw);
+}
+
+export function decodeKeychainValue(
+  raw: string,
+  isHexEncoded?: () => boolean,
+): string {
+  if (!looksLikeKeychainHex(raw)) return raw;
+  if (!isHexEncoded) return raw;
+  // The probe shells out, so it can throw for reasons that have nothing to do
+  // with this secret (keychain locked, `security` missing, spawn limit). Any of
+  // those must leave the value alone rather than decode on an unanswered
+  // question. Caught here as well as inside the probe: this function is
+  // exported and its contract should not depend on who supplies the callback.
+  let encoded = false;
+  try {
+    encoded = isHexEncoded();
+  } catch {
+    return raw;
   }
-  return raw;
+  if (!encoded) return raw;
+  return Buffer.from(raw, 'hex').toString('utf-8');
+}
+
+/**
+ * Parse `security find-generic-password -g` output for the explicit `0x` marker.
+ *
+ * Anchored to the `password:` line so a `0x` appearing inside the ATTRIBUTE dump
+ * that `-g` also prints cannot be mistaken for the encoding marker.
+ */
+export function keychainOutputIsHexEncoded(stderrAndStdout: string): boolean {
+  return /^password:\s*0x[0-9A-Fa-f]+/m.test(stderrAndStdout);
 }
 
 export class MacOSKeychainBackend implements WritableSecretBackend {
@@ -114,11 +156,18 @@ export class MacOSKeychainBackend implements WritableSecretBackend {
 
     const results: Record<string, string> = {};
     for (const key of matchingKeys) {
-      // Try new per-key service name first, fall back to legacy
-      const raw = this.findPassword(serviceNameFor(key), key)
-        ?? this.findPassword(LEGACY_SERVICE_NAME, key);
+      // Try new per-key service name first, fall back to legacy. Track WHICH
+      // service answered: the hex-encoding question has to be asked of the same
+      // entry the value came from, or the answer describes a different secret.
+      let service = serviceNameFor(key);
+      let raw = this.findPassword(service, key);
+      if (raw === null) {
+        service = LEGACY_SERVICE_NAME;
+        raw = this.findPassword(service, key);
+      }
       if (raw !== null) {
-        results[key] = decodeKeychainValue(raw);
+        const from = service;
+        results[key] = decodeKeychainValue(raw, () => this.isHexEncoded(from, key));
       }
     }
     return results;
@@ -175,6 +224,28 @@ export class MacOSKeychainBackend implements WritableSecretBackend {
         latencyMs: Date.now() - start,
         message: 'macOS Keychain not accessible',
       };
+    }
+  }
+
+  /**
+   * Ask macOS whether it hex-encoded this entry, using the `0x` marker on the
+   * `-g` password line. Only called when `-w` output is ambiguously shaped.
+   *
+   * `-g` prints the password line to STDERR, so both streams are captured.
+   * Any failure returns false, which leaves the value undecoded.
+   */
+  private isHexEncoded(service: string, account: string): boolean {
+    try {
+      const res = spawnSync('security', [
+        'find-generic-password',
+        '-s', service,
+        '-a', account,
+        '-g',
+      ], { encoding: 'utf-8' });
+      if (res.error) return false;
+      return keychainOutputIsHexEncoded(`${res.stderr ?? ''}\n${res.stdout ?? ''}`);
+    } catch {
+      return false;
     }
   }
 


### PR DESCRIPTION
Stop corrupting 32-hex secrets on read: ask macOS, do not guess

A HIBP Pro API key stored with `secret set` came back from `secret get` as 16
bytes of binary, and `secret run` injected the same corrupted value, so every
consumer authenticated with garbage. The Keychain entry was never wrong. The
read path was, which is why nothing looked broken until an API rejected it.

`security find-generic-password -w` hex-encodes a password it will not print
literally, and that has to be decoded back. Its output is ambiguous: the TEXT
"d259cc9961fbd259cc9961fbd259cc99" and the BYTES "line1\nline2" both come back
as an even-length run of hex digits, with nothing to tell them apart. The old
code decided from content, decoding when the decoded bytes held a control
character, to spare hex-looking passwords like "deadbeef".

A 32-hex key is 16 random bytes and the control ranges it tested cover 32 of
256 values, so 1 - (224/256)^16 = 88% of such keys tripped it. That shape is
ordinary: HIBP keys, MD5-form tokens, plenty of API keys. The surviving 12% is
what made this look intermittent -- a fabricated test vector round-tripped
clean while the real key next to it did not, which briefly argued the bug was
not there.

Content cannot answer the question, so the decision no longer comes from
content. `-g` states the encoding outright:

  plain   password: "d259cc9961fbd259cc9961fbd259cc99"
  binary  password: 0x6C696E65310A6C696E6532  "line1\012line2"

The `0x` marker now decides. Exact bytes still come from `-w`; `-g` is consulted
only when the shape is ambiguous, so the common case stays at one `security`
call, and the marker is matched anchored to the password line so a `0x` in the
attribute dump `-g` also prints cannot be mistaken for it.

Fails closed everywhere: a probe that throws, a locked Keychain, a missing
`security`, or output with no clear marker all return the raw value undecoded.
Handing back a secret verbatim is always safe; decoding one that was never
encoded is the bug. The throw case is caught inside `decodeKeychainValue` as
well as inside the probe, because the function is exported and its contract
should not depend on who supplies the callback -- a test asserting the documented
fail-closed behaviour caught that the code did not yet do it.

`resolve` now tracks WHICH service name answered before asking about encoding,
since the legacy fallback means the question could otherwise be asked of a
different entry than the value came from.

Verified end to end against the real key: 16 bytes of binary before, 32 hex
characters after, matching the sha256 read directly from the Keychain. Values
already stored are intact and need no re-entry.

Red-proofed: reverting to the content heuristic fails three of the new tests,
including the end-to-end `resolve()` one. 1181 tests, typecheck clean.

