### PR TITLE
Fail closed when the configured backend is unreachable; stop leaking the secret on a failed Keychain write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 - **Errors were buried under a stack trace.** The top-level handler printed the raw error object, so messages carrying `Verify:` and `Fix:` lines arrived underneath our own file paths and read as a crash. It now prints the message; set `SECRETLESS_DEBUG=1` when the stack is what you need.
 
+- **Overwriting a macOS Keychain secret could destroy it.** `store()` deleted the existing entry before adding the replacement, so a write that failed afterwards — a locked Keychain, a dismissed approval — left nothing behind. The entry is now updated in place with `security add-generic-password -U`, and the legacy-named duplicate is swept only after the new value is committed. Same defect and same fix as the 1Password backend above.
+
 - **Most 32-hex-character secrets were silently corrupted on read (macOS Keychain).** A HIBP Pro API key stored with `secret set` came back from `secret get` as 16 bytes of binary, and the same corrupted value was injected by `secret run`, so every consumer of that credential authenticated with garbage. The key in the Keychain was never wrong; only the read path was, which is why nothing looked broken until an API rejected the request.
 
   `security find-generic-password -w` hex-encodes a password it will not print literally (an embedded newline, for example), and the value has to be decoded back. But its output is genuinely ambiguous — the text `d259cc9961fbd259cc9961fbd259cc99` and the bytes `line1\nline2` both come back as an even-length run of hex digits, and nothing in the output distinguishes them. The old code decided from content: decode when the decoded bytes contain a control character, a rule meant to spare hex-looking passwords such as `deadbeef`.
@@ -35,6 +37,20 @@
   One upgrade note: resolved values are cached for five minutes in `~/.secretless-ai/store/.secret-cache`, so a corrupted value read by the previous version can still be served briefly after upgrading. It expires on its own; the cache is keyed on write time, not on access, so it cannot be held alive by reads. If a credential still looks wrong immediately after upgrading, wait out the TTL rather than re-entering the secret. This is also worth knowing when diagnosing: while the old CLI is still installed alongside a new build, running either one repopulates the shared cache for the other.
 
 ### Security
+
+- **`secret set` printed the secret value in its own error message (macOS).** When the Keychain refused a write, the failure surfaced as:
+
+  ```
+  Error: Command failed: security add-generic-password -s Secretless: NUTEST -a secret/NUTEST -w hello-world-123
+  ```
+
+  `security add-generic-password` takes the password as `-w <value>`, and Node's `execFileSync` puts the whole argv into the error it throws. So the credential landed in the terminal at the exact moment a user is most likely to copy the output and paste it somewhere to ask what went wrong — including into the AI assistant this tool exists to keep it away from. Found in a fresh-user walkthrough, not in the test suite.
+
+  The argv echo is our own command line and tells the user nothing, so it is now dropped entirely, the value is scrubbed from what remains, and a final unconditional check discards the detail altogether if the value can still be found in it. A vaguer error is always better than a leaked one. The message that replaces it names the key, explains that the Keychain declined the write, and carries `Verify:` and `Fix:` lines including the fallback to the encrypted file store.
+
+  The other backends were checked for the same shape: Linux passes the value on stdin, 1Password writes it to a mode-0600 temp file specifically to keep it out of argv, and Vault and GCP send it over HTTP. macOS was the only one, and it is the default there.
+
+  Not fixed in this release: the value is still in `argv` while `security` runs, so it is briefly visible to `ps`. macOS documents this itself ("Use of the -p or -w options is insecure"). The obvious fix — `-w` with no argument, reading the password from stdin — reads a single line and would silently truncate multi-line secrets such as private keys, which this backend supports. Tracked separately rather than traded for data loss.
 
 - **The guard hook no longer fails open on a pretty-printed payload.** `tool_name` and `file_path` were extracted with greps that match only compact JSON (`"tool_name":"Bash"`, no space after the colon). A client that pretty-prints its hook payload left both empty, which skipped the entire Bash-command branch and the file-path guard, so every guard silently permitted the call. This is the same dead-branch class as the 2026-07-16 `FILE_PATH` regression, reached through payload formatting rather than through `set -euo pipefail`. Both fields are now parsed with `python3`'s JSON module (as the `command` field already was), with the greps kept as the fallback for hosts without python3 — where python3 is absent, the pretty-printed payload still fails open, so this closes the hole only on hosts that have it.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,26 @@
 # Changelog
 
-## [Unreleased]
+## [0.21.0] - 2026-08-05
 
 ### Fixed
+
+- **A configured backend that could not be reached was silently replaced by the local store.** With `backend set 1password` and the 1Password desktop app disconnected, `secret set NAME=value` wrote to the *local* store and printed `Stored: NAME`. `secret get NAME` then read 1Password and reported nothing. `run` executed the command with no credentials injected at all. Each of those reports success at the point of use, and the failure only surfaces later as an authentication error that never mentions secretless.
+
+  `createBackend()` took a `strict` flag that defaulted to false, and `SecretStore` — the code behind `secret set`, `secret get`, `secret list` and `run` — never passed it. Only `backend migrate` did. On the default path an unavailable backend printed two lines to stderr and returned a `LocalBackend`.
+
+  The state that triggers it is ordinary. With the `op` binary installed and an account configured but the desktop app not running, `op --version` and `op account list` both exit 0 (the latter answers from local config), while `op account get` exits 1. Quitting the app, rebooting, or a reset CLI-integration toggle is enough.
+
+  Substituting a store is not a safe degradation for a credential manager, so it no longer happens. An unreachable configured backend now fails closed with an error that names the backend you chose, states that nothing was read from or written to anywhere else, and carries the `Verify:` and `Fix:` commands plus the deliberate `backend migrate` path. The permissive path remains for read-only diagnostics, and now says plainly that it is listing a different store.
+
+  **Behaviour change.** Commands that previously appeared to succeed against the wrong store now exit non-zero. That is the point: if `secret set` was quietly writing somewhere you did not choose, it was never succeeding. If a script depended on the old fallback, switch it deliberately with `secretless-ai backend set local`.
+
+- **Overwriting a 1Password secret could destroy it.** `store()` deleted the existing item before creating the replacement. If `op item create` then failed for any reason — app disconnected mid-command, vault permissions, network — the old value was already gone and the new one was never written. The replacement is now created first and the superseded item retired afterwards, by ID rather than by title, because the two legitimately share a title in the window between the calls.
+
+- **1Password items could land untagged and become invisible to every later read.** The tag was set only inside the JSON template, while `listItems()` filters on it, so an item that did not pick the tag up could never be resolved again. Title and tag are now passed as explicit `--title` and `--tags` flags as well, which take precedence in `op item create`.
+
+- **A pending 1Password approval hung the entire command.** `op` was invoked with no timeout, so an approval dialog waiting on someone who is not at the machine blocked the caller indefinitely with no output. Calls are now bounded (30s default, `SECRETLESS_OP_TIMEOUT_MS` to change it) and report what to check.
+
+- **Errors were buried under a stack trace.** The top-level handler printed the raw error object, so messages carrying `Verify:` and `Fix:` lines arrived underneath our own file paths and read as a crash. It now prints the message; set `SECRETLESS_DEBUG=1` when the stack is what you need.
 
 - **Most 32-hex-character secrets were silently corrupted on read (macOS Keychain).** A HIBP Pro API key stored with `secret set` came back from `secret get` as 16 bytes of binary, and the same corrupted value was injected by `secret run`, so every consumer of that credential authenticated with garbage. The key in the Keychain was never wrong; only the read path was, which is why nothing looked broken until an API rejected the request.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secretless-ai",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "One command to keep secrets out of AI. Works with Claude Code, Cursor, Copilot, Windsurf, and any AI coding tool.",
   "license": "Apache-2.0",
   "type": "commonjs",

--- a/src/backends/factory.test.ts
+++ b/src/backends/factory.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { execFileSync } from 'child_process';
-import { createBackend, isKeychainAvailable } from './factory';
+import { createBackend, isKeychainAvailable, unavailableBackendError } from './factory';
 import { LocalBackend } from './local';
 
 vi.mock('child_process', async (importOriginal) => {
@@ -167,5 +167,24 @@ describe('isKeychainAvailable', () => {
     } else if (process.platform === 'linux') {
       expect(result.platform).toBe('Linux');
     }
+  });
+});
+
+describe('unavailableBackendError formatting', () => {
+  it('keeps the Verify/Fix block intact when the reason carries newlines', () => {
+    const err = unavailableBackendError(
+      '1password',
+      'line one\nline two\n  indented three',
+      ['do the thing'],
+      'op account get',
+    );
+    const lines = err.message.split('\n');
+    // The reason must occupy exactly one line, or everything below it stops
+    // reading as a list.
+    expect(lines[0]).toBe(
+      'Configured backend "1password" is not reachable: line one line two indented three',
+    );
+    expect(err.message).toMatch(/^  Verify:  op account get$/m);
+    expect(err.message).toMatch(/^  Fix:     do the thing$/m);
   });
 });

--- a/src/backends/factory.test.ts
+++ b/src/backends/factory.test.ts
@@ -1,9 +1,42 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { execFileSync } from 'child_process';
 import { createBackend, isKeychainAvailable } from './factory';
 import { LocalBackend } from './local';
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return { ...actual, execFileSync: vi.fn() };
+});
+
+const mockExec = execFileSync as unknown as ReturnType<typeof vi.fn>;
+
+/**
+ * Reproduce the machine state that motivated this suite: the `op` BINARY is
+ * installed and an account is configured locally, but the 1Password desktop app
+ * is not connected, so any command needing the app fails.
+ *
+ * Measured on a real machine 2026-08-05 (op 2.32.1):
+ *   op --version                 -> exit 0
+ *   op account list              -> exit 0   (answers from local config)
+ *   op account get --format json -> exit 1   (needs the app)
+ *   op vault list                -> exit 1
+ *
+ * The `account list` / `account get` split matters: a probe that used the
+ * former would call this machine healthy.
+ */
+function mockOpInstalledButAppDisconnected(): void {
+  mockExec.mockImplementation((cmd: string, args: string[] = []) => {
+    if (cmd !== 'op') return '';
+    if (args[0] === '--version') return '2.32.1\n';
+    if (args[0] === 'account' && args[1] === 'list') return 'my.1password.com\n';
+    throw new Error(
+      "connecting to desktop app: 1Password CLI couldn't connect to the 1Password desktop app.",
+    );
+  });
+}
 
 function tmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-factory-test-'));
@@ -38,6 +71,81 @@ describe('createBackend', () => {
       'cached(keychain-macos)', 'cached(keychain-linux)', 'cached(local)',
     ];
     expect(validNames).toContain(backend.name);
+  });
+});
+
+/**
+ * Regression cover for the silent store-substitution bug.
+ *
+ * Before the fix, an unreachable configured backend returned a LocalBackend and
+ * only warned on stderr. `secret set` then wrote to a store the user never
+ * chose and printed "Stored: NAME", and `backend purge` would have deleted from
+ * that other store. These tests fail on the pre-fix factory, which returned
+ * LocalBackend here instead of throwing.
+ */
+describe('createBackend: unreachable configured backend fails closed', () => {
+  beforeEach(() => {
+    mockExec.mockReset();
+  });
+
+  afterEach(() => {
+    delete process.env.VAULT_ADDR;
+    delete process.env.VAULT_TOKEN;
+  });
+
+  it('throws instead of substituting local when 1Password is unreachable', () => {
+    mockOpInstalledButAppDisconnected();
+    expect(() => createBackend('1password')).toThrow(/not reachable/i);
+  });
+
+  it('never hands back a different store for an unreachable 1Password', () => {
+    mockOpInstalledButAppDisconnected();
+    let returned: unknown;
+    try {
+      returned = createBackend('1password');
+    } catch {
+      returned = undefined;
+    }
+    // The pre-fix code reached here holding a LocalBackend.
+    expect(returned).toBeUndefined();
+  });
+
+  it('names the configured backend and gives verify + fix commands, not a dead end', () => {
+    mockOpInstalledButAppDisconnected();
+    let message = '';
+    try {
+      createBackend('1password');
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toContain('1password');
+    expect(message).toMatch(/Verify:\s+op account get/);
+    expect(message).toMatch(/Fix:\s+brew install 1password-cli/);
+    // The reassurance is load-bearing: this fires while a user is mid-command.
+    expect(message).toMatch(/secrets are safe/i);
+    // It must NOT claim it used another store.
+    expect(message).not.toMatch(/using local backend instead/i);
+  });
+
+  it('throws for an unconfigured Vault backend rather than substituting local', () => {
+    expect(() => createBackend('vault')).toThrow(/not reachable/i);
+  });
+
+  it('builds the Vault backend once its environment is present', () => {
+    process.env.VAULT_ADDR = 'https://vault.example.com';
+    process.env.VAULT_TOKEN = 'test-token';
+    expect(() => createBackend('vault')).not.toThrow();
+  });
+
+  it('still degrades for read-only diagnostics that opt in explicitly', () => {
+    mockOpInstalledButAppDisconnected();
+    const scratch = tmpDir();
+    try {
+      const backend = createBackend('1password', { storeDir: scratch, key: 'test' }, false);
+      expect(backend).toBeInstanceOf(LocalBackend);
+    } finally {
+      cleanup(scratch);
+    }
   });
 });
 

--- a/src/backends/factory.ts
+++ b/src/backends/factory.ts
@@ -27,14 +27,23 @@ import type { SelectableBackendType } from './config';
  * is available (macOS Keychain, Linux Secret Service, or Windows Credential
  * Manager). Falls back to 'local' only when keychain initialization fails.
  *
+ * When the caller explicitly configured a non-local backend and that backend is
+ * unavailable, this THROWS rather than substituting a different store.
+ * Substituting is never a safe degradation for a credential manager: a write
+ * lands in a store the user did not choose while reporting success, and a read
+ * reports "no secrets" from an empty store the user never populated. Both look
+ * like success. See `unavailableBackendError` for the recovery message.
+ *
  * @param type   - 'local', 'keychain', '1password', 'vault', or 'gcp-sm'
  * @param config - Backend-specific configuration (e.g. storeDir, key, vault)
- * @param strict - If true, throw instead of falling back to local. Default: false.
+ * @param strict - Default TRUE. Pass false ONLY for read-only diagnostics that
+ *                 must render something even when the backend is down, and that
+ *                 disclose which backend actually answered.
  */
 export function createBackend(
   type: SelectableBackendType,
   config?: Record<string, unknown>,
-  strict?: boolean,
+  strict: boolean = true,
 ): WritableSecretBackend {
   let backend: WritableSecretBackend;
 
@@ -66,11 +75,13 @@ export function createBackend(
     case '1password': {
       const op = isOnePasswordAvailable();
       if (!op.available) {
-        if (strict) throw new Error(`Cannot use 1Password backend: ${op.message}`);
-        console.error(`secretless: 1Password CLI not available. Using local backend instead.`);
-        console.error(`  To fix: brew install 1password-cli && op signin`);
-        console.error(`  To switch: npx secretless-ai backend set local\n`);
-        return new LocalBackend(config);
+        if (strict) {
+          throw unavailableBackendError('1password', op.message, [
+            'brew install 1password-cli && op signin',
+            'Enable "Integrate with 1Password CLI" in the 1Password app under Settings > Developer',
+          ], 'op account get');
+        }
+        return degradedFallback('1password', op.message, config);
       }
       backend = new OnePasswordBackend(config);
       break;
@@ -78,11 +89,13 @@ export function createBackend(
 
     case 'vault': {
       if (!process.env.VAULT_ADDR || !process.env.VAULT_TOKEN) {
-        if (strict) throw new Error('Cannot use Vault backend: VAULT_ADDR and VAULT_TOKEN must be set');
-        console.error(`secretless: Vault not configured. Using local backend instead.`);
-        console.error(`  To fix: export VAULT_ADDR=... VAULT_TOKEN=...`);
-        console.error(`  To switch: npx secretless-ai backend set local\n`);
-        return new LocalBackend(config);
+        const why = 'VAULT_ADDR and VAULT_TOKEN must be set';
+        if (strict) {
+          throw unavailableBackendError('vault', why, [
+            'export VAULT_ADDR=https://vault.example.com VAULT_TOKEN=<token>',
+          ], 'vault token lookup');
+        }
+        return degradedFallback('vault', why, config);
       }
       backend = new VaultBackend(config);
       break;
@@ -91,11 +104,12 @@ export function createBackend(
     case 'gcp-sm': {
       const gcp = isGCPAvailable();
       if (!gcp.available) {
-        if (strict) throw new Error(`Cannot use GCP Secret Manager backend: ${gcp.message}`);
-        console.error(`secretless: GCP credentials not available. Using local backend instead.`);
-        console.error(`  To fix: ${gcp.message}`);
-        console.error(`  To switch: npx secretless-ai backend set local\n`);
-        return new LocalBackend(config);
+        if (strict) {
+          throw unavailableBackendError('gcp-sm', gcp.message, [
+            'gcloud auth application-default login',
+          ], 'gcloud auth application-default print-access-token');
+        }
+        return degradedFallback('gcp-sm', gcp.message, config);
       }
       backend = new GCPSecretManagerBackend(config);
       break;
@@ -113,6 +127,60 @@ export function createBackend(
     return new CachedBackend(backend, { ttlMs: ttlSeconds * 1000 });
   }
   return backend;
+}
+
+/**
+ * Build the error raised when a user-configured backend cannot be reached.
+ *
+ * The message has to do four things, because this is the moment a user decides
+ * whether the tool is trustworthy or broken:
+ *   - name the backend THEY chose, so it reads as a connection problem
+ *   - state that nothing was lost and nothing was written elsewhere
+ *   - give a command that VERIFIES the diagnosis independently
+ *   - give the command that FIXES it, and the explicit opt-out
+ * No dead ends: every line the user reads ends in something they can run.
+ */
+export function unavailableBackendError(
+  type: SelectableBackendType,
+  why: string,
+  fixes: string[],
+  verifyCmd: string,
+): Error {
+  const lines = [
+    `Configured backend "${type}" is not reachable: ${why}`,
+    '',
+    `  Your secrets are safe. Nothing was read from or written to another store.`,
+    '',
+    `  Verify:  ${verifyCmd}`,
+  ];
+  for (const fix of fixes) {
+    lines.push(`  Fix:     ${fix}`);
+  }
+  lines.push(
+    '',
+    `  Secretless will not silently use a different store, because a secret`,
+    `  written to the wrong one looks like success and is found by nothing.`,
+    `  To move to a different backend deliberately:`,
+    `    secretless-ai backend migrate --from ${type} --to local`,
+  );
+  return new Error(lines.join('\n'));
+}
+
+/**
+ * Non-strict path: return the local store, but say plainly that the answer
+ * comes from a DIFFERENT store than the one configured, so a caller rendering
+ * "no entries" cannot be misread as "the configured backend is empty".
+ *
+ * Only read-only diagnostics should reach this.
+ */
+function degradedFallback(
+  type: SelectableBackendType,
+  why: string,
+  config?: Record<string, unknown>,
+): WritableSecretBackend {
+  console.error(`secretless: backend "${type}" unreachable (${why}).`);
+  console.error(`  Showing the local store instead. Entries in "${type}" are NOT listed below.\n`);
+  return new LocalBackend(config);
 }
 
 /**

--- a/src/backends/factory.ts
+++ b/src/backends/factory.ts
@@ -146,8 +146,13 @@ export function unavailableBackendError(
   fixes: string[],
   verifyCmd: string,
 ): Error {
+  // `why` is the `.message` of a caught error and can carry newlines. Left as
+  // is, it breaks the block apart and the Verify/Fix lines stop reading as a
+  // list — the recovery instructions are the whole point of this message.
+  const reason = why.replace(/\s+/g, ' ').trim();
+
   const lines = [
-    `Configured backend "${type}" is not reachable: ${why}`,
+    `Configured backend "${type}" is not reachable: ${reason}`,
     '',
     `  Your secrets are safe. Nothing was read from or written to another store.`,
     '',

--- a/src/backends/keychain-macos.test.ts
+++ b/src/backends/keychain-macos.test.ts
@@ -7,6 +7,7 @@ import {
   MacOSKeychainBackend,
   decodeKeychainValue,
   keychainOutputIsHexEncoded,
+  redactSecurityError,
 } from './keychain-macos';
 
 vi.mock('child_process', () => ({
@@ -39,10 +40,10 @@ describe('MacOSKeychainBackend', () => {
   });
 
   describe('store()', () => {
-    it('calls security delete then add with per-key service name', async () => {
+    it('writes with an in-place update and sweeps the legacy entry after', async () => {
       const backend = new MacOSKeychainBackend({ storeDir: dir });
 
-      // delete may throw (not found) — that's ok
+      // legacy delete may throw (not found) — that's ok
       mockExecFileSync.mockImplementation((cmd, args) => {
         if (typeof cmd === 'string' && cmd === 'security' && Array.isArray(args) && args[0] === 'delete-generic-password') {
           throw new Error('not found');
@@ -52,24 +53,26 @@ describe('MacOSKeychainBackend', () => {
 
       await backend.store('mcp/client/server/KEY', 'secret-value');
 
-      // Verify delete with new service name was attempted
+      // `-U` updates in place, so no delete of the live entry precedes the
+      // write. The previous ordering deleted first and lost the credential
+      // outright whenever the add then failed.
       expect(mockExecFileSync).toHaveBeenCalledWith(
+        'security',
+        ['add-generic-password', '-s', 'Secretless: KEY', '-a', 'mcp/client/server/KEY', '-l', 'Secretless: mcp/client/server/KEY', '-U', '-w', 'secret-value'],
+        expect.any(Object),
+      );
+
+      // The live entry is never deleted as part of a write.
+      expect(mockExecFileSync).not.toHaveBeenCalledWith(
         'security',
         ['delete-generic-password', '-s', 'Secretless: KEY', '-a', 'mcp/client/server/KEY'],
         expect.any(Object),
       );
 
-      // Verify legacy delete was also attempted
+      // The legacy duplicate is still swept, after the value is committed.
       expect(mockExecFileSync).toHaveBeenCalledWith(
         'security',
         ['delete-generic-password', '-s', 'secretless', '-a', 'mcp/client/server/KEY'],
-        expect.any(Object),
-      );
-
-      // Verify add uses per-key service name
-      expect(mockExecFileSync).toHaveBeenCalledWith(
-        'security',
-        ['add-generic-password', '-s', 'Secretless: KEY', '-a', 'mcp/client/server/KEY', '-l', 'Secretless: mcp/client/server/KEY', '-w', 'secret-value'],
         expect.any(Object),
       );
     });
@@ -349,6 +352,110 @@ describe('resolve() hex handling', () => {
       expect(out['secret/MULTILINE']).toBe('line1\nline2');
     } finally {
       fs.rmSync(hexDir, { recursive: true, force: true });
+    }
+  });
+});
+
+/**
+ * `security add-generic-password` takes the password as `-w <value>`, and
+ * execFileSync puts the whole argv into the thrown message. Observed in a fresh
+ * -user walkthrough of 0.21.0-rc:
+ *
+ *   Error: Command failed: security add-generic-password -s Secretless: NUTEST \
+ *     -a secret/NUTEST -l Secretless: secret/NUTEST -w hello-world-123
+ *
+ * The secret is right there in the terminal, in a tool whose whole purpose is
+ * keeping it out of exactly that kind of output.
+ */
+describe('store() error redaction', () => {
+  const SECRET = 'hello-world-123';
+
+  it('does not leak the value through the thrown error', () => {
+    const err = redactSecurityError(
+      new Error(
+        'Command failed: security add-generic-password -s Secretless: NUTEST ' +
+        `-a secret/NUTEST -w ${SECRET}\n` +
+        'security: SecKeychainItemCreateFromContent (<default>): The authorization was canceled by the user.',
+      ),
+      SECRET,
+      'secret/NUTEST',
+    );
+    expect(err.message).not.toContain(SECRET);
+  });
+
+  it('drops our own argv echo and keeps the part that explains the failure', () => {
+    const err = redactSecurityError(
+      new Error(`Command failed: security add-generic-password -w ${SECRET}\nsecurity: the thing broke`),
+      SECRET,
+      'secret/K',
+    );
+    expect(err.message).not.toMatch(/Command failed:/);
+    expect(err.message).toContain('the thing broke');
+    expect(err.message).toContain('secret/K');
+  });
+
+  it('routes the locked-keychain case to advice the user can act on', () => {
+    const err = redactSecurityError(
+      new Error('security: The authorization was canceled by the user.'),
+      SECRET,
+      'secret/K',
+    );
+    expect(err.message).toMatch(/Verify:\s+security default-keychain/);
+    expect(err.message).toMatch(/backend set local/);
+  });
+
+  it('discards the detail rather than leaking when scrubbing cannot clear it', () => {
+    // A value that survives naive scrubbing because it reappears after
+    // replacement: splitting on "aa" in "aaa" leaves an "a" behind.
+    const tricky = 'aa';
+    const err = redactSecurityError(new Error('security: aaaaa failed'), tricky, 'secret/K');
+    expect(err.message).not.toContain(tricky);
+  });
+
+  it('is actually wired into store(), not merely exported', async () => {
+    const dir2 = tmpDir();
+    try {
+      mockExecFileSync.mockImplementation(((_cmd: string, args: string[]) => {
+        if (Array.isArray(args) && args[0] === 'add-generic-password') {
+          throw new Error(
+            `Command failed: security add-generic-password -w ${SECRET}\n` +
+            'security: The authorization was canceled by the user.',
+          );
+        }
+        return '' as unknown as Buffer;
+      }) as never);
+
+      const backend = new MacOSKeychainBackend({ storeDir: dir2 });
+      await expect(backend.store('secret/NUTEST', SECRET)).rejects.toThrow(
+        /Could not store "secret\/NUTEST"/,
+      );
+      await backend.store('secret/NUTEST', SECRET).catch((e: Error) => {
+        expect(e.message).not.toContain(SECRET);
+      });
+    } finally {
+      cleanup(dir2);
+    }
+  });
+
+  it('updates in place instead of deleting the old value before writing', async () => {
+    const dir2 = tmpDir();
+    try {
+      const calls: string[] = [];
+      mockExecFileSync.mockImplementation(((_cmd: string, args: string[]) => {
+        if (Array.isArray(args)) calls.push(args[0]);
+        return '' as unknown as Buffer;
+      }) as never);
+
+      const backend = new MacOSKeychainBackend({ storeDir: dir2 });
+      await backend.store('secret/K', 'v');
+
+      const addIdx = calls.indexOf('add-generic-password');
+      const delIdx = calls.indexOf('delete-generic-password');
+      expect(addIdx).toBeGreaterThanOrEqual(0);
+      // No delete may precede the write; the legacy sweep runs after it.
+      if (delIdx !== -1) expect(addIdx).toBeLessThan(delIdx);
+    } finally {
+      cleanup(dir2);
     }
   });
 });

--- a/src/backends/keychain-macos.test.ts
+++ b/src/backends/keychain-macos.test.ts
@@ -459,3 +459,48 @@ describe('store() error redaction', () => {
     }
   });
 });
+
+/**
+ * Adversarial cases for the redaction, found by probing it rather than by
+ * reading it. A secret may legitimately contain newlines — that is why the
+ * read path handles hex-encoded values at all.
+ */
+describe('store() error redaction: adversarial inputs', () => {
+  it('does not leak a fragment when the value straddles the filtered line', () => {
+    // Scrubbing after the "Command failed:" line filter split this value in
+    // two, so neither the replace nor the containment check could see it and
+    // "realsecret" survived into the message.
+    const value = 'Command failed: X\nrealsecret';
+    const err = redactSecurityError(
+      new Error(`Command failed: security add-generic-password -w ${value}`),
+      value,
+      'secret/K',
+    );
+    expect(err.message).not.toContain('realsecret');
+    expect(err.message).not.toContain(value);
+  });
+
+  it('does not leak any line of a multi-line secret echoed back mangled', () => {
+    const value = '-----BEGIN KEY-----\nMIIEvgIBADANBg\n-----END KEY-----';
+    // security echoes only the middle line back, so the whole-value check misses it.
+    const err = redactSecurityError(
+      new Error('security: could not store MIIEvgIBADANBg'),
+      value,
+      'secret/K',
+    );
+    expect(err.message).not.toContain('MIIEvgIBADANBg');
+  });
+
+  it('survives a value that is itself the redaction placeholder', () => {
+    const value = '[REDACTED]';
+    const err = redactSecurityError(new Error('security: [REDACTED] failed'), value, 'secret/K');
+    // Cannot distinguish placeholder from secret, so the detail is dropped.
+    expect(err.message).toContain('Could not store');
+  });
+
+  it('still produces an actionable message when the detail is discarded', () => {
+    const err = redactSecurityError(new Error('security: aaaaa'), 'aa', 'secret/K');
+    expect(err.message).toMatch(/Verify:/);
+    expect(err.message).toMatch(/Fix:/);
+  });
+});

--- a/src/backends/keychain-macos.ts
+++ b/src/backends/keychain-macos.ts
@@ -111,22 +111,47 @@ export function keychainOutputIsHexEncoded(stderrAndStdout: string): boolean {
  * from whatever remains. The final guard is unconditional: if the value can
  * still be found in the message, the message is discarded rather than trimmed.
  */
+/**
+ * True if `detail` still contains the whole value, or any individual line of a
+ * multi-line value.
+ *
+ * Defence in depth behind the scrub: `security` can echo part of a value back
+ * in a form that no longer matches it byte for byte, and a per-line check
+ * catches the fragment the whole-value comparison would miss. Lines shorter
+ * than four characters are ignored, or a secret containing a line like "1"
+ * would blank every error message the backend ever produces.
+ */
+function leaksAnyLineOf(detail: string, value: string): boolean {
+  if (detail.includes(value)) return true;
+  for (const line of value.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.length >= 4 && detail.includes(trimmed)) return true;
+  }
+  return false;
+}
+
 export function redactSecurityError(err: unknown, value: string, key: string): Error {
   const raw = err instanceof Error ? err.message : String(err);
 
-  let detail = raw
+  // Scrub BEFORE any line filtering. A secret may contain newlines — that is
+  // exactly why the read path has to handle hex-encoded values — and dropping
+  // lines first can split the value across the boundary, leaving a fragment
+  // that no longer matches `value` and so survives both the replace and the
+  // containment backstop. Replace it while it is still contiguous.
+  let detail = value.length > 0
+    ? raw.split(value).join('[REDACTED]')
+    : raw;
+
+  detail = detail
     .split('\n')
     .filter(line => !/^\s*Command failed:/.test(line))
     .join('\n')
     .trim();
 
-  if (value.length > 0) {
-    detail = detail.split(value).join('[REDACTED]');
-  }
-
-  // Unconditional backstop. Any path that would still expose the value loses
-  // the detail instead — a vaguer error is always preferable to a leaked one.
-  if (value.length > 0 && detail.includes(value)) {
+  // Unconditional backstop, checked against every line the value could have
+  // been split across. Any path that would still expose it loses the detail
+  // instead — a vaguer error is always preferable to a leaked one.
+  if (value.length > 0 && leaksAnyLineOf(detail, value)) {
     detail = '';
   }
 

--- a/src/backends/keychain-macos.ts
+++ b/src/backends/keychain-macos.ts
@@ -95,6 +95,65 @@ export function keychainOutputIsHexEncoded(stderrAndStdout: string): boolean {
   return /^password:\s*0x[0-9A-Fa-f]+/m.test(stderrAndStdout);
 }
 
+/**
+ * Turn a failed `security` invocation into an error that cannot carry the
+ * secret.
+ *
+ * `security add-generic-password` takes the password as `-w <value>`, and its
+ * own help says so plainly: "Use of the -p or -w options is insecure." Node's
+ * `execFileSync` puts the entire argv into the thrown message, so the raw error
+ * reads:
+ *
+ *   Command failed: security add-generic-password -s Secretless: K -a secret/K -w hunter2
+ *
+ * Printing that defeats the tool. The argv echo is our own command line and
+ * tells the user nothing, so it is dropped entirely and the value is scrubbed
+ * from whatever remains. The final guard is unconditional: if the value can
+ * still be found in the message, the message is discarded rather than trimmed.
+ */
+export function redactSecurityError(err: unknown, value: string, key: string): Error {
+  const raw = err instanceof Error ? err.message : String(err);
+
+  let detail = raw
+    .split('\n')
+    .filter(line => !/^\s*Command failed:/.test(line))
+    .join('\n')
+    .trim();
+
+  if (value.length > 0) {
+    detail = detail.split(value).join('[REDACTED]');
+  }
+
+  // Unconditional backstop. Any path that would still expose the value loses
+  // the detail instead — a vaguer error is always preferable to a leaked one.
+  if (value.length > 0 && detail.includes(value)) {
+    detail = '';
+  }
+
+  const lines = [`Could not store "${key}" in the macOS Keychain.`];
+  if (detail) lines.push(`  ${detail.split('\n').join('\n  ')}`);
+
+  if (/authorization was canceled|User interaction is not allowed|interaction not allowed/i.test(detail)) {
+    lines.push(
+      '',
+      '  The Keychain declined the write. It is usually locked, or the approval',
+      '  dialog was dismissed or could not be shown.',
+      '',
+      '  Verify:  security default-keychain',
+      '  Fix:     unlock the login keychain and retry, or run',
+      '           secretless-ai backend set local  to use the encrypted file store',
+    );
+  } else {
+    lines.push(
+      '',
+      '  Verify:  security default-keychain',
+      '  Fix:     secretless-ai doctor',
+    );
+  }
+
+  return new Error(lines.join('\n'));
+}
+
 export class MacOSKeychainBackend implements WritableSecretBackend {
   readonly name = 'keychain-macos';
   private readonly indexPath: string;
@@ -109,18 +168,29 @@ export class MacOSKeychainBackend implements WritableSecretBackend {
   async store(key: string, value: string): Promise<void> {
     const svc = serviceNameFor(key);
 
-    // Delete existing entry (new service name)
+    // `-U` updates the entry in place if it already exists, so the previous
+    // value is never deleted ahead of a write that might fail. Deleting first
+    // and then failing to add leaves the user with no credential at all.
     try {
       execFileSync('security', [
-        'delete-generic-password',
+        'add-generic-password',
         '-s', svc,
         '-a', key,
+        '-l', `Secretless: ${key}`,
+        '-U',
+        '-w', value,
       ], { stdio: 'pipe' });
-    } catch {
-      // Entry didn't exist — that's fine
+    } catch (err) {
+      // Node puts the full argv in the error message, and the value is in it.
+      // Rethrowing verbatim prints the secret to the terminal — which in this
+      // tool's own threat model is the thing being prevented, since that output
+      // is exactly what gets pasted into an AI chat when someone asks why the
+      // command failed. Never let the raw message escape.
+      throw redactSecurityError(err, value, key);
     }
 
-    // Also delete legacy entry (old unified service name) to prevent duplicates
+    // Only once the new value is committed, retire the legacy entry (old
+    // unified service name) so reads cannot resolve to a stale duplicate.
     try {
       execFileSync('security', [
         'delete-generic-password',
@@ -130,15 +200,6 @@ export class MacOSKeychainBackend implements WritableSecretBackend {
     } catch {
       // No legacy entry — that's fine
     }
-
-    // Add the new entry with a per-key service name (visible in macOS Passwords.app)
-    execFileSync('security', [
-      'add-generic-password',
-      '-s', svc,
-      '-a', key,
-      '-l', `Secretless: ${key}`,
-      '-w', value,
-    ], { stdio: 'pipe' });
 
     // Update index
     const index = this.readIndex();

--- a/src/backends/onepassword.test.ts
+++ b/src/backends/onepassword.test.ts
@@ -62,8 +62,9 @@ function mockOpCli(items: Array<{ id: string; title: string; password: string }>
     }
 
     if (sub === 'item delete') {
-      const title = args[2];
-      const found = items.find(i => i.title === title);
+      // store() deletes by ID; delete() still resolves by title.
+      const ref = args[2];
+      const found = items.find(i => i.id === ref || i.title === ref);
       if (!found) throw new Error('item not found');
       return '' as unknown as Buffer;
     }
@@ -82,7 +83,75 @@ describe('OnePasswordBackend', () => {
   });
 
   describe('store()', () => {
-    it('calls op item delete then create with correct args', async () => {
+    it('creates the replacement before retiring the previous item', async () => {
+      // A previous value for this key already exists.
+      mockOpCli([{ id: 'item-old', title: 'secret/API_KEY', password: 'sk-old' }]);
+      const backend = new OnePasswordBackend();
+
+      await backend.store('secret/API_KEY', 'sk-12345');
+
+      const opCalls = mockExecFileSync.mock.calls
+        .filter(c => c[0] === 'op' && Array.isArray(c[1]))
+        .map(c => (c[1] as string[]).slice(0, 2).join(' '));
+
+      const createIdx = opCalls.indexOf('item create');
+      const deleteIdx = opCalls.indexOf('item delete');
+
+      expect(createIdx).toBeGreaterThanOrEqual(0);
+      expect(deleteIdx).toBeGreaterThanOrEqual(0);
+      // The whole point: the old credential survives until the new one exists.
+      expect(createIdx).toBeLessThan(deleteIdx);
+
+      // And the retirement targets the snapshotted ID, not the title, because
+      // two items legitimately share the title in the window between the two.
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        'op',
+        ['item', 'delete', 'item-old', '--vault', VAULT_ID],
+        expect.any(Object),
+      );
+    });
+
+    it('does not destroy the stored value when create fails', async () => {
+      mockOpCli([{ id: 'item-old', title: 'secret/API_KEY', password: 'sk-old' }]);
+      // Make the write fail the way a disconnected desktop app does.
+      const base = mockExecFileSync.getMockImplementation()!;
+      mockExecFileSync.mockImplementation((cmd, args) => {
+        if (cmd === 'op' && Array.isArray(args) && args[0] === 'item' && args[1] === 'create') {
+          throw new Error('connecting to desktop app: could not connect');
+        }
+        return base(cmd as never, args as never);
+      });
+
+      const backend = new OnePasswordBackend();
+      await expect(backend.store('secret/API_KEY', 'sk-12345')).rejects.toThrow(/desktop app/);
+
+      // Pre-fix ordering deleted first, so the old value was already gone here.
+      const deleted = mockExecFileSync.mock.calls.some(
+        c => c[0] === 'op' && Array.isArray(c[1]) &&
+          (c[1] as string[])[0] === 'item' && (c[1] as string[])[1] === 'delete',
+      );
+      expect(deleted).toBe(false);
+    });
+
+    it('passes title and tag as explicit flags so reads can find the item', async () => {
+      mockOpCli([]);
+      const backend = new OnePasswordBackend();
+
+      await backend.store('secret/API_KEY', 'sk-12345');
+
+      const createCall = mockExecFileSync.mock.calls.find(
+        call => call[0] === 'op' && Array.isArray(call[1]) &&
+          call[1][0] === 'item' && call[1][1] === 'create',
+      );
+      const args = createCall![1] as string[];
+      // listItems() filters on the tag; an untagged item is invisible forever.
+      expect(args).toContain('--tags');
+      expect(args[args.indexOf('--tags') + 1]).toBe('secretless');
+      expect(args).toContain('--title');
+      expect(args[args.indexOf('--title') + 1]).toBe('secret/API_KEY');
+    });
+
+    it('stores via a template file and keeps the secret out of argv', async () => {
       mockOpCli([]);
       const backend = new OnePasswordBackend();
 
@@ -92,13 +161,6 @@ describe('OnePasswordBackend', () => {
       expect(mockExecFileSync).toHaveBeenCalledWith(
         'op',
         ['vault', 'get', 'Secretless', '--format', 'json'],
-        expect.any(Object),
-      );
-
-      // Verify item delete was attempted (may fail — that's fine)
-      expect(mockExecFileSync).toHaveBeenCalledWith(
-        'op',
-        ['item', 'delete', 'secret/API_KEY', '--vault', VAULT_ID],
         expect.any(Object),
       );
 

--- a/src/backends/onepassword.test.ts
+++ b/src/backends/onepassword.test.ts
@@ -522,3 +522,45 @@ describe('OnePasswordBackend', () => {
     });
   });
 });
+
+describe('op error handling', () => {
+  beforeEach(() => { mockExecFileSync.mockReset(); });
+
+  it('reports a timeout when execFileSync signals ETIMEDOUT rather than SIGTERM', async () => {
+    mockOpCli([]);
+    const base = mockExecFileSync.getMockImplementation()!;
+    mockExecFileSync.mockImplementation((cmd, args) => {
+      if (Array.isArray(args) && args[0] === 'item' && args[1] === 'create') {
+        const e = new Error('spawnSync op ETIMEDOUT') as NodeJS.ErrnoException;
+        e.code = 'ETIMEDOUT';
+        throw e;
+      }
+      return base(cmd as never, args as never);
+    });
+
+    const backend = new OnePasswordBackend();
+    // Without the ETIMEDOUT arm this fell through and reported something that
+    // read nothing like a timeout.
+    await expect(backend.store('secret/K', 'v')).rejects.toThrow(/did not respond within/);
+  });
+
+  it('keeps what op said but drops our own argv echo on a generic failure', async () => {
+    mockOpCli([]);
+    const base = mockExecFileSync.getMockImplementation()!;
+    mockExecFileSync.mockImplementation((cmd, args) => {
+      if (Array.isArray(args) && args[0] === 'item' && args[1] === 'create') {
+        throw new Error(
+          'Command failed: op item create --vault abc --template /tmp/x.json\n' +
+          '[ERROR] 2026/08/05 vault "abc" not found',
+        );
+      }
+      return base(cmd as never, args as never);
+    });
+
+    const backend = new OnePasswordBackend();
+    const err = await backend.store('secret/K', 'v').catch((e: Error) => e);
+    expect(err.message).toContain('vault "abc" not found');
+    expect(err.message).not.toMatch(/Command failed:/);
+    expect(err.message).toMatch(/Verify: op account get/);
+  });
+});

--- a/src/backends/onepassword.ts
+++ b/src/backends/onepassword.ts
@@ -31,6 +31,22 @@ const DEFAULT_VAULT = 'Secretless';
 const ITEM_TAG = 'secretless';
 const DEFAULT_OP_TIMEOUT_MS = 30_000;
 
+/**
+ * What `op` actually reported, without our own `Command failed: ...` argv echo.
+ * Returns an indented block ending in a newline, or empty when there is nothing
+ * useful to show.
+ */
+function opStderr(e: { stderr?: unknown; message?: string }): string {
+  const raw = typeof e?.stderr === 'string' && e.stderr.trim()
+    ? e.stderr
+    : (e?.message ?? '');
+  const kept = String(raw)
+    .split('\n')
+    .filter(line => line.trim() && !/^\s*Command failed:/.test(line))
+    .map(line => `  ${line.trim()}`);
+  return kept.length ? `${kept.join('\n')}\n` : '';
+}
+
 /** Per-invocation ceiling for `op`, overridable for slow approval flows. */
 function opTimeoutMs(): number {
   const raw = Number(process.env.SECRETLESS_OP_TIMEOUT_MS);
@@ -231,7 +247,11 @@ export class OnePasswordBackend implements WritableSecretBackend {
       }) as unknown as string;
     } catch (err) {
       const e = err as NodeJS.ErrnoException & { signal?: string };
-      if (e?.signal === 'SIGTERM') {
+      // execFileSync surfaces a timeout as the kill signal, but not on every
+      // path — `ETIMEDOUT` appears instead depending on where it trips. Match
+      // both, or a timed-out call falls through to the generic branch and
+      // reports something that reads nothing like "it timed out".
+      if (e?.signal === 'SIGTERM' || e?.code === 'ETIMEDOUT') {
         throw new Error(
           `1Password did not respond within ${opTimeoutMs() / 1000}s (op ${args[0]} ${args[1] ?? ''}).\n` +
           `  This usually means an approval prompt is waiting, or the desktop app is not running.\n` +
@@ -240,7 +260,15 @@ export class OnePasswordBackend implements WritableSecretBackend {
           `  Adjust: SECRETLESS_OP_TIMEOUT_MS=60000`,
         );
       }
-      throw err;
+      // Everything else: keep what `op` actually said, drop our own argv echo.
+      // No secret value is ever in this argv — that is why store() writes the
+      // value to a mode-0600 template file — but the echo is noise that buries
+      // op's real message, and vault ids and key names do not need reprinting.
+      throw new Error(
+        `1Password command failed (op ${args[0]} ${args[1] ?? ''}).\n` +
+        `${opStderr(e)}` +
+        `  Verify: op account get`,
+      );
     }
   }
 

--- a/src/backends/onepassword.ts
+++ b/src/backends/onepassword.ts
@@ -29,6 +29,13 @@ import type { WritableSecretBackend, BackendHealth } from './types';
 
 const DEFAULT_VAULT = 'Secretless';
 const ITEM_TAG = 'secretless';
+const DEFAULT_OP_TIMEOUT_MS = 30_000;
+
+/** Per-invocation ceiling for `op`, overridable for slow approval flows. */
+function opTimeoutMs(): number {
+  const raw = Number(process.env.SECRETLESS_OP_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_OP_TIMEOUT_MS;
+}
 
 /** Minimal shape returned by `op item list --format json`. */
 interface OpItem {
@@ -59,20 +66,29 @@ export class OnePasswordBackend implements WritableSecretBackend {
     this.vaultName = vault;
   }
 
+  /**
+   * Write a secret, replacing any previous value for the same key.
+   *
+   * ORDER MATTERS: create the replacement FIRST, and only delete the previous
+   * item once the new one exists. The reverse order — which this used to do —
+   * destroys the stored credential and then, if `op item create` fails for any
+   * reason (app disconnected mid-command, vault permissions, network), leaves
+   * the user with nothing. An overwrite that can lose the old value on failure
+   * is not an overwrite, it is a delete with extra steps.
+   *
+   * Previous items are removed by ID rather than title, because between create
+   * and delete two items legitimately share a title and `op item delete TITLE`
+   * cannot tell them apart.
+   */
   async store(key: string, value: string): Promise<void> {
     const vaultId = this.ensureVault();
 
-    // Delete existing entry first (ignore errors if it doesn't exist)
-    try {
-      this.deleteByTitle(key, vaultId);
-    } catch {
-      // Entry didn't exist — that's fine
-    }
+    // Snapshot what is already there, BEFORE writing anything.
+    const priorIds = this.findItemIdsByTitle(key, vaultId);
 
-    // Create new item via JSON template file.
-    // Using a temp file (mode 0600) keeps the secret value out of process
-    // argv, where it would be visible in /proc/<pid>/cmdline on Linux.
-    // The file is always cleaned up in the finally block.
+    // Create the new item via a JSON template file. Using a temp file (mode
+    // 0600) keeps the secret value out of process argv, where it would be
+    // visible in /proc/<pid>/cmdline on Linux. Always cleaned up in `finally`.
     const template = JSON.stringify({
       title: key,
       category: 'PASSWORD',
@@ -88,13 +104,55 @@ export class OnePasswordBackend implements WritableSecretBackend {
     const tmpFile = path.join(os.tmpdir(), `secretless-op-${process.pid}-${Date.now()}.json`);
     try {
       fs.writeFileSync(tmpFile, template, { mode: 0o600 });
+      // `--title` and `--tags` are passed as FLAGS as well as sitting in the
+      // template. The template alone is not a contract we can verify offline,
+      // and the tag is load-bearing: `listItems()` filters on it, so an item
+      // that silently lands untagged is invisible to every later read. Flags
+      // take precedence in `op item create`, so this is deterministic.
       this.op([
         'item', 'create',
         '--vault', vaultId,
         '--template', tmpFile,
+        '--title', key,
+        '--tags', ITEM_TAG,
       ]);
     } finally {
       try { fs.unlinkSync(tmpFile); } catch { /* already cleaned up */ }
+    }
+
+    // New value is committed. Now retire the superseded items.
+    for (const id of priorIds) {
+      try {
+        this.op(['item', 'delete', id, '--vault', vaultId]);
+      } catch {
+        // The new value IS stored, so this is not a write failure. It does
+        // leave a stale duplicate that would make reads ambiguous, so say so
+        // rather than letting the next `get` return an old value silently.
+        console.error(
+          `secretless: stored "${key}" in 1Password, but could not remove the previous item (${id}).\n` +
+          `  Two items now share this title and reads may return either one.\n` +
+          `  Fix: op item delete ${id} --vault ${vaultId}`,
+        );
+      }
+    }
+  }
+
+  /**
+   * IDs of every item in the vault carrying this exact title.
+   *
+   * Deliberately does NOT filter by tag: an item written before tagging was
+   * enforced, or by an older version, still shadows reads and must be cleaned
+   * up. Returns empty on any failure — a snapshot we could not take must not
+   * block a write.
+   */
+  private findItemIdsByTitle(title: string, vaultId: string): string[] {
+    try {
+      const out = this.op(['item', 'list', '--vault', vaultId, '--format', 'json']);
+      const parsed = JSON.parse(out || '[]');
+      if (!Array.isArray(parsed)) return [];
+      return (parsed as OpItem[]).filter(i => i.title === title).map(i => i.id);
+    } catch {
+      return [];
     }
   }
 
@@ -155,11 +213,35 @@ export class OnePasswordBackend implements WritableSecretBackend {
   // Private helpers
   // ---------------------------------------------------------------------------
 
+  /**
+   * Run `op`, bounded in time.
+   *
+   * Without a timeout this blocks forever: `op` waits on the desktop app, and
+   * the desktop app waits on a human who may not be at the machine — or on an
+   * approval dialog that never rendered. A secrets lookup inside `run` then
+   * hangs the user's whole command with no output at all. The window is wide
+   * enough for a real Touch ID approval and short enough to fail visibly.
+   */
   private op(args: string[]): string {
-    return execFileSync('op', args, {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      encoding: 'utf-8',
-    }) as unknown as string;
+    try {
+      return execFileSync('op', args, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        encoding: 'utf-8',
+        timeout: opTimeoutMs(),
+      }) as unknown as string;
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException & { signal?: string };
+      if (e?.signal === 'SIGTERM') {
+        throw new Error(
+          `1Password did not respond within ${opTimeoutMs() / 1000}s (op ${args[0]} ${args[1] ?? ''}).\n` +
+          `  This usually means an approval prompt is waiting, or the desktop app is not running.\n` +
+          `  Verify: op account get\n` +
+          `  Fix:    open the 1Password app, unlock it, and retry\n` +
+          `  Adjust: SECRETLESS_OP_TIMEOUT_MS=60000`,
+        );
+      }
+      throw err;
+    }
   }
 
   /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -246,7 +246,17 @@ async function dispatch(args: string[], command: string | undefined): Promise<nu
 main().then(
   (code) => process.exit(code),
   (err) => {
-    console.error(err);
+    // Print what the user can act on, not the call stack. These messages
+    // already carry Verify/Fix lines; a stack trace on top of them reads as a
+    // crash and buries the instructions under our own file paths.
+    // Set SECRETLESS_DEBUG=1 when the stack is what you actually need.
+    if (process.env.SECRETLESS_DEBUG) {
+      console.error(err);
+    } else if (err instanceof Error) {
+      console.error(`\n  ${err.message.split('\n').join('\n  ')}\n`);
+    } else {
+      console.error(`\n  ${String(err)}\n`);
+    }
     process.exit(1);
   },
 );

--- a/src/phantom/resolver.test.ts
+++ b/src/phantom/resolver.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../backends/factory', () => ({
+  createBackend: vi.fn(),
+}));
+
+vi.mock('../backends/config', () => ({
+  readBackendConfig: vi.fn(),
+}));
+
+import { createBackend } from '../backends/factory';
+import { readBackendConfig } from '../backends/config';
+import { resolveRef, RefResolutionError } from './resolver';
+
+const mockCreateBackend = vi.mocked(createBackend);
+const mockReadBackendConfig = vi.mocked(readBackendConfig);
+
+/**
+ * `resolveFromBackend` tries the ref's own backend, then falls back to the
+ * configured one. Both calls go through `createBackend`, which since 0.21.0
+ * THROWS when a configured backend is unreachable instead of quietly handing
+ * back a local store.
+ *
+ * That made the fallback call able to throw for the first time. Escaping there
+ * would replace the RefResolutionError — which names the URI that failed — with
+ * a bare backend error carrying no reference at all, from a function whose
+ * caller has no try/catch.
+ */
+describe('resolveRef when backends are unreachable', () => {
+  beforeEach(() => {
+    mockCreateBackend.mockReset();
+    mockReadBackendConfig.mockReset();
+  });
+
+  it('reports the failing ref when neither the ref backend nor the configured one is reachable', async () => {
+    mockReadBackendConfig.mockReturnValue('1password' as never);
+    mockCreateBackend.mockImplementation(() => {
+      throw new Error('Configured backend "1password" is not reachable: not signed in');
+    });
+
+    const uri = 'secret://1password/op://Personal/prod/password';
+
+    // Pre-fix this rejected with the raw backend Error, which names no ref.
+    await expect(resolveRef(uri)).rejects.toBeInstanceOf(RefResolutionError);
+    await expect(resolveRef(uri)).rejects.toThrow(uri);
+  });
+
+  it('still resolves through the fallback backend when only the ref backend is down', async () => {
+    mockReadBackendConfig.mockReturnValue('local' as never);
+
+    let call = 0;
+    mockCreateBackend.mockImplementation((() => {
+      call += 1;
+      if (call === 1) throw new Error('1password unreachable');
+      return {
+        name: 'local',
+        resolve: async () => ({ 'secret/prod/password': 'the-value' }),
+        store: async () => {},
+        delete: async () => false,
+        healthCheck: async () => ({ healthy: true, latencyMs: 0, message: '' }),
+      };
+    }) as never);
+
+    const result = await resolveRef('secret://1password/prod/password');
+    expect(result.value).toBe('the-value');
+    expect(mockCreateBackend).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/phantom/resolver.ts
+++ b/src/phantom/resolver.ts
@@ -131,9 +131,17 @@ async function resolveFromBackend(ref: SecretRef): Promise<string | undefined> {
     // Use the ref's backend type, not the configured default
     backend = createBackend(ref.backend as any);
   } catch {
-    // Backend not available (e.g., 1password CLI not installed)
-    // Try the configured backend as fallback
-    backend = createBackend(configuredBackend ?? 'local');
+    // Backend not available (e.g., 1password CLI not installed).
+    // Try the configured backend as fallback — which can be unavailable too,
+    // and now throws when it is. Both unreachable means this ref cannot be
+    // resolved, which is `undefined`: resolveRef() turns that into a
+    // RefResolutionError naming the URI. Letting the throw escape instead
+    // would replace that message with a bare backend error carrying no ref.
+    try {
+      backend = createBackend(configuredBackend ?? 'local');
+    } catch {
+      return undefined;
+    }
   }
 
   try {


### PR DESCRIPTION
## Why

Two ways a stored credential could go wrong without anything looking broken.

**A configured backend that could not be reached was silently replaced by the local store.** `createBackend()` took a `strict` flag defaulting to false, and `SecretStore` — the code behind `secret set`, `secret get`, `secret list` and `run` — never passed it. Only `backend migrate` did. So with `backend set 1password` and the desktop app disconnected:

- `secret set NAME=value` wrote to the **local** store and printed `Stored: NAME`
- `secret get NAME` then read 1Password and reported nothing
- `run` executed the command with **no credentials injected at all**

Each reports success at the point of use. The failure surfaces later as an auth error that never mentions secretless, which is a plausible reason nobody files an issue about it.

The triggering state is ordinary: with `op` installed and an account configured but the app not running, `op --version` and `op account list` both exit 0 (the latter answers from local config) while `op account get` exits 1. Quitting the app or a reset CLI-integration toggle is enough.

**`secret set` printed the secret value in its own error message on macOS.** `security add-generic-password` takes the password as `-w <value>` and `execFileSync` puts the whole argv into the error it throws, so a refused write produced:

```
Error: Command failed: security add-generic-password -s Secretless: NUTEST -a secret/NUTEST -w hello-world-123
```

The credential landed in the terminal at exactly the moment a user copies the output to ask what went wrong — including into the assistant this tool exists to keep it away from. macOS documents the hazard itself: *"Use of the -p or -w options is insecure."*

## What changed

- `createBackend` fails closed by default. The error names the backend the user chose, states nothing was written elsewhere, and carries `Verify:`/`Fix:` lines plus the deliberate `backend migrate` path. The permissive path stays for read-only diagnostics and now discloses that it is showing a different store.
- Keychain write errors are redacted: the argv echo is dropped, the value scrubbed while still contiguous, and an unconditional backstop discards the detail entirely if any line of the value can still be found in it.
- 1Password and Keychain both create/update before retiring the old entry. The previous order deleted first and lost the credential outright when the write then failed.
- 1Password items carry `--title`/`--tags` as explicit flags; the tag is load-bearing because `listItems()` filters on it and an untagged item is invisible to every later read.
- `op` calls are bounded by a timeout (`SECRETLESS_OP_TIMEOUT_MS`, default 30s). Without one a pending approval dialog hung the whole command with no output.
- The top-level CLI handler prints the message instead of the raw error; `SECRETLESS_DEBUG=1` restores the stack.

## Behaviour change

Commands that previously appeared to succeed against the wrong store now exit non-zero. If `secret set` was quietly writing somewhere you did not choose, it was never succeeding. Scripts relying on the old fallback should switch deliberately with `secretless-ai backend set local`.

## Verification

- 1202 tests across 70 files. 17 new; each fails on the pre-fix code (4 are behaviour-neutral by design and documented as such).
- The pre-existing tests asserting `delete then create` in both backends were pinning the data-loss ordering in place and were rewritten.
- Two regressions introduced during this work were caught by review and fixed here: the phantom resolver's fallback could throw uncaught, replacing `RefResolutionError` (which names the failing URI) with a bare backend error; and the redaction scrubbed after line filtering, so a multi-line secret straddling that boundary leaked a fragment.
- End-to-end against a disconnected 1Password: `secret set`, `secret list` and `run` all exit 1, nothing is written locally, and the command does not execute.
- HackMyAgent `secure`: 100/100, 209 static + 119 semantic checks, 0 skipped.