### PR TITLE
scan a named file; find config files below the root; --only '' fails closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ credentials missing. Both are reasons to upgrade promptly.
 
 ### Fixed
 
+- **`scan <file>` reported a clean result for a file containing a credential.** A file path was accepted, checked for existence, then walked as if it were a directory — which found nothing:
+
+  ```
+  $ secretless-ai scan single.js
+    No hardcoded credentials found.          # exit 0
+  $ secretless-ai scan .                     # the same file, via its directory
+    1 credential found                       # exit 1
+  ```
+
+  `secretless-ai scan src/config.ts` in a CI step was therefore a green pass over a live credential. A named file is now scanned as that file. Because naming a path is an explicit instruction rather than a directory walk, neither the ignore list nor the test-file heuristics apply to it: those exist to keep a walk from being noisy, and there is no walk.
+
+- **Config files were only found at the scan root.** Source files recursed; `config.json`, `docker-compose.yml`, `.mcp.json`, `terraform.tfvars` and the rest were matched only against the top directory. A monorepo, or anything under `deploy/` or `infra/`, reported clean at exactly the invocation everyone runs first, while the same scan from inside the subdirectory found the credential immediately.
+
+  Config files are now found at any depth, including in the hidden directories where tool configs actually live (`.cursor/`, `.claude/`, `.vscode/`). Generated trees (`node_modules/`, `dist/`, `build/`) are still never walked, and `.secretlessignore` still applies.
+
+- **`run --only ''` ran the command and exited 0.** An empty value read as "flag not supplied", so the filter vanished — while the semantically identical `--only ,,` correctly refused. Same input, opposite fail direction. A CI step computing `--only "$KEYS"` with an empty `$KEYS` ran unprotected and reported success. Both forms now fail closed.
+
 - **`run --only` never checked that the names it was given were found (#110).** One root cause, three failure modes, and only the least harmful was loud.
 
   | store | `--only` matches | before |

--- a/src/commands/env-run.test.ts
+++ b/src/commands/env-run.test.ts
@@ -100,3 +100,47 @@ describe('runRun surfaces a multi-line precondition error intact', () => {
     }
   });
 });
+
+// Release-test P2: `--only ''` and `--only ,,` are semantically identical but
+// failed in opposite directions — the empty string looked like "flag absent",
+// so the child ran and exited 0. A CI job computing `--only "$KEYS"` with an
+// empty $KEYS ran unprotected and reported success.
+describe('runRun --only with an empty value fails closed', () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("treats --only '' the same as --only ,,", async () => {
+    const { runRun } = await import('./env-run');
+    const { runWithSecrets } = await import('../run');
+    vi.mocked(runWithSecrets).mockClear();
+    vi.mocked(runWithSecrets).mockResolvedValue(0);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await runRun(['--only', '', '--', 'echo', 'hi']);
+
+    // The parse must pass an EMPTY LIST through, not `undefined`. `undefined`
+    // means "no filter", which injects the entire store.
+    expect(vi.mocked(runWithSecrets).mock.lastCall![2]).toEqual({ only: [] });
+  });
+
+  it('CONTROL: a real --only value still parses to that list', async () => {
+    const { runRun } = await import('./env-run');
+    const { runWithSecrets } = await import('../run');
+    vi.mocked(runWithSecrets).mockClear();
+    vi.mocked(runWithSecrets).mockResolvedValue(0);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await runRun(['--only', 'A,B', '--', 'echo', 'hi']);
+    expect(vi.mocked(runWithSecrets).mock.lastCall![2]).toEqual({ only: ['A', 'B'] });
+  });
+
+  it('CONTROL: no --only at all still means no filter', async () => {
+    const { runRun } = await import('./env-run');
+    const { runWithSecrets } = await import('../run');
+    vi.mocked(runWithSecrets).mockClear();
+    vi.mocked(runWithSecrets).mockResolvedValue(0);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await runRun(['--', 'echo', 'hi']);
+    expect(vi.mocked(runWithSecrets).mock.lastCall![2]).toEqual({ only: undefined });
+  });
+});

--- a/src/commands/env-run.ts
+++ b/src/commands/env-run.ts
@@ -13,7 +13,11 @@ export async function runRun(args: string[]): Promise<number> {
   // Check for --only before the separator
   const searchEnd = separatorIdx !== -1 ? separatorIdx : args.length;
   for (let i = 0; i < searchEnd; i++) {
-    if (args[i] === '--only' && args[i + 1]) {
+    // `args[i + 1] !== undefined`, not a truthiness test: `--only ''` is the
+    // flag WITH an empty value, and treating it as "flag absent" injected the
+    // whole store and exited 0, while the equivalent `--only ,,` failed closed.
+    // Same input, opposite fail direction (#110).
+    if (args[i] === '--only' && args[i + 1] !== undefined) {
       only = args[i + 1].split(',').map(s => s.trim()).filter(Boolean);
       break;
     }
@@ -71,7 +75,11 @@ export async function runEnv(args: string[]): Promise<number> {
   // Parse --only flag
   let only: string[] | undefined;
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--only' && args[i + 1]) {
+    // `args[i + 1] !== undefined`, not a truthiness test: `--only ''` is the
+    // flag WITH an empty value, and treating it as "flag absent" injected the
+    // whole store and exited 0, while the equivalent `--only ,,` failed closed.
+    // Same input, opposite fail direction (#110).
+    if (args[i] === '--only' && args[i + 1] !== undefined) {
       only = args[i + 1].split(',').map(s => s.trim()).filter(Boolean);
       break;
     }

--- a/src/scan.test.ts
+++ b/src/scan.test.ts
@@ -586,3 +586,133 @@ describe('scan() — every finding carries a fix (no dead ends)', () => {
     }
   });
 });
+
+describe('scan() — an explicitly named FILE is scanned (release-test P1)', () => {
+  function tmpProjectWith(files: Record<string, string>): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-file-'));
+    for (const [rel, content] of Object.entries(files)) {
+      const full = path.join(dir, rel);
+      fs.mkdirSync(path.dirname(full), { recursive: true });
+      fs.writeFileSync(full, content);
+    }
+    return dir;
+  }
+
+  const KEY = ['sk-proj-', 'Q1W2E3R4T5Y6U7I8O9P0A1S2D3F4G5H6J7K8L9Z0X1C2'].join('');
+
+  it('finds a credential when the target is the file itself', () => {
+    // `scan src/config.ts` accepted the path, checked it existed, then walked it
+    // as a directory and reported "No hardcoded credentials found" with exit 0.
+    // In CI that is a green pass over a live credential.
+    const dir = tmpProjectWith({ 'single.js': `const s = "${KEY}";\n` });
+    const findings = scan(path.join(dir, 'single.js'), { scanGlobal: false });
+    expect(findings.map(f => f.file)).toEqual(['single.js']);
+  });
+
+  it('CONTROL: the same file via its directory was always found', () => {
+    // Proves the test above is about the file target, not the pattern.
+    const dir = tmpProjectWith({ 'single.js': `const s = "${KEY}";\n` });
+    expect(scan(dir, { scanGlobal: false }).length).toBe(1);
+  });
+
+  it('scans an explicitly named file even inside a suppressed directory', () => {
+    // Naming a path is an explicit instruction; default suppression is a
+    // heuristic for directory walks. The explicit instruction wins.
+    const dir = tmpProjectWith({ 'test/fixture.test.js': `const s = "${KEY}";\n` });
+    const findings = scan(path.join(dir, 'test/fixture.test.js'), { scanGlobal: false });
+    expect(findings.length).toBe(1);
+  });
+
+  it('scans an explicitly named CONFIG file', () => {
+    const dir = tmpProjectWith({ 'config.json': `{"apiKey": "${KEY}"}\n` });
+    const findings = scan(path.join(dir, 'config.json'), { scanGlobal: false });
+    expect(findings.length).toBe(1);
+    expect(findings[0].severity).toBe('critical');
+  });
+
+  it('a file with no credential is still clean', () => {
+    const dir = tmpProjectWith({ 'clean.js': 'const x = 1;\n' });
+    expect(scan(path.join(dir, 'clean.js'), { scanGlobal: false })).toEqual([]);
+  });
+});
+
+describe('scan() — config files are found below the root (release-test P1)', () => {
+  function tmpProjectWith(files: Record<string, string>): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-cfgrec-'));
+    for (const [rel, content] of Object.entries(files)) {
+      const full = path.join(dir, rel);
+      fs.mkdirSync(path.dirname(full), { recursive: true });
+      fs.writeFileSync(full, content);
+    }
+    return dir;
+  }
+
+  const GKEY = ['AIzaSy', 'B7xK2mNvPwQ4tZ8hLcDfGjHkMnOpQrStU'].join('');
+
+  it('finds a credential in a nested config.json', () => {
+    // Source files recursed; config files only matched at the scan root, so a
+    // monorepo reported clean at exactly the invocation everyone runs first.
+    const dir = tmpProjectWith({ 'sub/config.json': `{"key": "${GKEY}"}\n` });
+    const findings = scan(dir, { scanGlobal: false });
+    expect(findings.map(f => f.file)).toEqual(['sub/config.json']);
+  });
+
+  it('finds a nested docker-compose.yml two levels down', () => {
+    const dir = tmpProjectWith({
+      'deploy/prod/docker-compose.yml': `services:\n  api:\n    environment:\n      GOOGLE_API_KEY: ${GKEY}\n`,
+    });
+    const findings = scan(dir, { scanGlobal: false });
+    expect(findings.map(f => f.file)).toEqual(['deploy/prod/docker-compose.yml']);
+  });
+
+  it('finds a nested tool config in a dot-directory', () => {
+    // Dot-dirs are skipped for source files but are exactly where tool configs
+    // live, so the config walk must not blanket-skip them.
+    const dir = tmpProjectWith({ 'pkg/.cursor/mcp.json': `{"token": "${GKEY}"}\n` });
+    const findings = scan(dir, { scanGlobal: false });
+    expect(findings.map(f => f.file)).toEqual(['pkg/.cursor/mcp.json']);
+  });
+
+  it('CONTROL: a root config file still works', () => {
+    const dir = tmpProjectWith({ 'config.json': `{"key": "${GKEY}"}\n` });
+    expect(scan(dir, { scanGlobal: false }).map(f => f.file)).toEqual(['config.json']);
+  });
+
+  it('does NOT descend into node_modules, dist, or build', () => {
+    const dir = tmpProjectWith({
+      'node_modules/pkg/config.json': `{"key": "${GKEY}"}\n`,
+      'dist/config.json': `{"key": "${GKEY}"}\n`,
+      'build/config.json': `{"key": "${GKEY}"}\n`,
+    });
+    expect(scan(dir, { scanGlobal: false })).toEqual([]);
+  });
+
+  it('does NOT descend into generated trees even with --no-ignore', () => {
+    // The assertion above cannot distinguish the walker's SOURCE_SKIP_DIRS from
+    // the default-ignore list, because both cover these directories — mutation
+    // testing caught it staying green with the walker's check removed. With
+    // `ignore: false` the ignore layer is gone, so the walker is the only thing
+    // left, and scanning a dependency tree would bury the report.
+    const dir = tmpProjectWith({
+      'node_modules/pkg/config.json': `{"key": "${GKEY}"}\n`,
+      'dist/config.json': `{"key": "${GKEY}"}\n`,
+      'build/config.json': `{"key": "${GKEY}"}\n`,
+    });
+    expect(scan(dir, { scanGlobal: false, ignore: false })).toEqual([]);
+  });
+
+  it('honours .secretlessignore for nested config files', () => {
+    const dir = tmpProjectWith({
+      'sub/config.json': `{"key": "${GKEY}"}\n`,
+      '.secretlessignore': 'sub/\n',
+    });
+    expect(scan(dir, { scanGlobal: false })).toEqual([]);
+  });
+
+  it('reports a nested config file exactly once', () => {
+    // The source-file pass must not re-report a file the config pass covered.
+    const dir = tmpProjectWith({ 'sub/package.json': `{"token": "${GKEY}"}\n` });
+    const findings = scan(dir, { scanGlobal: false });
+    expect(findings.length).toBe(1);
+  });
+});

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -263,6 +263,69 @@ const GLOBAL_CONFIG_FILES = [
  * Also scans global AI tool configs (e.g. ~/.claude/CLAUDE.md).
  * Returns findings sorted by severity then file.
  */
+/**
+ * Scan a single explicitly-named file.
+ *
+ * Severity mirrors the directory scan: a config file is `critical` (they get
+ * committed and read by tooling), source is `high`.
+ */
+function scanSingleFile(
+  filePath: string,
+  options: ScanOptions | undefined,
+  matchOpts: { includeExamples: boolean; onSuppressed: () => void },
+): ScanFinding[] {
+  const findings: ScanFinding[] = [];
+  const name = path.basename(filePath);
+  const isConfig = CONFIG_FILES.some(c => c === name || filePath.replace(/\\/g, '/').endsWith('/' + c));
+  const severity: 'critical' | 'high' = isConfig ? 'critical' : 'high';
+  const minConfidence = Math.max(0, Math.min(1, options?.minConfidence ?? 0));
+
+  try {
+    const stat = fs.statSync(filePath);
+    if (!stat.isFile() || stat.size > 10 * 1024 * 1024) return findings;
+    const lines = fs.readFileSync(filePath, 'utf-8').split('\n');
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (line.length > 4096) continue;
+      const trimmed = line.trim();
+      if (trimmed.startsWith('//') && trimmed.includes('regex')) continue;
+      if (/\$\{[A-Z_]+\}/.test(line) && !CREDENTIAL_PREFIX_QUICK_CHECK.test(line)) continue;
+      if (/process\.env\.[A-Z_]+/.test(line) && !CREDENTIAL_PREFIX_QUICK_CHECK.test(line)) continue;
+      if (/os\.environ/.test(line) && !CREDENTIAL_PREFIX_QUICK_CHECK.test(line)) continue;
+
+      for (const pattern of CREDENTIAL_PATTERNS) {
+        const match = findRealMatch(line, pattern, matchOpts);
+        if (match) {
+          const breakdown = scoreFinding({
+            pattern: { id: pattern.id, regex: pattern.regex },
+            value: match[0],
+            filePath: name,
+          });
+          if (breakdown.score >= minConfidence) {
+            findings.push({
+              file: name,
+              line: i + 1,
+              patternId: pattern.id,
+              patternName: pattern.name,
+              severity,
+              preview: maskLine(line, pattern).trim().substring(0, 80),
+              fix: fixFor(pattern),
+              confidence: breakdown.score,
+              confidenceTier: breakdown.tier,
+              looksLikeFixture: false,
+            });
+          }
+          break;
+        }
+      }
+    }
+  } catch {
+    // Unreadable — no findings rather than a crash.
+  }
+  return findings;
+}
+
 export function scan(projectDir: string, options?: ScanOptions, stats?: ScanStats): ScanFinding[] {
   // Shared per-match options for the credential-pattern call sites: reveal or count
   // placeholder-suppressed matches so the CLI can tell the user what was hidden.
@@ -272,6 +335,23 @@ export function scan(projectDir: string, options?: ScanOptions, stats?: ScanStat
   };
   const findings: ScanFinding[] = [];
   const scanGlobal = options?.scanGlobal !== false;
+
+  // A FILE target is scanned as that file. It used to be accepted, checked for
+  // existence, then walked as a directory — which found nothing and reported
+  // "No hardcoded credentials found" with exit 0, so `scan src/config.ts` in CI
+  // was a green pass over a live credential.
+  //
+  // Naming a path is an explicit instruction, so neither the ignore list nor
+  // the test-file heuristics apply: those exist to keep a directory WALK from
+  // being noisy, and there is no walk here.
+  try {
+    if (fs.statSync(projectDir).isFile()) {
+      return scanSingleFile(projectDir, options, matchOpts);
+    }
+  } catch {
+    // Unreadable/nonexistent — fall through to the directory path, which
+    // reports the not-found error the CLI already renders.
+  }
 
   // Resolve the ignore matcher. Default: load `<projectDir>/.secretlessignore`
   // plus the default-ignore list. `ignore: false` disables both.
@@ -297,6 +377,7 @@ export function scan(projectDir: string, options?: ScanOptions, stats?: ScanStat
     : null;
 
   const minConfidence = Math.max(0, Math.min(1, options?.minConfidence ?? 0));
+  const includeTestsOpt = options?.includeTests ?? false;
 
   // Helper: classify a match into a `ScanFinding` with confidence + fixture flag.
   function buildFinding(
@@ -354,11 +435,19 @@ export function scan(projectDir: string, options?: ScanOptions, stats?: ScanStat
     } catch { /* skip */ }
   }
 
-  // Scan project-level config files
-  for (const configFile of CONFIG_FILES) {
+  // Scan project-level config files, at any depth.
+  //
+  // These used to be looked up ONLY at the scan root, while source files
+  // recursed — so a monorepo with `packages/*/config.json`, or anything under
+  // `deploy/` or `infra/`, reported clean at exactly the invocation every user
+  // runs first. A scanner that answers "clean" for a tree it never walked is
+  // worse than one that errors.
+  const scannedConfigFiles: string[] = [];
+  for (const configFile of walkConfigFiles(projectDir, options?.maxSourceFiles ?? 5000, includeTestsOpt, ignore)) {
     if (ignore && ignore.matches(configFile)) continue;
     const fullPath = path.join(projectDir, configFile);
     if (!fs.existsSync(fullPath)) continue;
+    scannedConfigFiles.push(configFile);
 
     try {
       const stat = fs.statSync(fullPath);
@@ -396,7 +485,7 @@ export function scan(projectDir: string, options?: ScanOptions, stats?: ScanStat
 
   // Scan source code files for hardcoded credentials
   if (options?.scanSource !== false) {
-    const configFileSet = new Set(CONFIG_FILES);
+    const configFileSet = new Set(scannedConfigFiles);
     const maxFiles = options?.maxSourceFiles ?? 5000;
     const includeTests = options?.includeTests ?? false;
     const sourceFiles = walkSourceFiles(projectDir, maxFiles, includeTests, ignore);
@@ -579,6 +668,67 @@ function walkKeyFiles(
         if (!includeTests && isTestFile(entry.name)) continue;
         if (ignore && ignore.matches(relFromRoot)) continue;
         results.push(entryPath);
+      }
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Walk a directory tree and return paths (relative, POSIX) of project config
+ * files at ANY depth.
+ *
+ * Config files used to be looked up only at the scan root while source files
+ * recursed, so a monorepo's per-package config, `deploy/`, and `infra/` were
+ * invisible to the root invocation. Entries containing a slash
+ * (`.cursor/mcp.json`) match as a path suffix; the rest match on basename.
+ *
+ * Unlike source files, config files commonly live in HIDDEN directories
+ * (`.claude/`, `.cursor/`, `.vscode/`), so dot-dirs are walked — mirroring
+ * walkKeyFiles rather than walkSourceFiles.
+ */
+function walkConfigFiles(
+  dir: string,
+  maxFiles: number,
+  includeTests: boolean,
+  ignore: IgnoreMatcher | null,
+): string[] {
+  const byBasename = new Set<string>();
+  const bySuffix: string[] = [];
+  for (const entry of CONFIG_FILES) {
+    if (entry.includes('/')) bySuffix.push(entry);
+    else byBasename.add(entry);
+  }
+
+  const results: string[] = [];
+  const queue: string[] = [dir];
+
+  while (queue.length > 0 && results.length < maxFiles) {
+    const current = queue.shift()!;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (results.length >= maxFiles) break;
+      const entryPath = path.join(current, entry.name);
+      const relFromRoot = path.relative(dir, entryPath).replace(/\\/g, '/');
+
+      if (entry.isDirectory()) {
+        if (SOURCE_SKIP_DIRS.has(entry.name) || entry.name === '.git') continue;
+        if (!includeTests && TEST_DIRS.has(entry.name)) continue;
+        if (ignore && ignore.matches(relFromRoot + '/.')) continue;
+        queue.push(entryPath);
+      } else if (entry.isFile()) {
+        const isConfig = byBasename.has(entry.name)
+          || bySuffix.some(sfx => relFromRoot === sfx || relFromRoot.endsWith('/' + sfx));
+        if (!isConfig) continue;
+        if (ignore && ignore.matches(relFromRoot)) continue;
+        results.push(relFromRoot);
       }
     }
   }


### PR DESCRIPTION
Three defects found by the fresh-user release test for 0.21.1. All pre-existing (present in the published 0.20.0 and 0.21.0), and all the same shape as the ones 0.21.1 already fixes: **a command reporting success while doing less than it said.**

Shipping 0.21.1 without these would be incoherent, since that is precisely what the release is about.

## P1: `scan <file>` reported clean over a live credential

```
$ printf 'const s="sk_live_...";\n' > single.js

$ secretless-ai scan single.js
  No hardcoded credentials found.          # exit 0

$ secretless-ai scan .                      # the same file, via its directory
  1 credential found                        # exit 1
```

A file path was accepted, checked for existence (a nonexistent path correctly errors), then walked as if it were a directory — which found nothing. `secretless-ai scan src/config.ts` in a CI step was a green pass over a live credential.

A named file is now scanned as that file. Because naming a path is an explicit instruction rather than a directory walk, the ignore list and the test-file heuristics do not apply to it — those exist to keep a *walk* from being noisy, and there is no walk. So `scan test/fixture.test.js` scans it.

## P1: config files were only found at the scan root

```
$ find . -type f
./sub/config.json
./sub/deep/docker-compose.yml       # both contain a live key

$ secretless-ai scan                # from the root
  No hardcoded credentials found.   # exit 0

$ cd sub && secretless-ai scan
  1 critical credential exposed
```

Source files recursed; config files (`config.json`, `docker-compose.yml`, `.mcp.json`, `terraform.tfvars`, …) were matched only against the top directory. A monorepo, or anything under `deploy/` or `infra/`, got a false clean bill of health from the first command anyone runs.

Config files are now found at any depth, including the hidden directories where tool configs actually live (`.cursor/`, `.claude/`, `.vscode/`) — those are skipped for source files but are exactly where these configs are. Generated trees (`node_modules/`, `dist/`, `build/`) are still never walked, `.secretlessignore` still applies, and a file covered by the config pass is not re-reported by the source pass.

## P2: `run --only ''` ran the command and exited 0

```
$ secretless-ai run --only ,, -- echo hello
  --only was given but named no secrets.     # exit 1, fail-closed

$ secretless-ai run --only '' -- echo hello
hello                                        # exit 0, fail-OPEN
```

An empty value read as "flag not supplied", so the filter vanished. Semantically identical input, opposite fail direction. A CI step computing `--only "$KEYS"` with an empty `$KEYS` ran unprotected and reported success. Both forms now fail closed, at both `run` and `env` parse sites.

## Verification

- **Red proof:** 7 new tests fail against the pre-fix code, controls stay green.
- **Mutation:** 28 mutants killed, 0 survived. One survivor was found and fixed first: the `node_modules` assertion could not fail, because the default-ignore list covers the same directories as the walker's own skip list, so removing the walker's check left it green. The replacement runs with `ignore: false`, where the walker is the only thing left.
- 1297 tests / 74 files.
- Re-verified end to end against the built CLI, including that the source-file control still reports separately from the config findings.
