### PR TITLE
Fix a documented postinstall hook that failed every npm install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 
 - **A pending 1Password approval hung the entire command.** `op` was invoked with no timeout, so an approval dialog waiting on someone who is not at the machine blocked the caller indefinitely with no output. Calls are now bounded (30s default, `SECRETLESS_OP_TIMEOUT_MS` to change it) and report what to check.
 
+- **The team-setup guide published a `postinstall` hook that fails every `npm install`.** `docs/use-cases/team-setup.md` told teams to add `"postinstall": "npx secretless-ai init --ci"`, directly under the line "Now every `npm install` configures AI tool protections automatically." `init` takes an optional directory path and no flags, so it exits 2 with `Unknown option: --ci` and npm fails the install for every developer who followed the guide.
+
+  The guide was correct when it was written. Making `init` reject unknown flags (#62 — before that, `init --dry-run` created a literal `--dry-run/` directory) is what turned a silently-wrong documented command into a loudly-broken one. A release that tightens a parser has to re-check every command its own docs publish. `src/docs-commands.test.ts` now derives the command list from the dispatch sites in `cli.ts` and fails if any documented command does not exist, or if any doc puts a flag on `init`.
+
 - **Errors were buried under a stack trace.** The top-level handler printed the raw error object, so messages carrying `Verify:` and `Fix:` lines arrived underneath our own file paths and read as a crash. It now prints the message; set `SECRETLESS_DEBUG=1` when the stack is what you need.
 
 - **Overwriting a macOS Keychain secret could destroy it.** `store()` deleted the existing entry before adding the replacement, so a write that failed afterwards — a locked Keychain, a dismissed approval — left nothing behind. The entry is now updated in place with `security add-generic-password -U`, and the legacy-named duplicate is swept only after the new value is committed. Same defect and same fix as the 1Password backend above.

--- a/docs/testing/release-smoke.md
+++ b/docs/testing/release-smoke.md
@@ -19,7 +19,7 @@ cd secretless-ai
 git status                 # clean, or only the branch you intend to ship
 npm ci                     # lockfile valid
 npm run build              # zero output, zero errors
-npm test                   # all green (baseline: 1099 tests)
+npm test                   # all green (baseline: 1206 tests)
 ```
 
 Fail the release if any step is red.
@@ -268,6 +268,25 @@ Fail the release if:
   node_major)
 - a command blocks more than 2 seconds when the telemetry endpoint is
   unreachable
+
+---
+
+## 10b. Documented commands must exist (1 min)
+
+Every command the README and `docs/` tell a user to run is copied verbatim by
+readers. Reading the page cannot tell you whether the CLI accepts it — only
+running it can.
+
+```bash
+npm test -- src/docs-commands.test.ts   # derives the command list from cli.ts
+```
+
+This is covered by a unit test, so §0 already ran it. Exercise it by hand only
+when the release **tightens a parser**: a stricter validator turns previously
+silent doc errors into hard failures. Precedent (0.21.0): making `init` reject
+unknown flags (#62) meant the team-setup guide's documented postinstall hook
+(which passed `--ci` to `init`) began exiting 2, failing `npm install` for
+every developer on a team that followed it.
 
 ---
 

--- a/docs/use-cases/team-setup.md
+++ b/docs/use-cases/team-setup.md
@@ -69,7 +69,7 @@ Add to `package.json`:
 ```json
 {
   "scripts": {
-    "postinstall": "npx secretless-ai init --ci"
+    "postinstall": "npx secretless-ai init"
   }
 }
 ```

--- a/src/docs-commands.test.ts
+++ b/src/docs-commands.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Every command this project's own docs tell a user to run must actually be a
+ * command. A reader copies these verbatim; one that does not parse is a dead
+ * end no amount of proofreading finds, because reading the page cannot tell
+ * you whether the CLI accepts it.
+ *
+ * Caught in the 0.21.0 release test: `docs/use-cases/team-setup.md` published
+ *
+ *     "postinstall": "npx secretless-ai init --ci"
+ *
+ * directly under "Now every `npm install` configures AI tool protections
+ * automatically." `init` takes an optional directory path and no flags, so it
+ * exits 2 with "Unknown option: --ci" — the documented hook failed every
+ * `npm install` for every developer on a team that followed the guide.
+ *
+ * The docs were right when they were written. Issue #62 made `init` reject
+ * unknown flags (before that, `init --dry-run` created a literal `--dry-run/`
+ * directory), and tightening the parser is what turned a silently-wrong
+ * documented command into a loudly-broken one. A release that tightens a
+ * parser has to re-check every command its docs publish.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+/**
+ * Commands the CLI actually dispatches, read from `cli.ts` itself so the list
+ * cannot drift from the implementation.
+ *
+ * Two dispatch sites, and missing either produces false failures: the main
+ * `switch (command)`, and the handful intercepted before it (`telemetry` is
+ * handled ahead of the switch so its own invocation is not tracked).
+ */
+function dispatchedCommands(): Set<string> {
+  const cli = fs.readFileSync(path.join(REPO_ROOT, 'src', 'cli.ts'), 'utf-8');
+  const commands = new Set<string>();
+  for (const m of cli.matchAll(/^\s*case '([a-z][a-z-]*)':/gm)) {
+    commands.add(m[1]);
+  }
+  for (const m of cli.matchAll(/command === '([a-z][a-z-]*)'/g)) {
+    commands.add(m[1]);
+  }
+  return commands;
+}
+
+/**
+ * Command references only. A doc sentence containing the package name followed
+ * by a word ("common secretless-ai workflows") is prose, and `npm view
+ * secretless-ai dist.attestations` is an npm invocation. Require the reference
+ * to be inside backticks or on a fenced code line, which is how a reader tells
+ * the difference too.
+ */
+function commandReferences(line: string): string[] {
+  const verbs: string[] = [];
+  const inCode = /^\s{4,}\S/.test(line) || /^\s*[$>]/.test(line);
+  const candidates = [...line.matchAll(/`([^`]+)`/g)].map(m => m[1]);
+  if (inCode) candidates.push(line);
+
+  for (const snippet of candidates) {
+    if (/npm\s+\w+\s+secretless-ai/.test(snippet)) continue;
+    for (const m of snippet.matchAll(/(?:^|[$\s(])(?:npx\s+)?secretless-ai\s+([a-z][a-z-]*)/g)) {
+      verbs.push(m[1]);
+    }
+  }
+  return verbs;
+}
+
+/** Markdown the project publishes to users. */
+function docFiles(): string[] {
+  const files: string[] = [];
+  const readme = path.join(REPO_ROOT, 'README.md');
+  if (fs.existsSync(readme)) files.push(readme);
+
+  const walk = (dir: string): void => {
+    if (!fs.existsSync(dir)) return;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith('.md')) files.push(full);
+    }
+  };
+  walk(path.join(REPO_ROOT, 'docs'));
+  return files;
+}
+
+describe('documented commands exist', () => {
+  const commands = dispatchedCommands();
+  const files = docFiles();
+
+  it('derives a real command list from both dispatch sites', () => {
+    // Guard against the extraction silently matching nothing, which would make
+    // every assertion below vacuously true.
+    expect(commands.size).toBeGreaterThan(20);
+    expect(commands.has('init')).toBe(true);
+    expect(commands.has('scan')).toBe(true);
+    // Dispatched before the switch — missing this site is what made the first
+    // version of this test report `telemetry` as undefined.
+    expect(commands.has('telemetry')).toBe(true);
+  });
+
+  it('distinguishes a command reference from prose and from npm invocations', () => {
+    // The extractor is the part most likely to go quietly wrong, so pin both
+    // directions rather than trusting a green run over the real docs.
+    expect(commandReferences('Run `secretless-ai scan` to check.')).toEqual(['scan']);
+    expect(commandReferences('guides for common secretless-ai workflows.')).toEqual([]);
+    expect(commandReferences('`npm view secretless-ai dist.attestations --json`')).toEqual([]);
+    expect(commandReferences('# secretless-ai release smoke test')).toEqual([]);
+    expect(commandReferences('    npx secretless-ai init')).toEqual(['init']);
+  });
+
+  it('finds docs to check', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it('never documents a flag on `init`, which accepts a path and no flags', () => {
+    // The exact shape that shipped broken. `init` is the highest-risk case:
+    // it is the command teams wire into automation, so a rejected flag fails
+    // `npm install` rather than merely printing an error someone reads.
+    const offenders: string[] = [];
+    for (const file of files) {
+      const text = fs.readFileSync(file, 'utf-8');
+      text.split('\n').forEach((line, i) => {
+        if (/secretless-ai\s+init\s+--/.test(line)) {
+          offenders.push(`${path.relative(REPO_ROOT, file)}:${i + 1}: ${line.trim()}`);
+        }
+      });
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('only names commands the CLI dispatches', () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      const text = fs.readFileSync(file, 'utf-8');
+      text.split('\n').forEach((line, i) => {
+        for (const verb of commandReferences(line)) {
+          if (!commands.has(verb)) {
+            offenders.push(`${path.relative(REPO_ROOT, file)}:${i + 1}: "${verb}" — ${line.trim()}`);
+          }
+        }
+      });
+    }
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Found by the 0.21.0 release test, by running the commands the docs publish rather than reading them.

## The defect

`docs/use-cases/team-setup.md:72` told teams to add:

```json
{
  "scripts": {
    "postinstall": "npx secretless-ai init --ci"
  }
}
```

immediately above the line "Now every `npm install` configures AI tool protections automatically."

`init` takes an optional directory path and no flags, so it exits 2 with `Unknown option: --ci`. npm fails an install on a non-zero postinstall, so the documented hook broke `npm install` for every developer on a team that followed the guide.

## Why it happened

The guide was correct when it was written. Issue #62 made `init` reject unknown flags — before that, `init --dry-run` created a literal `--dry-run/` directory — and tightening the parser is what turned a silently-wrong documented command into a loudly-broken one. Under the old behaviour `init --ci` would have created a `--ci/` directory and exited 0, so npm never noticed.

**A release that tightens a parser has to re-check every command its own docs publish.** Reading the page cannot find this; only running it can.

## The fix

- Drop the flag. `init` is already non-interactive, so `--ci` never added anything.
- `src/docs-commands.test.ts` derives the valid command list from **both** dispatch sites in `cli.ts` — the main `switch`, and the pre-switch `command === '...'` interceptions — rather than restating it in the test. Missing the second site made the first version of the test report `telemetry` as a non-existent command.
- The extractor is pinned in both directions, so prose ("guides for common secretless-ai workflows"), doc titles, and `npm view secretless-ai dist.attestations` do not register as command references while real invocations do.
- The test fails with the flag restored.

Also folds the check into `docs/testing/release-smoke.md` as §10b, per that document's own rule that a regression it would have missed gets added as part of the fix, and refreshes its stale test baseline (1099 → 1206).

## Not changed

`--ci` support is inconsistent across the CLI: accepted by `verify`, `doctor`, `setup`, `mcp-status`; rejected by `scan`, `status`, `init`. That is worth settling, but it is a separate decision from fixing a doc that breaks installs, so it is recorded rather than bundled here.

1210 tests across 71 files.