### PR TITLE
Report a resolvable path, refuse extra scan paths, sweep backend reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ credentials missing. Both are reasons to upgrade promptly.
 
   Config files are now found at any depth, including in the hidden directories where tool configs actually live (`.cursor/`, `.claude/`, `.vscode/`). Generated trees (`node_modules/`, `dist/`, `build/`) are still never walked, and `.secretlessignore` still applies.
 
+- **`scan <a> <b>` silently scanned only the first path.** The second was dropped with no warning, and because the first path's findings still set exit 1, the run looked complete while an entire file went unscanned. It now exits 2 naming the paths it was given, rather than answering for input it ignored.
+
+- **A single-file finding reported a path that did not resolve.** `scan deploy/prod/app.js --json` reported `file: "app.js"`, so a CI job annotating `file:line` from the JSON pointed at the wrong file or at nothing. It now reports the same path a directory scan does.
+
+- **`status`, `cache` and `mcp-status` reported the configured backend rather than the one in use.** The same defect as #111, in the three surfaces that were not swept when `backend` was fixed. `cache` drew a wrong conclusion from it — `Status: Not needed (local backend has no auth prompts)` on a machine whose secrets go to the Keychain, which does prompt. All four surfaces now name the effective backend and agree; `status --json` gains a `configuredBackend` field alongside it.
+
 - **`run --only ''` ran the command and exited 0.** An empty value read as "flag not supplied", so the filter vanished — while the semantically identical `--only ,,` correctly refused. Same input, opposite fail direction. A CI step computing `--only "$KEYS"` with an empty `$KEYS` ran unprotected and reported success. Both forms now fail closed.
 
 - **`run --only` never checked that the names it was given were found (#110).** One root cause, three failure modes, and only the least harmful was loud.

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -338,3 +338,43 @@ describe('scan warns on unknown flags / secret usage (regression: #80, #81)', ()
     }
   });
 });
+
+/**
+ * Re-test P2: `scan a.js b.js` dropped every path after the first with no
+ * warning. Because the first path's findings still set exit 1, the run looked
+ * complete while an entire file went unscanned.
+ */
+describe('scan rejects more than one path', () => {
+  const hasBuild = fs.existsSync(CLI_PATH);
+  const itIfBuilt = hasBuild ? it : it.skip;
+
+  itIfBuilt('refuses more than one path', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-multipath-'));
+    const KEY = ['sk-proj-', 'R1T2Y3U4I5O6P7A8S9D0F1G2H3J4K5L6Z7X8C9V0B1N2'].join('');
+    fs.writeFileSync(path.join(dir, 'a.js'), `const k = "${KEY}";\n`);
+    fs.writeFileSync(path.join(dir, 'b.js'), `const k = "${KEY}";\n`);
+
+    const res = spawnSync(process.execPath, [CLI_PATH, 'scan', 'a.js', 'b.js'], {
+      encoding: 'utf-8', cwd: dir, stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    expect(res.status).toBe(2);
+    const err = res.stderr ?? '';
+    expect(err).toContain('one path');
+    // It must name what it was given, so the user can see what was refused.
+    expect(err).toContain('a.js');
+    expect(err).toContain('b.js');
+  });
+
+  itIfBuilt('CONTROL: a single path still scans', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-singlepath-'));
+    const KEY = ['sk-proj-', 'R1T2Y3U4I5O6P7A8S9D0F1G2H3J4K5L6Z7X8C9V0B1N2'].join('');
+    fs.writeFileSync(path.join(dir, 'a.js'), `const k = "${KEY}";\n`);
+
+    const res = spawnSync(process.execPath, [CLI_PATH, 'scan', 'a.js'], {
+      encoding: 'utf-8', cwd: dir, stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    expect(res.status).toBe(1);
+    expect(res.stdout).toContain('credential');
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -165,6 +165,18 @@ async function dispatch(args: string[], command: string | undefined): Promise<nu
         console.error(`  Warning: ignoring unknown flag${unknownFlags.length > 1 ? 's' : ''} ${unknownFlags.join(', ')}.`);
         console.error(`  Run \`${CLI_BARE} scan\` for supported flags (--json, --show-placeholders, --min-confidence, --no-ignore, --include-tests, --explain).`);
       }
+      // Refuse extra paths rather than silently scanning only the first. A
+      // second path used to be dropped with no warning, and since the first
+      // path's findings still set exit 1, the run LOOKED complete while a whole
+      // file went unscanned — the same silent-shortfall class this release is
+      // about. Failing loudly is better than answering for input we ignored.
+      if (positionalArgs.length > 1) {
+        console.error(`  scan takes one path, but ${positionalArgs.length} were given: ${positionalArgs.join(', ')}`);
+        console.error('  Scan them one at a time, or pass the directory that contains them:');
+        console.error(`    ${CLI_BARE} scan ${positionalArgs[0]}`);
+        console.error(`    ${CLI_BARE} scan .`);
+        return 2;
+      }
       const dirArg = positionalArgs[0];
       const projectDir = dirArg ? path.resolve(dirArg) : process.cwd();
       return runScan(projectDir, { includeTests, explain, noIgnore, minConfidence, json, showPlaceholders });

--- a/src/commands/backend.silence.test.ts
+++ b/src/commands/backend.silence.test.ts
@@ -111,3 +111,32 @@ describe('read-only commands stay silent (no biometric / 1P prompts)', () => {
     expect(offending()).toEqual([]);
   });
 });
+
+// Re-test P2: `cache` keyed its auth-prompt advice off the CONFIGURED backend,
+// so on a default machine it said "Not needed (local backend has no auth
+// prompts)" while secrets were going to the Keychain, which does prompt.
+describe('cache reports the effective backend', () => {
+  it('names the same backend `backend` and SecretStore report', async () => {
+    const { runCache } = await import('./backend');
+    const { effectiveBackendName } = await import('../backends/factory');
+    const { resolveBackendType } = await import('../backends/config');
+
+    const out: string[] = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => { out.push(a.join(' ')); });
+    try {
+      await runCache([]);
+    } finally {
+      spy.mockRestore();
+    }
+
+    const expected = effectiveBackendName(resolveBackendType());
+    const backendLine = out.find(l => l.includes('Backend:')) ?? '';
+    expect(backendLine).toContain(expected);
+
+    // And the advice must follow from the EFFECTIVE backend, not the config.
+    const statusLine = out.find(l => l.includes('Status:')) ?? '';
+    if (expected.startsWith('keychain') || expected === '1password') {
+      expect(statusLine).not.toContain('no auth prompts');
+    }
+  });
+});

--- a/src/commands/backend.ts
+++ b/src/commands/backend.ts
@@ -363,8 +363,12 @@ export function runCache(args: string[]): number {
 
   // Default: show cache status
   const ttl = readCacheTtl();
-  const backendType = resolveBackendType();
-  const needsCache = backendType === 'keychain' || backendType === '1password';
+  // The EFFECTIVE backend, not the configured one: `local` upgrades to the
+  // platform keychain, which DOES prompt. Keying this off the configured value
+  // printed "Not needed (local backend has no auth prompts)" on a machine whose
+  // secrets were going to the keychain — advice that was exactly backwards.
+  const backendType = effectiveBackendName(resolveBackendType());
+  const needsCache = backendType.startsWith('keychain') || backendType === '1password';
 
   console.log('\n  Secret Cache\n');
   console.log(`  Backend:  ${backendType}`);

--- a/src/commands/core.ts
+++ b/src/commands/core.ts
@@ -5,7 +5,8 @@ import { status } from '../status';
 import { verify } from '../verify';
 import { toolDisplayName } from '../detect';
 import { doctor, quickDiagnosis, fixProfiles } from '../doctor';
-import { readBackendConfig } from '../backends/config';
+import { readBackendConfig, resolveBackendType } from '../backends/config';
+import { effectiveBackendName } from '../backends/factory';
 import { getDaemonStatus } from '../broker/daemon';
 import { getSessionStatus } from '../session/session-state';
 import { isDaemonInstalled } from '../session/install';
@@ -308,8 +309,11 @@ export function runStatus(projectDir: string, options?: { json?: boolean }): num
   const brokerInstalled = isDaemonInstalled();
   const tp = s.transcriptProtection;
   const configuredBackend = readBackendConfig();
-  // Session warmth only matters for backends that trigger OS auth prompts.
-  const sessionRelevant = configuredBackend === '1password' || configuredBackend === 'keychain';
+  // Session warmth only matters for backends that trigger OS auth prompts, and
+  // that is a property of the EFFECTIVE backend: `local` upgrades to the
+  // platform keychain, which prompts.
+  const effectiveBackend = effectiveBackendName(resolveBackendType());
+  const sessionRelevant = effectiveBackend.startsWith('keychain') || effectiveBackend === '1password';
 
   // Build observation rows. Each row: glyph + label + optional → command.
   // Satisfied observations use ✓; needs-action use ⚠. Every ⚠ ends in a
@@ -401,7 +405,8 @@ export function runStatus(projectDir: string, options?: { json?: boolean }): num
       configuredTools: s.configuredTools,
       secretsFound: s.secretsFound,
       transcriptProtection: tp,
-      backend: configuredBackend ?? null,
+      backend: effectiveBackend,
+      configuredBackend: configuredBackend ?? null,
       session: { relevant: sessionRelevant, warm: session.warm },
       broker: {
         installed: brokerInstalled,

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -4,6 +4,7 @@ import { discoverMcpConfigs } from '../mcp/discover';
 import { classifyEnvVars } from '../mcp/classify';
 import { restoreConfig } from '../mcp/rewrite';
 import { resolveBackendType } from '../backends/config';
+import { effectiveBackendName } from '../backends/factory';
 import type { SelectableBackendType } from '../backends/config';
 
 function getWrapperPath(): string {
@@ -82,7 +83,8 @@ export async function runProtectMcp(args: string[]): Promise<number> {
 export function runMcpStatus(): number {
   console.log('\n  Secretless MCP Status\n');
 
-  const backend = resolveBackendType();
+  // Report where secrets actually go, matching `backend` and `secret list`.
+  const backend = effectiveBackendName(resolveBackendType());
   console.log(`  Backend: ${backend}\n`);
 
   const configs = discoverMcpConfigs();

--- a/src/scan.test.ts
+++ b/src/scan.test.ts
@@ -606,7 +606,10 @@ describe('scan() — an explicitly named FILE is scanned (release-test P1)', () 
     // In CI that is a green pass over a live credential.
     const dir = tmpProjectWith({ 'single.js': `const s = "${KEY}";\n` });
     const findings = scan(path.join(dir, 'single.js'), { scanGlobal: false });
-    expect(findings.map(f => f.file)).toEqual(['single.js']);
+    expect(findings.length).toBe(1);
+    expect(path.basename(findings[0].file)).toBe('single.js');
+    // Whatever form the path takes, it must point at a real file.
+    expect(fs.existsSync(findings[0].file)).toBe(true);
   });
 
   it('CONTROL: the same file via its directory was always found', () => {
@@ -714,5 +717,47 @@ describe('scan() — config files are found below the root (release-test P1)', (
     const dir = tmpProjectWith({ 'sub/package.json': `{"token": "${GKEY}"}\n` });
     const findings = scan(dir, { scanGlobal: false });
     expect(findings.length).toBe(1);
+  });
+});
+
+describe('scan() — a single-file finding reports a path that resolves (re-test P2)', () => {
+  it('reports the path relative to cwd, not the bare basename', () => {
+    // The basename alone does not resolve from the caller's cwd, so a CI job
+    // annotating file:line from --json pointed at the wrong file or nothing.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-relpath-'));
+    fs.mkdirSync(path.join(dir, 'deploy/prod'), { recursive: true });
+    const KEY = ['sk-proj-', 'M1N2B3V4C5X6Z7L8K9J0H1G2F3D4S5A6P7O8I9U0Y1T2'].join('');
+    fs.writeFileSync(path.join(dir, 'deploy/prod/app.js'), `const k = "${KEY}";\n`);
+
+    const cwd = process.cwd();
+    try {
+      process.chdir(dir);
+      const findings = scan(path.join(dir, 'deploy/prod/app.js'), { scanGlobal: false });
+      expect(findings.length).toBe(1);
+      // Must match what a directory scan of the same tree reports.
+      expect(findings[0].file).toBe('deploy/prod/app.js');
+      // And it must actually exist relative to cwd.
+      expect(fs.existsSync(findings[0].file)).toBe(true);
+    } finally {
+      process.chdir(cwd);
+    }
+  });
+
+  it('falls back to the absolute path for a target outside cwd', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-outside-'));
+    const KEY = ['sk-proj-', 'M1N2B3V4C5X6Z7L8K9J0H1G2F3D4S5A6P7O8I9U0Y1T2'].join('');
+    const target = path.join(dir, 'outside.js');
+    fs.writeFileSync(target, `const k = "${KEY}";\n`);
+
+    const cwd = process.cwd();
+    try {
+      process.chdir(os.homedir());
+      const findings = scan(target, { scanGlobal: false });
+      expect(findings.length).toBe(1);
+      // Whatever form it takes, it must point at a real file.
+      expect(fs.existsSync(findings[0].file)).toBe(true);
+    } finally {
+      process.chdir(cwd);
+    }
   });
 });

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -276,6 +276,22 @@ function scanSingleFile(
 ): ScanFinding[] {
   const findings: ScanFinding[] = [];
   const name = path.basename(filePath);
+  // Report a path the reader can act on. The basename alone does not resolve
+  // from the caller's cwd, so a CI job annotating file:line from --json pointed
+  // at the wrong file or at nothing. Prefer cwd-relative; fall back to the
+  // absolute path when the target is outside the tree.
+  // realpath both sides: on macOS the temp dir and /tmp are symlinks, so a
+  // literal cwd-vs-path comparison escapes with `../../..` and loses the
+  // relative form for paths that are genuinely inside the tree.
+  const display = (() => {
+    try {
+      const rel = path.relative(fs.realpathSync(process.cwd()), fs.realpathSync(filePath));
+      if (rel && !rel.startsWith('..') && !path.isAbsolute(rel)) return rel.replace(/\\/g, '/');
+    } catch {
+      // fall through to the path as given
+    }
+    return filePath;
+  })();
   const isConfig = CONFIG_FILES.some(c => c === name || filePath.replace(/\\/g, '/').endsWith('/' + c));
   const severity: 'critical' | 'high' = isConfig ? 'critical' : 'high';
   const minConfidence = Math.max(0, Math.min(1, options?.minConfidence ?? 0));
@@ -304,7 +320,7 @@ function scanSingleFile(
           });
           if (breakdown.score >= minConfidence) {
             findings.push({
-              file: name,
+              file: display,
               line: i + 1,
               patternId: pattern.id,
               patternName: pattern.name,


### PR DESCRIPTION
Three findings from the fresh-user **re-test** of 0.21.1. The re-test confirmed the three P1s fixed in #114 (each red-proofed against a real pre-fix build) with **no regressions** — zero findings lost across 12 fixture trees, no double-reporting, no perf change. These are the remaining P2s worth fixing now: two are in the single-file scan path #114 added, and one is a class I fixed in a single surface and failed to sweep.

## `scan <a> <b>` silently scanned only the first path

```
$ secretless-ai scan a.js b.js --json
  ['a.js']  total=1        # b.js also holds a credential
$ secretless-ai scan b.js --json
  ['b.js']  total=1
```

No warning on stdout or stderr, and because the first path's findings still set exit 1, the run *looked* complete while an entire file went unscanned. That is the same silent-shortfall shape this release is about, introduced by the new file-target support. It now exits 2 naming the paths it was given:

```
  scan takes one path, but 2 were given: a.js, b.js
  Scan them one at a time, or pass the directory that contains them:
    secretless-ai scan a.js
    secretless-ai scan .
```

## A single-file finding reported a path that did not resolve

`scan deploy/prod/app.js --json` reported `file: "app.js"`, which does not exist relative to cwd, so a CI job annotating `file:line` from the JSON pointed at the wrong file or at nothing. It now reports `deploy/prod/app.js` — the same path a directory scan of the same tree reports.

Both sides are `realpath`'d before comparing: on macOS `os.tmpdir()` is `/var/folders/…` while `process.cwd()` resolves to `/private/var/…`, so a literal comparison escaped with `../../..` and lost the relative form for paths genuinely inside the tree. That bug was in the first version of this fix and is what the second test pins.

## `status`, `cache` and `mcp-status` reported the configured backend

The same defect as #111, in the three surfaces not swept when `backend` was fixed:

```
backend cmd    : keychain-macos  (configured: local, upgraded …)
status --json  : local
cache cmd      : local
mcp-status cmd : local
```

`cache` then drew a wrong conclusion from it — `Status: Not needed (local backend has no auth prompts)` on a machine whose secrets go to the Keychain, which *does* prompt. All four surfaces now name the effective backend and agree; `status --json` keeps the configured value in its own `configuredBackend` field.

## Verification

- **Mutation: 31 killed, 0 survived**, including all three new mutants.
- Fixing the harness was part of this: it never rebuilt `dist`, so the spawn-based CLI tests judged pre-mutant code and the `cli.ts` mutant would have survived for a reason unrelated to the test. It now rebuilds before each run and after each restore. (It had also previously left a live mutant in the working tree — restore now runs in a `finally`, and the restore list covers every file it mutates.)
- 1301 tests / 74 files.
- Verified end to end against the built CLI: the single-file path resolves and matches the directory scan, multi-path exits 2, and all four backend surfaces report `keychain-macos` with `cache` advice flipped from "Not needed" to "Active".
