### PR TITLE
Fix three fail-open defects that shipped in 0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## [0.21.2] - 2026-08-06
+
+Three defects that shipped in 0.21.1, two of them regressions introduced by that
+release's own fixes. All three are cases where the scanner reported a clean or
+complete result for work it had not done, so upgrade promptly.
+
+**Behavior change worth reading before you upgrade:** a scan that could not read
+everything no longer exits 0. If the file walk stops at the cap, or any file
+cannot be opened, `scan` exits 1 and says `No credentials found in the files
+scanned` instead of `No hardcoded credentials found`. A CI job over a tree larger
+than the 5000-file cap that was passing will now fail until you raise
+`--max-files` or narrow the path. Those passes were not earned: the walk stopped
+early and the result was reported as clean.
+
+### Fixed
+
+- **A symlinked config file or directory was silently skipped (regression in 0.21.1).** `walkConfigFiles` classified entries with `Dirent.isDirectory()` / `isFile()`, which are `lstat`-based — a symlink is neither, so it fell through both branches and was dropped. 0.21.0 reached config files through `existsSync`/`statSync`, which follow links; making the config walk recursive removed symlink support without anything noticing.
+
+  ```
+  repo/.claude -> shared-claude/          # settings.json holds a live key
+  0.21.0   exit 1   1 critical credential exposed
+  0.21.1   exit 0   No hardcoded credentials found.
+  ```
+
+  This affected every `CONFIG_FILES` entry at any depth — `.env`, `.mcp.json`, `docker-compose.yml`, `terraform.tfvars` — and a symlinked `.claude/` is exactly what a dotfile manager or a shared monorepo config produces. Entries are now classified by following the link, in all three walkers rather than only the config walk. A visited-realpath cycle guard lands in the same change: no walker has a depth bound, so restoring symlink-following without one would have traded a fail-open for a hang.
+
+- **A scan that hit the file cap reported clean.** The walkers stopped at `maxSourceFiles` (default 5000) and returned quietly, so an incomplete scan was indistinguishable from a complete one — fewer findings, no signal, exit 0. Truncation is now reported through `ScanStats.truncated`, surfaced in the human output and in `--json` as `summary.truncated` alongside `summary.maxFiles`, and exits 1. Adds `--max-files <n>` so the warning has a runnable fix.
+
+- **`.secretless` parse errors echoed credential values to stderr, twice.** The manifest is documented safe to commit, and `setup --check` stderr is exactly what lands in CI logs. A `NAME=VALUE` line echoed the whole line; a `NAME VALUE` line echoed it again interpolated into the error reason, which was also unbounded — so a 200 KB token flooded stderr through a field the 120-char line limit did not cover.
+
+  Redaction is an allowlist by position rather than a character test. Secret names allow `[a-zA-Z0-9_-]`, so a live token is itself a valid name and no charset rule can tell the two apart; only position can. The reason now names the shape it saw (dotenv, YAML, JSON), which is more actionable than the echo it replaces:
+
+  ```
+  line 1: ANTHROPIC_API_KEY=[redacted]
+          looks like dotenv (NAME=VALUE) — .secretless declares names only, never values
+  ```
+
+  `scan` now also reads `.secretless`, which nothing did before, so a pasted value is flagged rather than only printed.
+
+- **An unreadable file was reported as clean, exit 0 (#116).** The same content, readable, produces a finding. A directory scan dropped the file from the count and a named target printed `No hardcoded credentials found`. Unreadable paths are now listed with a runnable `chmod` fix, counted in `--json` as `summary.unreadable`, and exit 1.
+
+- **`.env` variants were mostly missed (#116).** `.env` and `.env.local` were detected; `.env.development`, `.env.production`, `.env.staging`, `.env.test` and `.env.prod` were not — the exact set named in the CLAUDE.md block Secretless itself installs. Any unrecognised `.env.*` is now scanned and only known template suffixes (`.example`, `.sample`, `.template`, `.dist`) are skipped, so the unknown case fails closed.
+
+- **Config filenames were matched case-sensitively.** On macOS and Windows `Claude.md` and `CLAUDE.md` are the same file to the OS but not to an exact-match lookup, so a file the user could plainly see was skipped.
+
+### Internal
+
+- Two tests asserted nothing and were rewritten. One asserted a pattern that accepted the unfixed value it claimed to guard against; the other computed its expectation by calling the same function as the code under test, so a wrong answer was wrong identically on both sides. Both are now pinned against independent oracles and verified to fail on a mutant.
+
 ## [0.21.1] - 2026-08-06
 
 Four defects that shipped in 0.21.0, plus issues #110, #111 and #112. Two of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ than the 5000-file cap that was passing will now fail until you raise
 `--max-files` or narrow the path. Those passes were not earned: the walk stopped
 early and the result was reported as clean.
 
+### Known issues
+
+- **`init` destroys `.claude/settings.json` when it does not parse as strict JSON, and reports the merge as successful ([#122](https://github.com/opena2a-org/secretless-ai/issues/122)).** Not introduced here — it reproduces identically on 0.21.1 — but disclosed rather than left silent, because it is the same defect class this release is about: a tool reporting success for work it did not do. The trigger is JSONC (`//` comments, trailing commas), which is what VS Code writes and what people hand-edit. A valid JSON settings file merges correctly and preserves every user key; only a parse failure clobbers, and no backup is written. If you keep comments in that file, back it up before running `init`. Fix targeted at 0.21.3.
+
 ### Fixed
 
 - **A symlinked config file or directory was silently skipped (regression in 0.21.1).** `walkConfigFiles` classified entries with `Dirent.isDirectory()` / `isFile()`, which are `lstat`-based — a symlink is neither, so it fell through both branches and was dropped. 0.21.0 reached config files through `existsSync`/`statSync`, which follow links; making the config walk recursive removed symlink support without anything noticing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,9 @@ early and the result was reported as clean.
   0.21.1   exit 0   No hardcoded credentials found.
   ```
 
-  This affected every `CONFIG_FILES` entry at any depth — `.env`, `.mcp.json`, `docker-compose.yml`, `terraform.tfvars` — and a symlinked `.claude/` is exactly what a dotfile manager or a shared monorepo config produces. Entries are now classified by following the link, in all three walkers rather than only the config walk. A visited-realpath cycle guard lands in the same change: no walker has a depth bound, so restoring symlink-following without one would have traded a fail-open for a hang.
+  This affected every `CONFIG_FILES` entry at any depth — `.env`, `.mcp.json`, `docker-compose.yml`, `terraform.tfvars` — and a symlinked `.claude/` is exactly what a dotfile manager or a shared monorepo config produces. Entries are now classified by following the link, and the three near-identical tree walks were collapsed onto one shared traversal: they had drifted apart, which is how the config copy gained recursion while losing the symlink handling, and sharing the walk means link handling, cycle safety and coverage reporting cannot diverge again.
 
-  Note this means a symlink whose target lies outside the scan root is read, which is what makes a symlinked shared-config directory work at all. Sockets, FIFOs and device files are never opened. Use `.secretlessignore` to exclude a link you do not want followed.
+  Two boundaries come with it. A directory is treated as a cycle only when it appears in its **own ancestor chain** — a global visited set also terminates, but it drops a directory reachable by a second path once the first is seen, which silently re-broke this very case whenever the link's target was itself in the tree. And a symlink whose target resolves **outside the scan root is not followed**, because otherwise a repo containing `link -> $HOME` makes `scan .` traverse the whole home directory; such links are listed in the output with the command to scan the target directly, so declining to follow them is never silent. Sockets, FIFOs and device files are never opened.
 
 - **A scan that hit the file cap reported clean.** The walkers stopped at `maxSourceFiles` (default 5000) and returned quietly, so an incomplete scan was indistinguishable from a complete one — fewer findings, no signal, exit 0. Truncation is now reported through `ScanStats.truncated`, surfaced in the human output and in `--json` as `summary.truncated` alongside `summary.maxFiles`, and exits 1. Adds `--max-files <n>` so the warning has a runnable fix.
 
@@ -35,13 +35,17 @@ early and the result was reported as clean.
   Redaction is an allowlist by position rather than a character test. Secret names allow `[a-zA-Z0-9_-]`, so a live token is itself a valid name and no charset rule can tell the two apart; only position can. The reason now names the shape it saw (dotenv, YAML, JSON), which is more actionable than the echo it replaces:
 
   ```
-  line 1: ANTHROPIC_API_KEY=[redacted]
+  line 1: [redacted]
           looks like dotenv (NAME=VALUE) — .secretless declares names only, never values
   ```
 
-  `scan` now also reads `.secretless`, which nothing did before, so a pasted value is flagged rather than only printed.
+  The first token is echoed only when the WHOLE token is a valid secret name. An earlier form of this fix split a `NAME=VALUE` paste and printed the left side, on the reasoning that in dotenv the left of `=` is the name — but `=` is also base64 padding, so for a secret from `openssl rand -base64 32` the "name" is the entire secret, and it was printed in full.
 
-- **An unreadable file was reported as clean, exit 0 (#116).** The same content, readable, produces a finding. A directory scan dropped the file from the count and a named target printed `No hardcoded credentials found`. Unreadable paths are now listed with a runnable `chmod` fix, counted in `--json` as `summary.unreadable`, and exit 1.
+- **An unreadable file or directory was reported as clean, exit 0 (#116).** The same content, readable, produces a finding. A directory scan dropped the file from the count and a named target printed `No hardcoded credentials found`; a directory whose listing failed vanished with nothing recorded at all. Unreadable paths are now listed with a runnable `chmod` fix, counted in `--json` as `summary.unreadable`, and exit 1. A broken symlink still counts as nothing to scan, but `EACCES`/`ELOOP` on a link target is reported rather than skipped.
+
+- **`status` and `vault scan` discarded the coverage signal.** Both call the same scanner and neither asked for it, so `vault scan` printed the unqualified `No hardcoded credentials found` over a tree it could not fully read — the exact string `scan` was fixed to stop printing — and `status --json` reported `secretsFound: 0` as though it were a verdict. `status --json` gains `scanIncomplete`.
+
+- **`--max-files` accepted a value it then ignored.** `parseInt` stops at the first non-digit, so `--max-files 20abc` silently became a cap of 20 and `--max-files 1e6` a cap of 1: the user believed the cap was raised while the scan covered a fraction of the tree and exited 0. The value must now be all digits.
 
 - **`.env` variants were mostly missed (#116).** `.env` and `.env.local` were detected; `.env.development`, `.env.production`, `.env.staging`, `.env.test` and `.env.prod` were not — the exact set named in the CLAUDE.md block Secretless itself installs. Any unrecognised `.env.*` is now scanned and only known template suffixes (`.example`, `.sample`, `.template`, `.dist`) are skipped, so the unknown case fails closed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ early and the result was reported as clean.
 
   This affected every `CONFIG_FILES` entry at any depth — `.env`, `.mcp.json`, `docker-compose.yml`, `terraform.tfvars` — and a symlinked `.claude/` is exactly what a dotfile manager or a shared monorepo config produces. Entries are now classified by following the link, in all three walkers rather than only the config walk. A visited-realpath cycle guard lands in the same change: no walker has a depth bound, so restoring symlink-following without one would have traded a fail-open for a hang.
 
+  Note this means a symlink whose target lies outside the scan root is read, which is what makes a symlinked shared-config directory work at all. Sockets, FIFOs and device files are never opened. Use `.secretlessignore` to exclude a link you do not want followed.
+
 - **A scan that hit the file cap reported clean.** The walkers stopped at `maxSourceFiles` (default 5000) and returned quietly, so an incomplete scan was indistinguishable from a complete one — fewer findings, no signal, exit 0. Truncation is now reported through `ScanStats.truncated`, surfaced in the human output and in `--json` as `summary.truncated` alongside `summary.maxFiles`, and exits 1. Adds `--max-files <n>` so the warning has a runnable fix.
 
 - **`.secretless` parse errors echoed credential values to stderr, twice.** The manifest is documented safe to commit, and `setup --check` stderr is exactly what lands in CI logs. A `NAME=VALUE` line echoed the whole line; a `NAME VALUE` line echoed it again interpolated into the error reason, which was also unbounded — so a 200 KB token flooded stderr through a field the 120-char line limit did not cover.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,15 @@ early and the result was reported as clean.
 
   This affected every `CONFIG_FILES` entry at any depth — `.env`, `.mcp.json`, `docker-compose.yml`, `terraform.tfvars` — and a symlinked `.claude/` is exactly what a dotfile manager or a shared monorepo config produces. Entries are now classified by following the link, and the three near-identical tree walks were collapsed onto one shared traversal: they had drifted apart, which is how the config copy gained recursion while losing the symlink handling, and sharing the walk means link handling, cycle safety and coverage reporting cannot diverge again.
 
-  Two boundaries come with it. A directory is treated as a cycle only when it appears in its **own ancestor chain** — a global visited set also terminates, but it drops a directory reachable by a second path once the first is seen, which silently re-broke this very case whenever the link's target was itself in the tree. And a symlink whose target resolves **outside the scan root is not followed**, because otherwise a repo containing `link -> $HOME` makes `scan .` traverse the whole home directory; such links are listed in the output with the command to scan the target directly, so declining to follow them is never silent. Sockets, FIFOs and device files are never opened.
+  Three bounds come with it, because a repository is an untrusted input to a scanner.
+
+  A directory is treated as a cycle only when it appears in its **own ancestor chain**. A global visited-realpath set also terminates, but it drops a directory reachable by a second path once the first is seen — which silently re-broke this very case whenever the link's target was itself in the tree, and which of the two paths won depended on readdir order.
+
+  A **directory** link resolving outside the scan root is not followed, because otherwise a repo containing `link -> $HOME` makes `scan .` traverse the whole home directory; these are listed with the command to scan the target directly, so declining is never silent. A **file** link is still followed wherever it points: reading one file the repository explicitly names is bounded work, and `pkg/.env -> ../../shared/.env` is what stow, chezmoi and monorepo-root env files actually produce.
+
+  Finally, the number of distinct paths through a lattice of links is exponential — a 15-level fixture reaches one directory 32,767 ways — so the number of routes followed to any one directory is capped, and crossing that cap reports the scan as incomplete rather than passing silently. Sockets, FIFOs and device files are never opened.
+
+  Findings are deduplicated on the resolved file, so a credential reachable by several paths is one finding rather than one per path.
 
 - **A scan that hit the file cap reported clean.** The walkers stopped at `maxSourceFiles` (default 5000) and returned quietly, so an incomplete scan was indistinguishable from a complete one — fewer findings, no signal, exit 0. Truncation is now reported through `ScanStats.truncated`, surfaced in the human output and in `--json` as `summary.truncated` alongside `summary.maxFiles`, and exits 1. Adds `--max-files <n>` so the warning has a runnable fix.
 
@@ -50,6 +58,10 @@ early and the result was reported as clean.
 - **`.env` variants were mostly missed (#116).** `.env` and `.env.local` were detected; `.env.development`, `.env.production`, `.env.staging`, `.env.test` and `.env.prod` were not — the exact set named in the CLAUDE.md block Secretless itself installs. Any unrecognised `.env.*` is now scanned and only known template suffixes (`.example`, `.sample`, `.template`, `.dist`) are skipped, so the unknown case fails closed.
 
 - **Config filenames were matched case-sensitively.** On macOS and Windows `Claude.md` and `CLAUDE.md` are the same file to the OS but not to an exact-match lookup, so a file the user could plainly see was skipped.
+
+### Security
+
+- **The `Verify:` and `Fix:` lines quote the paths they print.** Those paths are filenames from the scanned repository — attacker-controlled by definition — and the lines exist to be copy-pasted into a terminal. A symlink named `a"; id; echo "b` previously produced a command that closed the quote and ran `id`.
 
 ### Internal
 
@@ -417,6 +429,10 @@ These harden the best-effort Claude Code layers that back the primary tool-level
 - `ScanFinding` interface gained three required fields: `confidence: number`, `confidenceTier: 'high' | 'medium' | 'low'`, `looksLikeFixture: boolean`. Library consumers that destructure `ScanFinding` will need to handle the new fields (additive, not breaking — JSON consumers see strictly more keys).
 - `printFindings` (CLI) renders the confidence tier under each finding. Tier colour mirrors the severity ramp — `high` green, `medium` yellow, `low` dim — so a low-confidence high-severity finding visually de-emphasises without disappearing.
 
+### Security
+
+- **The `Verify:` and `Fix:` lines quote the paths they print.** Those paths are filenames from the scanned repository — attacker-controlled by definition — and the lines exist to be copy-pasted into a terminal. A symlink named `a"; id; echo "b` previously produced a command that closed the quote and ran `id`.
+
 ### Internal
 - New `src/confidence.ts` module + 32-test `confidence.test.ts` covering pattern-specificity escape handling, entropy noise floor, length-tier monotonicity, path-tier classification (Windows path normalisation, mixed-case, `*.test.ts` suffix), composite determinism, monotonicity-on-every-axis, and tier-rendering.
 - New `src/commands/ignore.ts` + 20-test `ignore.test.ts` covering file creation, append behaviour, idempotence (whitespace and `./` normalisation), traversal rejection (Unix absolute, Windows drive prefix, parent traversal, nested `..`), symlink rejection, 1MB size cap, and non-file refusal.
@@ -434,6 +450,10 @@ These harden the best-effort Claude Code layers that back the primary tool-level
 - **`status` output redesigned** per CISO Rule 11. The previous five sub-blocks (top-level metrics, Session, Broker, Transcript Protection, transcript line counts) collapsed into one Observations table. Every warning row ends in `→ <runnable command>` so the user has no dead end. Glyphs differentiate satisfied (`✓`) from needs-action (`⚠`). The Verdict line now reflects the warning count instead of a bare `Protected: Yes` — `Protected — Clean`, `Protected (4 unblocked credentials need review)`, `Not protected. Run secretless-ai init to install hooks.`
 - **Catalog re-pin to `@opena2a/credential-patterns@0.1.1`** with three new false-positive suppression branches (mirrored locally to keep the lockstep test green): block-comment marker recognition for line-level `'''`/`"""`/`<!--`/`-->`/`*` (JSDoc continuation lines now allowlisted when paired with the substring `example`), bare `'fake'` in `PLACEHOLDER_INDICATORS` (replaces `'fake_'` and `'fake-'` — case-insensitive substring match accepts `sk-proj-fake1234567890abcdefghijklmnop`), and a localhost-bound demo-password allowlist for connection strings (`postgres://admin:password123@localhost`/`@127.0.0.1`/`@[::1]` recognized as tutorial fixtures).
 - `init` `InitResult` interface gained `denyRulesAdded` (delta this run) and `denyRulesTotal` (full count after merge). The existing `denyRuleCount` on `StatusResult` is unchanged.
+
+### Security
+
+- **The `Verify:` and `Fix:` lines quote the paths they print.** Those paths are filenames from the scanned repository — attacker-controlled by definition — and the lines exist to be copy-pasted into a terminal. A symlink named `a"; id; echo "b` previously produced a command that closed the quote and ran `id`.
 
 ### Internal
 - New `src/secretlessignore.ts` parser (gitignore-subset glob → regex) plus 18-test `secretlessignore.test.ts` covering defaults, user file, negation, glob semantics, anchor rules, Windows path normalization, and path-traversal rejection. New `scan()` integration tests assert default-ignore suppression of fixture paths and `--no-ignore` round-trip.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Keep API keys and other secrets invisible to AI coding tools. Works with Claude 
 
 [![npm version](https://img.shields.io/npm/v/secretless-ai.svg)](https://www.npmjs.com/package/secretless-ai)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-1101%20passing-brightgreen)](https://github.com/opena2a-org/secretless-ai)
+[![Tests](https://img.shields.io/badge/tests-1333%20passing-brightgreen)](https://github.com/opena2a-org/secretless-ai)
 
 [Website](https://opena2a.org/secretless) · [Demos](https://opena2a.org/demos) · [Discord](https://discord.gg/uRZa3KXgEn)
 
@@ -19,7 +19,7 @@ npx secretless-ai init
 ```
 
 ```
-  Secretless v0.18.3
+  Secretless v0.21.2
   Keeping secrets out of AI
 
   Configured: Claude Code (1 of 1 detected)

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ npx secretless-ai mcp-unprotect                     # restore original configs f
 
 ```bash
 npx secretless-ai scan --min-confidence 0.85   # high-confidence findings only
+npx secretless-ai scan --max-files 20000       # raise the per-walk file cap (default 5000)
 npx secretless-ai ignore docs/migration.md     # append a path to .secretlessignore
 npx secretless-ai ignore --pattern '*.golden.txt'
 npx secretless-ai diff main                    # audit secretless-managed file changes vs a git ref
@@ -160,6 +161,16 @@ npx secretless-ai status --json                # protection state for CI (gate o
 ```
 
 `scan` renders a `Confidence: high (0.92)` line under every finding. The score combines pattern specificity, value entropy, value length, and path tier. With `--no-ignore`, findings whose path matches the default-ignore list are tagged `(looks like a test fixture)` so they stay visible without being re-suppressed.
+
+### Incomplete scans do not report clean
+
+A scan that could not read everything is not a passing scan. If the walk stops at the file cap, or a file cannot be opened, `scan` prints what it missed, exits 1, and says `No credentials found in the files scanned` rather than `No hardcoded credentials found`. In `--json`, `summary.truncated` and `summary.unreadable` carry the same signal, so CI can tell "clean" from "unfinished".
+
+```bash
+npx secretless-ai scan --json | jq '.summary'
+# { "total": 0, "critical": 0, "high": 0, "placeholdersSuppressed": 0,
+#   "truncated": false, "maxFiles": 5000, "unreadable": 0 }
+```
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -164,12 +164,14 @@ npx secretless-ai status --json                # protection state for CI (gate o
 
 ### Incomplete scans do not report clean
 
-A scan that could not read everything is not a passing scan. If the walk stops at the file cap, or a file cannot be opened, `scan` prints what it missed, exits 1, and says `No credentials found in the files scanned` rather than `No hardcoded credentials found`. In `--json`, `summary.truncated` and `summary.unreadable` carry the same signal, so CI can tell "clean" from "unfinished".
+A scan that could not read everything is not a passing scan. If the walk stops at the file cap, or a path cannot be opened, `scan` prints what it missed, exits 1, and says `No credentials found in the files scanned` rather than `No hardcoded credentials found`. In `--json`, `summary.truncated` and `summary.unreadable` carry the same signal, so CI can tell "clean" from "unfinished".
+
+Symlinks are followed inside the scan root. A link whose target resolves outside it is not followed -- otherwise a repo containing `link -> $HOME` would pull the whole home directory into the scan -- and each one is listed with the command to scan its target directly, so the boundary is never silent. These do not affect the exit code.
 
 ```bash
 npx secretless-ai scan --json | jq '.summary'
 # { "total": 0, "critical": 0, "high": 0, "placeholdersSuppressed": 0,
-#   "truncated": false, "maxFiles": 5000, "unreadable": 0 }
+#   "truncated": false, "maxFiles": 5000, "unreadable": 0, "outOfRoot": 0 }
 ```
 
 ## Architecture

--- a/src/backends/effective-name.test.ts
+++ b/src/backends/effective-name.test.ts
@@ -8,6 +8,7 @@
  * restated platform mapping.
  */
 import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
 import { effectiveBackendName, createBackend } from './factory';
 import { SecretStore } from '../secret-store';
 
@@ -26,14 +27,38 @@ describe('effectiveBackendName agrees with the constructed backend', () => {
   });
 
   it('names a keychain on a platform that has one', () => {
-    // Guards the direction of the fix: on macOS/Linux with a keychain
-    // available, "local" must NOT be reported as the effective backend.
+    // Guards the DIRECTION of the fix: where a keychain exists, "local" must
+    // not be reported as the effective backend.
+    //
+    // This assertion used to be `toMatch(/^(keychain-(macos|linux)|local)$/)`,
+    // which ACCEPTS the unfixed value `local` — so it passed whether or not the
+    // fix was present and could not fail in the direction its own comment
+    // claimed to guard. Availability is probed here independently (`security`
+    // / `secret-tool` on PATH) rather than by calling the implementation's own
+    // `isKeychainLikely`, which would only restate it.
     const name = effectiveBackendName('local');
-    if (process.platform === 'darwin' || process.platform === 'linux') {
-      expect(name).toMatch(/^(keychain-(macos|linux)|local)$/);
-    } else {
-      expect(name).toBe('local');
+
+    if (process.platform === 'darwin') {
+      // The macOS keychain CLI ships with the OS, so there is no conditional:
+      // this must resolve to the keychain, and `local` is a failure.
+      expect(name).toBe('keychain-macos');
+      return;
     }
+
+    if (process.platform === 'linux') {
+      const hasSecretTool = (() => {
+        try {
+          execFileSync('which', ['secret-tool'], { stdio: 'pipe' });
+          return true;
+        } catch {
+          return false;
+        }
+      })();
+      expect(name).toBe(hasSecretTool ? 'keychain-linux' : 'local');
+      return;
+    }
+
+    expect(name).toBe('local');
   });
 
   it('leaves every non-local type alone', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -153,11 +153,15 @@ async function dispatch(args: string[], command: string | undefined): Promise<nu
       const mfIdx = args.indexOf('--max-files');
       if (mfIdx !== -1 && mfIdx + 1 < args.length) {
         const raw = args[mfIdx + 1];
-        const parsed = Number.parseInt(raw, 10);
-        if (Number.isFinite(parsed) && parsed > 0) {
+        // Must be ALL digits. `parseInt` stops at the first non-digit and
+        // returns what it got, so `--max-files 20abc` silently became a cap of
+        // 20 and `--max-files 1e6` a cap of 1 — the user believes the cap was
+        // raised while the scan quietly covers a fraction of the tree.
+        const parsed = /^\d+$/.test(raw) ? Number.parseInt(raw, 10) : NaN;
+        if (Number.isSafeInteger(parsed) && parsed > 0) {
           maxFiles = parsed;
         } else {
-          console.error(`  Warning: ignoring invalid --max-files value "${raw}" (must be a positive integer).`);
+          console.error(`  Warning: ignoring invalid --max-files value "${raw}" (must be a positive whole number, e.g. --max-files 20000).`);
         }
       }
       const flagFlag = new Set(['--include-tests', '--explain', '--no-ignore', '--json', '--show-placeholders', '--min-confidence', '--max-files']);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -146,13 +146,27 @@ async function dispatch(args: string[], command: string | undefined): Promise<nu
           console.error(`  Warning: ignoring invalid --min-confidence value "${raw}" (must be in [0, 1]).`);
         }
       }
-      const flagFlag = new Set(['--include-tests', '--explain', '--no-ignore', '--json', '--show-placeholders', '--min-confidence']);
+      // --max-files <n>  Raise the per-walk file cap (default 5000). Without
+      // this, hitting the cap is a dead end: the scan reports it stopped early
+      // but the user has no way to finish it short of scanning subtrees by hand.
+      let maxFiles: number | undefined;
+      const mfIdx = args.indexOf('--max-files');
+      if (mfIdx !== -1 && mfIdx + 1 < args.length) {
+        const raw = args[mfIdx + 1];
+        const parsed = Number.parseInt(raw, 10);
+        if (Number.isFinite(parsed) && parsed > 0) {
+          maxFiles = parsed;
+        } else {
+          console.error(`  Warning: ignoring invalid --max-files value "${raw}" (must be a positive integer).`);
+        }
+      }
+      const flagFlag = new Set(['--include-tests', '--explain', '--no-ignore', '--json', '--show-placeholders', '--min-confidence', '--max-files']);
       const positionalArgs: string[] = [];
       const unknownFlags: string[] = [];
       for (let k = 1; k < args.length; k++) {
         const a = args[k];
         if (flagFlag.has(a)) {
-          if (a === '--min-confidence') k++;
+          if (a === '--min-confidence' || a === '--max-files') k++;
           continue;
         }
         // Warn (don't fail) on an unrecognized flag so a typo like `--show-placeholder`
@@ -163,7 +177,7 @@ async function dispatch(args: string[], command: string | undefined): Promise<nu
       }
       if (unknownFlags.length > 0) {
         console.error(`  Warning: ignoring unknown flag${unknownFlags.length > 1 ? 's' : ''} ${unknownFlags.join(', ')}.`);
-        console.error(`  Run \`${CLI_BARE} scan\` for supported flags (--json, --show-placeholders, --min-confidence, --no-ignore, --include-tests, --explain).`);
+        console.error(`  Run \`${CLI_BARE} scan\` for supported flags (--json, --show-placeholders, --min-confidence, --max-files, --no-ignore, --include-tests, --explain).`);
       }
       // Refuse extra paths rather than silently scanning only the first. A
       // second path used to be dropped with no warning, and since the first
@@ -179,7 +193,7 @@ async function dispatch(args: string[], command: string | undefined): Promise<nu
       }
       const dirArg = positionalArgs[0];
       const projectDir = dirArg ? path.resolve(dirArg) : process.cwd();
-      return runScan(projectDir, { includeTests, explain, noIgnore, minConfidence, json, showPlaceholders });
+      return runScan(projectDir, { includeTests, explain, noIgnore, minConfidence, json, showPlaceholders, maxFiles });
     }
     case 'status': {
       const json = args.includes('--json');

--- a/src/commands/backend.silence.test.ts
+++ b/src/commands/backend.silence.test.ts
@@ -118,8 +118,8 @@ describe('read-only commands stay silent (no biometric / 1P prompts)', () => {
 describe('cache reports the effective backend', () => {
   it('names the same backend `backend` and SecretStore report', async () => {
     const { runCache } = await import('./backend');
-    const { effectiveBackendName } = await import('../backends/factory');
     const { resolveBackendType } = await import('../backends/config');
+    const { SecretStore } = await import('../secret-store');
 
     const out: string[] = [];
     const spy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => { out.push(a.join(' ')); });
@@ -129,14 +129,25 @@ describe('cache reports the effective backend', () => {
       spy.mockRestore();
     }
 
-    const expected = effectiveBackendName(resolveBackendType());
+    // Independent oracle: the backend SecretStore actually CONSTRUCTED, which is
+    // the value `secret list` prints. The expectation used to be computed by
+    // calling `effectiveBackendName` — the same function `cache` uses — so a
+    // wrong answer was wrong identically on both sides and the assertion could
+    // not fail. Agreement between the two is pinned in effective-name.test.ts.
+    const expected = new SecretStore({ backendType: resolveBackendType() }).backendName;
     const backendLine = out.find(l => l.includes('Backend:')) ?? '';
     expect(backendLine).toContain(expected);
 
     // And the advice must follow from the EFFECTIVE backend, not the config.
+    // Both directions are asserted: the old form only checked the prompting
+    // case, so a regression that reported `local` skipped the branch entirely
+    // and passed — which is the exact defect this test exists for.
     const statusLine = out.find(l => l.includes('Status:')) ?? '';
-    if (expected.startsWith('keychain') || expected === '1password') {
+    const prompts = expected.startsWith('keychain') || expected === '1password';
+    if (prompts) {
       expect(statusLine).not.toContain('no auth prompts');
+    } else {
+      expect(statusLine).toContain('no auth prompts');
     }
   });
 });

--- a/src/commands/core.ts
+++ b/src/commands/core.ts
@@ -123,7 +123,7 @@ export function runInit(projectDir: string): number {
   return 0;
 }
 
-export async function runScan(projectDir: string, options?: { includeTests?: boolean; explain?: boolean; noIgnore?: boolean; minConfidence?: number; json?: boolean; showPlaceholders?: boolean }): Promise<number> {
+export async function runScan(projectDir: string, options?: { includeTests?: boolean; explain?: boolean; noIgnore?: boolean; minConfidence?: number; json?: boolean; showPlaceholders?: boolean; maxFiles?: number }): Promise<number> {
   const nodeFs = require('fs') as typeof import('fs');
   const scanOpts = {
     includeTests: options?.includeTests,
@@ -133,7 +133,9 @@ export async function runScan(projectDir: string, options?: { includeTests?: boo
     ignore: options?.noIgnore ? false : undefined,
     minConfidence: options?.minConfidence,
     showPlaceholders: options?.showPlaceholders,
+    maxSourceFiles: options?.maxFiles,
   };
+  const capUsed = options?.maxFiles ?? 5000;
 
   // --json: emit a single valid JSON document to stdout and nothing else, so the
   // output is machine-parseable (issue #63 — the flag previously printed the human
@@ -143,7 +145,7 @@ export async function runScan(projectDir: string, options?: { includeTests?: boo
       console.error(`Directory not found: ${projectDir}`);
       return 1;
     }
-    const stats = { placeholdersSuppressed: 0 };
+    const stats = { placeholdersSuppressed: 0, truncated: false };
     const findings = scan(projectDir, scanOpts, stats);
     const critical = findings.filter(f => f.severity === 'critical').length;
     console.log(JSON.stringify({
@@ -155,9 +157,14 @@ export async function runScan(projectDir: string, options?: { includeTests?: boo
         critical,
         high: findings.length - critical,
         placeholdersSuppressed: stats.placeholdersSuppressed,
+        // A machine consumer must be able to tell "clean" from "unfinished".
+        truncated: stats.truncated,
+        maxFiles: capUsed,
       },
     }, null, 2));
-    return findings.length > 0 ? 1 : 0;
+    // An incomplete scan is not a pass. `total: 0` with `truncated: true` means
+    // the walk stopped early, so exiting 0 would gate CI on a subset.
+    return findings.length > 0 || stats.truncated ? 1 : 0;
   }
 
   console.log('\n  Secretless Scanner\n');
@@ -168,8 +175,19 @@ export async function runScan(projectDir: string, options?: { includeTests?: boo
     return 1;
   }
 
-  const stats = { placeholdersSuppressed: 0 };
+  const stats = { placeholdersSuppressed: 0, truncated: false };
   const findings = scan(projectDir, scanOpts, stats);
+
+  // A walk that stopped at the file cap left tree unvisited, so the findings are
+  // a SUBSET. Rendering that as "No hardcoded credentials found." is the
+  // fail-open this warning closes: an answer we never got is not a good answer.
+  const truncationWarning = () => {
+    if (!stats.truncated) return;
+    console.log(`  ${c.boldYellow('Scan incomplete')} — stopped at the ${capUsed}-file cap, so files were left unscanned.`);
+    console.log(`  ${c.dim('This is not a clean result. Raise the cap or scan subtrees:')}`);
+    console.log(`  ${c.cyan('Verify:')} npx secretless-ai scan --max-files ${capUsed * 4}`);
+    console.log(`  ${c.cyan('Fix:')}    npx secretless-ai scan ./<subdirectory>\n`);
+  };
 
   // When everything (or a real subset) was hidden as a placeholder, say so and
   // point at the flag that reveals them. A silent "No credentials found" makes a
@@ -186,6 +204,14 @@ export async function runScan(projectDir: string, options?: { includeTests?: boo
   };
 
   if (findings.length === 0) {
+    if (stats.truncated) {
+      // Deliberately NOT "No hardcoded credentials found" — nothing was found in
+      // the part we reached, which is a different claim.
+      console.log('  No credentials found in the files scanned.\n');
+      truncationWarning();
+      placeholderHint();
+      return 1;
+    }
     console.log('  No hardcoded credentials found.');
     placeholderHint();
     console.log('  Verify keys are working: npx secretless-ai verify\n');
@@ -194,12 +220,15 @@ export async function runScan(projectDir: string, options?: { includeTests?: boo
 
   // If --explain requested, use NanoMind engine for rich context
   if (options?.explain) {
-    return runScanWithExplanations(findings);
+    const code = await runScanWithExplanations(findings);
+    truncationWarning();
+    return code;
   }
 
   printFindings(findings);
+  truncationWarning();
   placeholderHint();
-  return findings.length > 0 ? 1 : 0;
+  return 1;
 }
 
 function printFindings(findings: ReturnType<typeof scan>): void {

--- a/src/commands/core.ts
+++ b/src/commands/core.ts
@@ -230,8 +230,15 @@ export async function runScan(projectDir: string, options?: { includeTests?: boo
         console.log(`  ${c.dim(`  ${runnable(f)}`)}`);
       }
       if (n > 10) console.log(`  ${c.dim(`  … and ${n - 10} more`)}`);
+      // Do NOT assert the cause. "Unreadable" covers permissions, a symlink
+      // loop (ELOOP) and a too-many-open-files failure, and `chmod +r` is a dead
+      // end for the last two — a Fix that cannot work is worse than none.
+      // `ls -ld` distinguishes them, so it leads. `+rx` not `+r`: a directory
+      // needs the execute bit to be traversed, so `+r` alone leaves the scan
+      // still unable to enter it.
+      console.log(`  ${c.dim('Cause differs by path — permissions, a broken or looping symlink, or an I/O error.')}`);
       console.log(`  ${c.cyan('Verify:')} ls -ld ${runnable(stats.unreadable[0])}`);
-      console.log(`  ${c.cyan('Fix:')}    chmod +r ${runnable(stats.unreadable[0])}\n`);
+      console.log(`  ${c.cyan('Fix:')}    chmod +rx ${runnable(stats.unreadable[0])}   ${c.dim('# if the cause is permissions')}\n`);
     }
     if (stats.outOfRoot.length > 0) {
       const n = stats.outOfRoot.length;

--- a/src/commands/core.ts
+++ b/src/commands/core.ts
@@ -145,7 +145,7 @@ export async function runScan(projectDir: string, options?: { includeTests?: boo
       console.error(`Directory not found: ${projectDir}`);
       return 1;
     }
-    const stats = { placeholdersSuppressed: 0, truncated: false };
+    const stats = { placeholdersSuppressed: 0, truncated: false, unreadable: [] as string[] };
     const findings = scan(projectDir, scanOpts, stats);
     const critical = findings.filter(f => f.severity === 'critical').length;
     console.log(JSON.stringify({
@@ -160,11 +160,14 @@ export async function runScan(projectDir: string, options?: { includeTests?: boo
         // A machine consumer must be able to tell "clean" from "unfinished".
         truncated: stats.truncated,
         maxFiles: capUsed,
+        unreadable: stats.unreadable.length,
       },
+      unreadableFiles: stats.unreadable,
     }, null, 2));
-    // An incomplete scan is not a pass. `total: 0` with `truncated: true` means
-    // the walk stopped early, so exiting 0 would gate CI on a subset.
-    return findings.length > 0 || stats.truncated ? 1 : 0;
+    // An incomplete scan is not a pass. `total: 0` with `truncated: true` or an
+    // unreadable file means part of the tree was never read, so exiting 0 would
+    // gate CI on a subset.
+    return findings.length > 0 || stats.truncated || stats.unreadable.length > 0 ? 1 : 0;
   }
 
   console.log('\n  Secretless Scanner\n');
@@ -175,19 +178,32 @@ export async function runScan(projectDir: string, options?: { includeTests?: boo
     return 1;
   }
 
-  const stats = { placeholdersSuppressed: 0, truncated: false };
+  const stats = { placeholdersSuppressed: 0, truncated: false, unreadable: [] as string[] };
   const findings = scan(projectDir, scanOpts, stats);
 
-  // A walk that stopped at the file cap left tree unvisited, so the findings are
-  // a SUBSET. Rendering that as "No hardcoded credentials found." is the
-  // fail-open this warning closes: an answer we never got is not a good answer.
-  const truncationWarning = () => {
-    if (!stats.truncated) return;
-    console.log(`  ${c.boldYellow('Scan incomplete')} — stopped at the ${capUsed}-file cap, so files were left unscanned.`);
-    console.log(`  ${c.dim('This is not a clean result. Raise the cap or scan subtrees:')}`);
-    console.log(`  ${c.cyan('Verify:')} npx secretless-ai scan --max-files ${capUsed * 4}`);
-    console.log(`  ${c.cyan('Fix:')}    npx secretless-ai scan ./<subdirectory>\n`);
+  // A walk that stopped at the file cap left tree unvisited, and a file we could
+  // not open was never read at all. Either way the findings are a SUBSET, so
+  // rendering them as "No hardcoded credentials found." is the fail-open these
+  // warnings close: an answer we never got is not a good answer.
+  const coverageWarnings = () => {
+    if (stats.truncated) {
+      console.log(`  ${c.boldYellow('Scan incomplete')} — stopped at the ${capUsed}-file cap, so files were left unscanned.`);
+      console.log(`  ${c.dim('This is not a clean result. Raise the cap or scan subtrees:')}`);
+      console.log(`  ${c.cyan('Verify:')} npx secretless-ai scan --max-files ${capUsed * 4}`);
+      console.log(`  ${c.cyan('Fix:')}    npx secretless-ai scan ./<subdirectory>\n`);
+    }
+    if (stats.unreadable.length > 0) {
+      const n = stats.unreadable.length;
+      console.log(`  ${c.boldYellow(`${n} file${n > 1 ? 's' : ''} could not be read`)} — not scanned, so not known to be clean.`);
+      for (const f of stats.unreadable.slice(0, 10)) {
+        console.log(`  ${c.dim(`  ${f}`)}`);
+      }
+      if (n > 10) console.log(`  ${c.dim(`  … and ${n - 10} more`)}`);
+      console.log(`  ${c.cyan('Verify:')} ls -l ${stats.unreadable[0]}`);
+      console.log(`  ${c.cyan('Fix:')}    chmod +r ${stats.unreadable[0]}\n`);
+    }
   };
+  const anyCoverageGap = () => stats.truncated || stats.unreadable.length > 0;
 
   // When everything (or a real subset) was hidden as a placeholder, say so and
   // point at the flag that reveals them. A silent "No credentials found" makes a
@@ -204,11 +220,11 @@ export async function runScan(projectDir: string, options?: { includeTests?: boo
   };
 
   if (findings.length === 0) {
-    if (stats.truncated) {
+    if (anyCoverageGap()) {
       // Deliberately NOT "No hardcoded credentials found" — nothing was found in
       // the part we reached, which is a different claim.
       console.log('  No credentials found in the files scanned.\n');
-      truncationWarning();
+      coverageWarnings();
       placeholderHint();
       return 1;
     }
@@ -221,12 +237,12 @@ export async function runScan(projectDir: string, options?: { includeTests?: boo
   // If --explain requested, use NanoMind engine for rich context
   if (options?.explain) {
     const code = await runScanWithExplanations(findings);
-    truncationWarning();
+    coverageWarnings();
     return code;
   }
 
   printFindings(findings);
-  truncationWarning();
+  coverageWarnings();
   placeholderHint();
   return 1;
 }

--- a/src/commands/core.ts
+++ b/src/commands/core.ts
@@ -145,7 +145,7 @@ export async function runScan(projectDir: string, options?: { includeTests?: boo
       console.error(`Directory not found: ${projectDir}`);
       return 1;
     }
-    const stats = { placeholdersSuppressed: 0, truncated: false, unreadable: [] as string[] };
+    const stats = { placeholdersSuppressed: 0, truncated: false, unreadable: [] as string[], outOfRoot: [] as string[] };
     const findings = scan(projectDir, scanOpts, stats);
     const critical = findings.filter(f => f.severity === 'critical').length;
     console.log(JSON.stringify({
@@ -161,12 +161,15 @@ export async function runScan(projectDir: string, options?: { includeTests?: boo
         truncated: stats.truncated,
         maxFiles: capUsed,
         unreadable: stats.unreadable.length,
+        outOfRoot: stats.outOfRoot.length,
       },
       unreadableFiles: stats.unreadable,
+      outOfRootLinks: stats.outOfRoot,
     }, null, 2));
     // An incomplete scan is not a pass. `total: 0` with `truncated: true` or an
     // unreadable file means part of the tree was never read, so exiting 0 would
-    // gate CI on a subset.
+    // gate CI on a subset. An out-of-root link is a deliberate, reported
+    // boundary rather than a failure, so it does not by itself set exit 1.
     return findings.length > 0 || stats.truncated || stats.unreadable.length > 0 ? 1 : 0;
   }
 
@@ -178,8 +181,20 @@ export async function runScan(projectDir: string, options?: { includeTests?: boo
     return 1;
   }
 
-  const stats = { placeholdersSuppressed: 0, truncated: false, unreadable: [] as string[] };
+  const stats = { placeholdersSuppressed: 0, truncated: false, unreadable: [] as string[], outOfRoot: [] as string[] };
   const findings = scan(projectDir, scanOpts, stats);
+
+  // Coverage-gap paths are reported relative to the SCAN ROOT, which is not the
+  // shell's cwd when a path argument was given. Printing them bare produced a
+  // `ls -l config.json` that fails with "No such file or directory" — a fix
+  // command that does not run is a dead end, which is exactly what this whole
+  // release is about.
+  const nodePath = require('path') as typeof import('path');
+  const runnable = (rel: string) => {
+    const abs = nodePath.resolve(projectDir, rel);
+    const fromCwd = nodePath.relative(process.cwd(), abs);
+    return fromCwd && !fromCwd.startsWith('..') ? fromCwd : abs;
+  };
 
   // A walk that stopped at the file cap left tree unvisited, and a file we could
   // not open was never read at all. Either way the findings are a SUBSET, so
@@ -188,21 +203,33 @@ export async function runScan(projectDir: string, options?: { includeTests?: boo
   const coverageWarnings = () => {
     if (stats.truncated) {
       console.log(`  ${c.boldYellow('Scan incomplete')} — stopped at the ${capUsed}-file cap, so files were left unscanned.`);
-      console.log(`  ${c.dim('This is not a clean result. Raise the cap or scan subtrees:')}`);
-      console.log(`  ${c.cyan('Verify:')} npx secretless-ai scan --max-files ${capUsed * 4}`);
-      console.log(`  ${c.cyan('Fix:')}    npx secretless-ai scan ./<subdirectory>\n`);
+      console.log(`  ${c.dim('This is not a clean result. Raise the cap, or scan a subtree at a time:')}`);
+      console.log(`  ${c.cyan('Fix:')}    npx secretless-ai scan ${runnable('.')} --max-files ${capUsed * 4}`);
+      console.log(`  ${c.cyan('Verify:')} npx secretless-ai scan ${runnable('.')} --max-files ${capUsed * 4} --json | jq .summary.truncated\n`);
     }
     if (stats.unreadable.length > 0) {
       const n = stats.unreadable.length;
-      console.log(`  ${c.boldYellow(`${n} file${n > 1 ? 's' : ''} could not be read`)} — not scanned, so not known to be clean.`);
+      console.log(`  ${c.boldYellow(`${n} path${n > 1 ? 's' : ''} could not be read`)} — not scanned, so not known to be clean.`);
       for (const f of stats.unreadable.slice(0, 10)) {
-        console.log(`  ${c.dim(`  ${f}`)}`);
+        console.log(`  ${c.dim(`  ${runnable(f)}`)}`);
       }
       if (n > 10) console.log(`  ${c.dim(`  … and ${n - 10} more`)}`);
-      console.log(`  ${c.cyan('Verify:')} ls -l ${stats.unreadable[0]}`);
-      console.log(`  ${c.cyan('Fix:')}    chmod +r ${stats.unreadable[0]}\n`);
+      console.log(`  ${c.cyan('Verify:')} ls -ld ${runnable(stats.unreadable[0])}`);
+      console.log(`  ${c.cyan('Fix:')}    chmod +r ${runnable(stats.unreadable[0])}\n`);
+    }
+    if (stats.outOfRoot.length > 0) {
+      const n = stats.outOfRoot.length;
+      console.log(`  ${c.boldYellow(`${n} symlink${n > 1 ? 's' : ''} ${n > 1 ? 'point' : 'points'} outside the scan root`)} — not followed.`);
+      for (const f of stats.outOfRoot.slice(0, 10)) {
+        console.log(`  ${c.dim(`  ${runnable(f)}`)}`);
+      }
+      if (n > 10) console.log(`  ${c.dim(`  … and ${n - 10} more`)}`);
+      console.log(`  ${c.dim('Following them would let a link to $HOME pull the whole home directory into the scan.')}`);
+      console.log(`  ${c.cyan('Fix:')}    npx secretless-ai scan "$(readlink -f ${runnable(stats.outOfRoot[0])})"\n`);
     }
   };
+  // An out-of-root link is a reported boundary, not a gap in what we claimed to
+  // cover, so it does not make the result non-clean.
   const anyCoverageGap = () => stats.truncated || stats.unreadable.length > 0;
 
   // When everything (or a real subset) was hidden as a placeholder, say so and
@@ -228,7 +255,11 @@ export async function runScan(projectDir: string, options?: { includeTests?: boo
       placeholderHint();
       return 1;
     }
-    console.log('  No hardcoded credentials found.');
+    console.log('  No hardcoded credentials found.\n');
+    // Still report a boundary we chose not to cross. The result IS clean for the
+    // tree we claimed to scan, so this stays exit 0 — but a link we declined to
+    // follow must be visible, or declining becomes its own silent gap.
+    coverageWarnings();
     placeholderHint();
     console.log('  Verify keys are working: npx secretless-ai verify\n');
     return 0;
@@ -449,6 +480,10 @@ export function runStatus(projectDir: string, options?: { json?: boolean }): num
       denyRuleCount: s.denyRuleCount,
       configuredTools: s.configuredTools,
       secretsFound: s.secretsFound,
+      // `secretsFound: 0` is a lower bound, not a verdict, when the scan behind
+      // it could not read the whole tree. A CI consumer gating on this needs to
+      // tell "found nothing" from "could not look".
+      scanIncomplete: s.scanIncomplete,
       transcriptProtection: tp,
       backend: effectiveBackend,
       configuredBackend: configuredBackend ?? null,

--- a/src/commands/core.ts
+++ b/src/commands/core.ts
@@ -123,6 +123,19 @@ export function runInit(projectDir: string): number {
   return 0;
 }
 
+/**
+ * Quote a path for a shell command we PRINT for the user to copy.
+ *
+ * The paths here are filenames from a scanned repository, i.e. attacker
+ * controlled, and the whole point of a `Fix:` line is that it gets pasted into a
+ * terminal. A link named `a"; id; echo "b` interpolated raw produced a command
+ * that closed the quote and ran `id`. Single quotes with the standard
+ * `'\''` escape make every byte literal.
+ */
+function shellQuote(p: string): string {
+  return /^[A-Za-z0-9_./-]+$/.test(p) ? p : `'${p.split("'").join("'\\''")}'`;
+}
+
 export async function runScan(projectDir: string, options?: { includeTests?: boolean; explain?: boolean; noIgnore?: boolean; minConfidence?: number; json?: boolean; showPlaceholders?: boolean; maxFiles?: number }): Promise<number> {
   const nodeFs = require('fs') as typeof import('fs');
   const scanOpts = {
@@ -193,7 +206,10 @@ export async function runScan(projectDir: string, options?: { includeTests?: boo
   const runnable = (rel: string) => {
     const abs = nodePath.resolve(projectDir, rel);
     const fromCwd = nodePath.relative(process.cwd(), abs);
-    return fromCwd && !fromCwd.startsWith('..') ? fromCwd : abs;
+    // A bare relative path is only usable when it stays inside cwd AND does not
+    // read as a flag; anything else falls back to the absolute path.
+    const chosen = fromCwd && !fromCwd.startsWith('..') && !fromCwd.startsWith('-') ? fromCwd : abs;
+    return shellQuote(chosen);
   };
 
   // A walk that stopped at the file cap left tree unvisited, and a file we could
@@ -225,7 +241,10 @@ export async function runScan(projectDir: string, options?: { includeTests?: boo
       }
       if (n > 10) console.log(`  ${c.dim(`  … and ${n - 10} more`)}`);
       console.log(`  ${c.dim('Following them would let a link to $HOME pull the whole home directory into the scan.')}`);
-      console.log(`  ${c.cyan('Fix:')}    npx secretless-ai scan "$(readlink -f ${runnable(stats.outOfRoot[0])})"\n`);
+      // No `$(...)` here: the path is attacker-controlled (it is a filename in a
+      // scanned repo), and a command substitution around it hands a
+      // copy-pasting user an execution primitive.
+      console.log(`  ${c.cyan('Fix:')}    npx secretless-ai scan ${runnable(nodeFs.realpathSync(nodePath.resolve(projectDir, stats.outOfRoot[0])))}\n`);
     }
   };
   // An out-of-root link is a reported boundary, not a gap in what we claimed to

--- a/src/manifest.test.ts
+++ b/src/manifest.test.ts
@@ -140,9 +140,18 @@ describe('parseManifestDetailed — an unrecognised manifest is an error, not na
     expect(errors.map(e => e.text)).not.toContain('ANTHROPIC_API_KEY');
   });
 
-  it('names the offending character in the reason', () => {
+  it('names the YAML shape rather than only the offending character', () => {
+    // The reason used to quote the bad character. Naming the shape is both more
+    // actionable and leak-free, which is what makes redacting the line
+    // affordable — the user loses the echo but gains the diagnosis.
     const { errors } = parseManifestDetailed('required:\n');
-    expect(errors[0].reason).toContain('":"');
+    expect(errors[0].reason).toContain('YAML');
+  });
+
+  it('still names the offending character when the shape is not a known one', () => {
+    // The character list is the fallback and must not have been dropped.
+    const { errors } = parseManifestDetailed('BAD!NAME\n');
+    expect(errors[0].reason).toContain('"!"');
   });
 
   it('rejects a dotenv-shaped guess', () => {
@@ -150,7 +159,10 @@ describe('parseManifestDetailed — an unrecognised manifest is an error, not na
     const { entries, errors } = parseManifestDetailed('ANTHROPIC_API_KEY=sk-ant-xxx\n');
     expect(entries).toEqual([]);
     expect(errors).toHaveLength(1);
-    expect(errors[0].reason).toContain('"="');
+    expect(errors[0].reason).toContain('dotenv');
+    // The name is still identified; only the value position is dropped.
+    expect(errors[0].text).toContain('ANTHROPIC_API_KEY');
+    expect(errors[0].text).not.toContain('sk-ant-xxx');
   });
 
   it('rejects a JSON-shaped guess', () => {
@@ -163,7 +175,15 @@ describe('parseManifestDetailed — an unrecognised manifest is an error, not na
     // Otherwise the original defect just moves one token to the right.
     const { entries, errors } = parseManifestDetailed('API_KEY required\n');
     expect(entries).toEqual([]);
-    expect(errors[0].reason).toContain('required');
+    expect(errors).toHaveLength(1);
+    // The reason used to interpolate the extra token. In `GITHUB_TOKEN ghp_live…`
+    // that token IS the value, and nothing distinguishes it from a second name,
+    // so it is described rather than echoed.
+    expect(errors[0].reason).toContain('unexpected text after the name');
+    expect(errors[0].reason).not.toContain('required');
+    // The line is still located and the declared name still shown.
+    expect(errors[0].line).toBe(1);
+    expect(errors[0].text).toContain('API_KEY');
   });
 
   it('reports the line number of each bad line, counting comments and blanks', () => {
@@ -233,6 +253,73 @@ describe('checkManifest surfaces manifest errors to library consumers (#112)', (
     expect(result.errors).toEqual([]);
     expect(result.missing.map(e => e.name)).toEqual(['SOME_KEY']);
     fs.rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe('parseManifestDetailed — a parse error never echoes a credential VALUE', () => {
+  // `.secretless` is documented "safe to commit" and `scan` does not look inside
+  // it, so the parse-error path is the ONLY surface that reads the file — and it
+  // printed the file back verbatim. `setup --check` stderr is exactly what lands
+  // in CI logs. Two shapes leaked: `NAME=VALUE` echoed the line, and
+  // `NAME VALUE` echoed it TWICE (once as `text`, once interpolated into
+  // `reason`).
+  //
+  // Note the values below are name-shaped (`SAFE_NAME` is /^[a-zA-Z0-9_-]+$/), so
+  // no charset rule can tell them from a name. Only position and role can.
+  const ANTHROPIC = ['sk-ant-api03-', 'FAKEvalueLEAKEDdonotprint'].join('');
+  const GITHUB = ['ghp_', 'FAKEtokenLEAKEDdonotprint'].join('');
+
+  it('does not echo the value from a NAME=VALUE line', () => {
+    const { errors } = parseManifestDetailed(`ANTHROPIC_API_KEY=${ANTHROPIC}\n`);
+    expect(errors.length).toBe(1);
+    expect(JSON.stringify(errors[0])).not.toContain(ANTHROPIC);
+  });
+
+  it('does not echo the value from a NAME VALUE line — in text OR reason', () => {
+    const { errors } = parseManifestDetailed(`GITHUB_TOKEN ${GITHUB}\n`);
+    expect(errors.length).toBe(1);
+    expect(errors[0].text).not.toContain(GITHUB);
+    expect(errors[0].reason).not.toContain(GITHUB);
+  });
+
+  it('does not echo a value hidden in a trailing comment', () => {
+    const { errors } = parseManifestDetailed(`GITHUB_TOKEN oops # ${GITHUB}\n`);
+    expect(errors.length).toBe(1);
+    expect(JSON.stringify(errors[0])).not.toContain(GITHUB);
+  });
+
+  it('still identifies WHICH line and WHICH declared name', () => {
+    // Redaction must not turn the error into a dead end. The name is the part
+    // the user wrote as a name, so it stays; only the value position is dropped.
+    const { errors } = parseManifestDetailed(`OK_NAME\nGITHUB_TOKEN ${GITHUB}\n`);
+    expect(errors[0].line).toBe(2);
+    expect(errors[0].text).toContain('GITHUB_TOKEN');
+  });
+
+  it('names the dotenv shape instead of echoing it', () => {
+    const { errors } = parseManifestDetailed(`ANTHROPIC_API_KEY=${ANTHROPIC}\n`);
+    expect(errors[0].reason.toLowerCase()).toContain('value');
+    // The declared name is safe and useful; the value is not.
+    expect(errors[0].text).toContain('ANTHROPIC_API_KEY');
+  });
+
+  it('bounds the reason as well as the text (a 200 KB token must not flood stderr)', () => {
+    // MAX_ECHOED_LINE bounded `text` but not the sibling `reason`, so a
+    // pathological token still flooded stderr through the second field.
+    const huge = 'A'.repeat(200_000);
+    const { errors } = parseManifestDetailed(`GITHUB_TOKEN ${huge}\n`);
+    expect(errors.length).toBe(1);
+    expect(errors[0].reason.length).toBeLessThan(1000);
+    expect(errors[0].text.length).toBeLessThan(1000);
+  });
+
+  it('CONTROL: a valid manifest still parses, so redaction did not break the happy path', () => {
+    const { entries, errors } = parseManifestDetailed(
+      'GITHUB_TOKEN            # required\nSTRIPE_SECRET_KEY optional  # payments\n',
+    );
+    expect(errors).toEqual([]);
+    expect(entries.map(e => e.name)).toEqual(['GITHUB_TOKEN', 'STRIPE_SECRET_KEY']);
+    expect(entries[1].required).toBe(false);
   });
 });
 

--- a/src/manifest.test.ts
+++ b/src/manifest.test.ts
@@ -160,8 +160,6 @@ describe('parseManifestDetailed — an unrecognised manifest is an error, not na
     expect(entries).toEqual([]);
     expect(errors).toHaveLength(1);
     expect(errors[0].reason).toContain('dotenv');
-    // The name is still identified; only the value position is dropped.
-    expect(errors[0].text).toContain('ANTHROPIC_API_KEY');
     expect(errors[0].text).not.toContain('sk-ant-xxx');
   });
 
@@ -299,8 +297,28 @@ describe('parseManifestDetailed — a parse error never echoes a credential VALU
   it('names the dotenv shape instead of echoing it', () => {
     const { errors } = parseManifestDetailed(`ANTHROPIC_API_KEY=${ANTHROPIC}\n`);
     expect(errors[0].reason.toLowerCase()).toContain('value');
-    // The declared name is safe and useful; the value is not.
-    expect(errors[0].text).toContain('ANTHROPIC_API_KEY');
+    expect(errors[0].reason).toContain('dotenv');
+    expect(errors[0].line).toBe(1);
+  });
+
+  it('does not echo a base64 secret whose PADDING looks like a NAME=VALUE split', () => {
+    // The redactor briefly split on `=` and echoed the left side, reasoning that
+    // in dotenv the left of `=` is the name. But `=` is also base64 padding, so
+    // for `openssl rand -base64 32` output the "name" is the entire secret. The
+    // left side of a separator is not a name just because a separator appears.
+    const B64 = ['ZjQ2NmE4YzBkNzFl', 'NGY5M2E4YjJjNWQ2ZTdmMDExMjM='].join('');
+    const payload = B64.slice(0, -1); // everything before the padding
+    const { errors } = parseManifestDetailed(`${B64}\n`);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].text).not.toContain(payload);
+    expect(JSON.stringify(errors[0])).not.toContain(payload);
+  });
+
+  it('does not echo a token that merely ENDS in = (no value after it)', () => {
+    const TOKEN = ['ghp_', 'FAKEliveTOKENvalue123'].join('');
+    const { errors } = parseManifestDetailed(`${TOKEN}=\n`);
+    expect(errors).toHaveLength(1);
+    expect(JSON.stringify(errors[0])).not.toContain(TOKEN);
   });
 
   it('bounds the reason as well as the text (a 200 KB token must not flood stderr)', () => {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -161,17 +161,19 @@ function redactManifestLine(line: string): string {
 }
 
 /**
- * Show the first token when it is name-shaped, and split a `NAME=VALUE` paste so
- * the user still sees WHICH key they got wrong. In dotenv the left side of `=`
- * is the variable name and the right side is the value, so the left side is safe.
+ * Show the first token only when the whole token is a valid secret name.
+ *
+ * An earlier version split a `NAME=VALUE` paste and echoed the left side, on the
+ * reasoning that in dotenv the left of `=` is the name. That is a leak: `=` is
+ * also base64 PADDING, so for a secret from `openssl rand -base64 32` the "left
+ * side of the `=`" IS the entire secret, and it was printed in full to
+ * `setup --check` stderr. The left side of a separator is not a name just
+ * because a separator appears — the token is only a name if the WHOLE token is
+ * one. `describeInvalidName` still reports the dotenv shape, so the user learns
+ * what is wrong without the value being read back to them.
  */
 function redactFirstToken(token: string): string {
-  if (isValidSecretName(token)) return token;
-  const eq = token.indexOf('=');
-  if (eq > 0 && isValidSecretName(token.slice(0, eq))) {
-    return `${token.slice(0, eq)}=${REDACTED}`;
-  }
-  return REDACTED;
+  return isValidSecretName(token) ? token : REDACTED;
 }
 
 /**

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -28,9 +28,13 @@ export interface ManifestEntry {
 export interface ManifestError {
   /** 1-based line number in the manifest file. */
   line: number;
-  /** The offending text, as written. */
+  /**
+   * The offending line, REDACTED — not as written. Only the tokens that can be
+   * shown safely survive (see `redactManifestLine`); a value position renders as
+   * `[redacted]`. Use `line` to locate the original.
+   */
   text: string;
-  /** Why it cannot be a name. */
+  /** Why it cannot be a name. Never contains text copied from the file. */
   reason: string;
 }
 
@@ -85,7 +89,7 @@ export function parseManifestDetailed(content: string): ParsedManifest {
     if (!name) continue;
 
     if (!isValidSecretName(name)) {
-      errors.push({ line: i + 1, text: forDisplay(line), reason: describeInvalidName(name) });
+      errors.push({ line: i + 1, text: redactManifestLine(line), reason: describeInvalidName(name) });
       continue;
     }
 
@@ -96,8 +100,8 @@ export function parseManifestDetailed(content: string): ParsedManifest {
     if (extra.length > 0) {
       errors.push({
         line: i + 1,
-        text: forDisplay(line),
-        reason: `unexpected "${extra[0]}" after the name (only "optional" and a # comment may follow)`,
+        text: redactManifestLine(line),
+        reason: describeUnexpectedExtra(name),
       });
       continue;
     }
@@ -115,11 +119,74 @@ export function parseManifestDetailed(content: string): ParsedManifest {
 /** Longest manifest line echoed back in an error. */
 const MAX_ECHOED_LINE = 120;
 
+/** Stand-in for a token that could be a credential value. */
+const REDACTED = '[redacted]';
+
 /** Trim a line for display so a pathological one cannot flood stderr. */
 function forDisplay(line: string): string {
   return line.length <= MAX_ECHOED_LINE
     ? line
     : `${line.slice(0, MAX_ECHOED_LINE)}… (${line.length} chars)`;
+}
+
+/**
+ * Render a manifest line for an error message without echoing anything that
+ * could be a credential VALUE.
+ *
+ * `.secretless` is documented "safe to commit", so the parse-error path is the
+ * surface users actually see — and it printed the file back verbatim into
+ * `setup --check` stderr, which is exactly what lands in CI logs. The
+ * `NAME VALUE` shape leaked twice: once here and once interpolated into the
+ * reason.
+ *
+ * Redaction is an ALLOWLIST BY POSITION, not a charset test. `SAFE_NAME` is
+ * /^[a-zA-Z0-9_-]+$/, so `ghp_aLiveTokenPastedHere` is a perfectly valid secret
+ * NAME — no character rule can separate a name from a name-shaped value. Only
+ * position can: token 0 is where a name belongs, `optional` is the one keyword
+ * that may follow it, and everything else is dropped. The trailing comment goes
+ * too: it is never the cause of a parse error and may hold anything.
+ */
+function redactManifestLine(line: string): string {
+  const commentIdx = line.indexOf('#');
+  const beforeComment = (commentIdx !== -1 ? line.slice(0, commentIdx) : line).trim();
+  const tokens = beforeComment.split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return REDACTED;
+
+  const rendered = tokens.map((token, i) =>
+    i === 0 ? redactFirstToken(token) : (token === 'optional' ? token : REDACTED),
+  );
+  // Still bounded: a 200 KB run of name-charset bytes is a valid NAME, so the
+  // allowlist alone does not cap the length.
+  return forDisplay(rendered.join(' '));
+}
+
+/**
+ * Show the first token when it is name-shaped, and split a `NAME=VALUE` paste so
+ * the user still sees WHICH key they got wrong. In dotenv the left side of `=`
+ * is the variable name and the right side is the value, so the left side is safe.
+ */
+function redactFirstToken(token: string): string {
+  if (isValidSecretName(token)) return token;
+  const eq = token.indexOf('=');
+  if (eq > 0 && isValidSecretName(token.slice(0, eq))) {
+    return `${token.slice(0, eq)}=${REDACTED}`;
+  }
+  return REDACTED;
+}
+
+/**
+ * Why a trailing token is a problem, WITHOUT echoing it — in `GITHUB_TOKEN
+ * ghp_live…` that token is the value, and nothing distinguishes it from a
+ * second name. This also bounds the message: the old form interpolated the
+ * token raw, so a 200 KB token flooded stderr through the reason even though
+ * `MAX_ECHOED_LINE` bounded the sibling text.
+ */
+function describeUnexpectedExtra(name: string): string {
+  if (name === '-') {
+    return 'looks like a YAML list item — .secretless is not YAML; write the name on its own line';
+  }
+  return 'unexpected text after the name (only "optional" and a # comment may follow). '
+    + 'If that was a value, delete it: .secretless declares names, never values';
 }
 
 /**
@@ -131,6 +198,19 @@ function forDisplay(line: string): string {
  * one the store enforces, which is the defect class this file just fixed.
  */
 function describeInvalidName(name: string): string {
+  // Name the SHAPE the user actually wrote. This is strictly more actionable
+  // than a character list AND it cannot leak, which is what makes redacting the
+  // line affordable: the user loses the echo but gains the diagnosis.
+  if (name.includes('=')) {
+    return 'looks like dotenv (NAME=VALUE) — .secretless declares names only, never values; '
+      + 'write just the name and store the value with `secretless-ai secret set <NAME>`';
+  }
+  if (name.endsWith(':')) {
+    return 'looks like a YAML key — .secretless is not YAML; write the name on its own line';
+  }
+  if (name.startsWith('{') || name.startsWith('[') || name.startsWith('"')) {
+    return 'looks like JSON — .secretless is not JSON; write one name per line';
+  }
   const bad = [...new Set(name.split(''))].filter((c) => !isValidSecretName(c));
   if (bad.length > 0) {
     const shown = bad.slice(0, 5).map((c) => `"${c}"`).join(', ');

--- a/src/scan.test.ts
+++ b/src/scan.test.ts
@@ -895,6 +895,31 @@ describe('scan() — a symlinked config file or directory is followed (0.21.1 re
     expect(findings.length).toBe(1);
   });
 
+  it('finds an in-root symlink target when the scan path differs in CASE', () => {
+    // Containment compares resolved paths as strings. If resolution does not
+    // canonicalise case, scanning `ROOT` when the directory is `root` leaves an
+    // in-tree link resolving to a differently-cased string, which fails the
+    // prefix test and silently drops the subtree. On a case-sensitive volume the
+    // uppercase path simply does not exist, so the case is skipped there rather
+    // than asserted the other way.
+    const parent = tmpdir('scan-case-');
+    fs.mkdirSync(path.join(parent, 'root/inner'), { recursive: true });
+    fs.writeFileSync(path.join(parent, 'root/inner/config.json'), `{"key": "${GKEY}"}\n`);
+    fs.symlinkSync(path.join(parent, 'root/inner'), path.join(parent, 'root/link'), 'dir');
+
+    const upper = path.join(parent, 'ROOT');
+    let caseInsensitive = true;
+    try { fs.readdirSync(upper); } catch { caseInsensitive = false; }
+    if (!caseInsensitive) return;
+
+    const stats = { placeholdersSuppressed: 0, truncated: false, outOfRoot: [] as string[] };
+    const findings = scan(upper, { scanGlobal: false }, stats);
+    // The credential is reachable, and the in-root link must not be reported as
+    // pointing outside the root.
+    expect(findings.length).toBeGreaterThan(0);
+    expect(stats.outOfRoot).toEqual([]);
+  });
+
   it('an unreadable DIRECTORY is reported, not counted as clean', () => {
     // readdirSync failure used to `continue` with nothing recorded, so the scan
     // asserted truncated:false / unreadable:0 over a subtree it never opened.

--- a/src/scan.test.ts
+++ b/src/scan.test.ts
@@ -772,10 +772,12 @@ describe('scan() — a symlinked config file or directory is followed (0.21.1 re
     expect(scan(dir, { scanGlobal: false }).map(f => f.file)).toEqual(['config.json']);
   });
 
-  it('a symlink CYCLE terminates instead of hanging', () => {
-    // Restoring symlink-following without a visited guard trades a fail-open for
-    // a hang: no walker has a depth bound. A self-referential directory link is
-    // the minimal case; `a/link -> a` recurses forever without a realpath guard.
+  it('a symlink CYCLE terminates and reports the file once', () => {
+    // Note on what this does and does not prove: the OS bounds a symlink loop
+    // with ELOOP after ~32 hops, so a walk with NO cycle guard at all still
+    // terminates (measured at 7ms). The timing bound below is therefore a
+    // smoke check, not the assertion that matters. What the guard buys is the
+    // COUNT: without it the same file is collected once per lap (measured 16).
     const dir = tmpdir('scan-symloop-');
     fs.mkdirSync(path.join(dir, 'a'), { recursive: true });
     fs.writeFileSync(path.join(dir, 'a/config.json'), `{"key": "${GKEY}"}\n`);
@@ -793,13 +795,66 @@ describe('scan() — a symlinked config file or directory is followed (0.21.1 re
     expect(findings.filter(f => f.file.endsWith('config.json')).length).toBe(1);
   });
 
-  it('a symlink pointing OUTSIDE the scan root is followed, not silently dropped', () => {
+  it('a symlink pointing OUTSIDE the scan root is NOT followed, but IS reported', () => {
+    // Containment. Following out-of-root links makes `scan .` on a repo holding
+    // `link -> $HOME` traverse the entire home directory, and it contradicts the
+    // policy transcript.ts already states for its own walk. Reporting the skip is
+    // what keeps this from being a fail-open of its own: the user is told the
+    // boundary was hit and given the command to scan the target directly.
     const outside = tmpdir('scan-symout-target-');
     fs.writeFileSync(path.join(outside, 'payload.json'), `{"key": "${GKEY}"}\n`);
     const dir = tmpdir('scan-symout-');
     fs.symlinkSync(path.join(outside, 'payload.json'), path.join(dir, 'config.json'));
 
-    expect(scan(dir, { scanGlobal: false }).map(f => f.file)).toContain('config.json');
+    const stats = { placeholdersSuppressed: 0, truncated: false, outOfRoot: [] as string[] };
+    expect(scan(dir, { scanGlobal: false }, stats).map(f => f.file)).not.toContain('config.json');
+    expect(stats.outOfRoot).toEqual(['config.json']);
+  });
+
+  it('an out-of-root symlinked DIRECTORY is not traversed', () => {
+    const outside = tmpdir('scan-symoutdir-target-');
+    fs.mkdirSync(path.join(outside, 'deep'), { recursive: true });
+    fs.writeFileSync(path.join(outside, 'deep/config.json'), `{"key": "${GKEY}"}\n`);
+    const dir = tmpdir('scan-symoutdir-');
+    fs.symlinkSync(outside, path.join(dir, 'link'), 'dir');
+
+    const stats = { placeholdersSuppressed: 0, truncated: false, outOfRoot: [] as string[] };
+    expect(scan(dir, { scanGlobal: false }, stats)).toEqual([]);
+    expect(stats.outOfRoot).toEqual(['link']);
+  });
+
+  it('follows a symlinked config dir whose TARGET is also inside the tree', () => {
+    // The cycle guard was a GLOBAL visited-realpath set, so whichever path BFS
+    // reached first won and the other was dropped. Here the real directory is
+    // in-tree and sorts first, so it was marked seen and `pkg/.claude` skipped —
+    // and only the `.claude` path matches the `.claude/settings.json` config
+    // entry, because `settings.json` is not a bare basename in CONFIG_FILES.
+    // Result: the exact case the changelog advertises reported clean, exit 0,
+    // and which way it fell depended on readdir order.
+    const dir = tmpdir('scan-symdual-');
+    fs.mkdirSync(path.join(dir, 'shared'), { recursive: true });
+    fs.mkdirSync(path.join(dir, 'pkg'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'shared/settings.json'), `{"key": "${GKEY}"}\n`);
+    fs.symlinkSync(path.join(dir, 'shared'), path.join(dir, 'pkg/.claude'), 'dir');
+
+    expect(scan(dir, { scanGlobal: false }).map(f => f.file)).toContain('pkg/.claude/settings.json');
+  });
+
+  it('an unreadable DIRECTORY is reported, not counted as clean', () => {
+    // readdirSync failure used to `continue` with nothing recorded, so the scan
+    // asserted truncated:false / unreadable:0 over a subtree it never opened.
+    if (process.platform === 'win32' || (process.getuid?.() === 0)) return;
+    const dir = tmpdir('scan-noreaddir-');
+    fs.mkdirSync(path.join(dir, 'locked'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'locked/config.json'), `{"key": "${GKEY}"}\n`);
+    fs.chmodSync(path.join(dir, 'locked'), 0o000);
+    try {
+      const stats = { placeholdersSuppressed: 0, truncated: false, unreadable: [] as string[] };
+      expect(scan(dir, { scanGlobal: false }, stats)).toEqual([]);
+      expect(stats.unreadable).toContain('locked');
+    } finally {
+      fs.chmodSync(path.join(dir, 'locked'), 0o755);
+    }
   });
 
   it('a BROKEN symlink does not throw and does not report a finding', () => {
@@ -868,43 +923,6 @@ describe('scan() — an unreadable file is not reported as clean (#116 P2-1)', (
     const findings = scan(dir, { scanGlobal: false }, stats);
     expect(findings.length).toBe(1);
     expect(stats.unreadable).toEqual([]);
-  });
-});
-
-describe('scan() — a credential pasted into .secretless is detected', () => {
-  // The manifest is documented "safe to commit" and holds names only, so a value
-  // there is a mistake nothing caught: the parse-error path was the ONLY reader
-  // of the file, and it echoed the value rather than flagging it. Detection is
-  // the half that makes the redaction fix permanent.
-  function tmpProjectWith(files: Record<string, string>): string {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-manifest-'));
-    for (const [rel, content] of Object.entries(files)) {
-      fs.writeFileSync(path.join(dir, rel), content);
-    }
-    return dir;
-  }
-
-  it('flags a credential value pasted into .secretless', () => {
-    const KEY = ['AIzaSy', 'B7xK2mNvPwQ4tZ8hLcDfGjHkMnOpQrStU'].join('');
-    const dir = tmpProjectWith({ '.secretless': `GOOGLE_API_KEY=${KEY}\n` });
-    expect(scan(dir, { scanGlobal: false }).map(f => f.file)).toEqual(['.secretless']);
-  });
-
-  it('CONTROL: a names-only manifest produces no findings', () => {
-    // The absence half. Without it, this could pass by flagging every manifest —
-    // the name-gated patterns (AWS_SECRET_ACCESS_KEY) need a VALUE to fire, and
-    // a manifest that tripped them would make the scanner unusable on itself.
-    const dir = tmpProjectWith({
-      '.secretless': [
-        'GITHUB_TOKEN                 # required, GitHub API access',
-        'DATABASE_URL                 # required, PostgreSQL connection',
-        'ANTHROPIC_API_KEY',
-        'AWS_SECRET_ACCESS_KEY',
-        'STRIPE_SECRET_KEY  optional  # only needed for payments',
-        '',
-      ].join('\n'),
-    });
-    expect(scan(dir, { scanGlobal: false })).toEqual([]);
   });
 });
 

--- a/src/scan.test.ts
+++ b/src/scan.test.ts
@@ -720,6 +720,194 @@ describe('scan() — config files are found below the root (release-test P1)', (
   });
 });
 
+describe('scan() — a symlinked config file or directory is followed (0.21.1 regression)', () => {
+  // `walkConfigFiles` classifies with Dirent.isDirectory()/isFile(), which are
+  // LSTAT-based: a symlink is neither, so it fell through both branches and was
+  // dropped. 0.21.0 reached config files via existsSync/statSync, which FOLLOW
+  // symlinks — making the walk recursive silently removed symlink support, and a
+  // symlinked `.claude/` (what a dotfile manager or a shared monorepo config
+  // produces) reported "No hardcoded credentials found." with exit 0.
+  const GKEY = ['AIzaSy', 'B7xK2mNvPwQ4tZ8hLcDfGjHkMnOpQrStU'].join('');
+
+  function tmpdir(prefix: string): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  }
+
+  it('follows a symlinked config DIRECTORY', () => {
+    const dir = tmpdir('scan-symdir-');
+    fs.mkdirSync(path.join(dir, 'shared-claude'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'shared-claude/settings.json'), `{"key": "${GKEY}"}\n`);
+    fs.symlinkSync('shared-claude', path.join(dir, '.claude'), 'dir');
+
+    const findings = scan(dir, { scanGlobal: false });
+    expect(findings.map(f => f.file)).toContain('.claude/settings.json');
+  });
+
+  it('follows a symlinked config FILE', () => {
+    const dir = tmpdir('scan-symfile-');
+    fs.mkdirSync(path.join(dir, 'real'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'real/payload.json'), `{"key": "${GKEY}"}\n`);
+    fs.symlinkSync('real/payload.json', path.join(dir, 'config.json'));
+
+    const findings = scan(dir, { scanGlobal: false });
+    expect(findings.map(f => f.file)).toContain('config.json');
+  });
+
+  it('follows a symlinked config file nested below the root', () => {
+    const dir = tmpdir('scan-symnest-');
+    fs.mkdirSync(path.join(dir, 'real'), { recursive: true });
+    fs.mkdirSync(path.join(dir, 'pkg/a'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'real/payload.json'), `{"key": "${GKEY}"}\n`);
+    fs.symlinkSync(path.join(dir, 'real/payload.json'), path.join(dir, 'pkg/a/config.json'));
+
+    const findings = scan(dir, { scanGlobal: false });
+    expect(findings.map(f => f.file)).toContain('pkg/a/config.json');
+  });
+
+  it('CONTROL: the same file reached without a symlink is found', () => {
+    // Pins that the assertions above measure symlink FOLLOWING and not merely
+    // "the walker finds config.json", which would pass with the fix reverted.
+    const dir = tmpdir('scan-symctl-');
+    fs.writeFileSync(path.join(dir, 'config.json'), `{"key": "${GKEY}"}\n`);
+    expect(scan(dir, { scanGlobal: false }).map(f => f.file)).toEqual(['config.json']);
+  });
+
+  it('a symlink CYCLE terminates instead of hanging', () => {
+    // Restoring symlink-following without a visited guard trades a fail-open for
+    // a hang: no walker has a depth bound. A self-referential directory link is
+    // the minimal case; `a/link -> a` recurses forever without a realpath guard.
+    const dir = tmpdir('scan-symloop-');
+    fs.mkdirSync(path.join(dir, 'a'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'a/config.json'), `{"key": "${GKEY}"}\n`);
+    fs.symlinkSync(path.join(dir, 'a'), path.join(dir, 'a/loop'), 'dir');
+
+    const started = process.hrtime.bigint();
+    const findings = scan(dir, { scanGlobal: false });
+    const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+
+    // Terminating at all is the assertion; the bound catches a walk that only
+    // ends because it hit the 5000-file cap after thousands of stat calls.
+    expect(elapsedMs).toBeLessThan(5000);
+    expect(findings.map(f => f.file)).toContain('a/config.json');
+    // And it must be reported ONCE, not once per lap around the cycle.
+    expect(findings.filter(f => f.file.endsWith('config.json')).length).toBe(1);
+  });
+
+  it('a symlink pointing OUTSIDE the scan root is followed, not silently dropped', () => {
+    const outside = tmpdir('scan-symout-target-');
+    fs.writeFileSync(path.join(outside, 'payload.json'), `{"key": "${GKEY}"}\n`);
+    const dir = tmpdir('scan-symout-');
+    fs.symlinkSync(path.join(outside, 'payload.json'), path.join(dir, 'config.json'));
+
+    expect(scan(dir, { scanGlobal: false }).map(f => f.file)).toContain('config.json');
+  });
+
+  it('a BROKEN symlink does not throw and does not report a finding', () => {
+    const dir = tmpdir('scan-symbroken-');
+    fs.symlinkSync(path.join(dir, 'does-not-exist.json'), path.join(dir, 'config.json'));
+    expect(() => scan(dir, { scanGlobal: false })).not.toThrow();
+    expect(scan(dir, { scanGlobal: false })).toEqual([]);
+  });
+});
+
+describe('scan() — a credential pasted into .secretless is detected', () => {
+  // The manifest is documented "safe to commit" and holds names only, so a value
+  // there is a mistake nothing caught: the parse-error path was the ONLY reader
+  // of the file, and it echoed the value rather than flagging it. Detection is
+  // the half that makes the redaction fix permanent.
+  function tmpProjectWith(files: Record<string, string>): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-manifest-'));
+    for (const [rel, content] of Object.entries(files)) {
+      fs.writeFileSync(path.join(dir, rel), content);
+    }
+    return dir;
+  }
+
+  it('flags a credential value pasted into .secretless', () => {
+    const KEY = ['AIzaSy', 'B7xK2mNvPwQ4tZ8hLcDfGjHkMnOpQrStU'].join('');
+    const dir = tmpProjectWith({ '.secretless': `GOOGLE_API_KEY=${KEY}\n` });
+    expect(scan(dir, { scanGlobal: false }).map(f => f.file)).toEqual(['.secretless']);
+  });
+
+  it('CONTROL: a names-only manifest produces no findings', () => {
+    // The absence half. Without it, this could pass by flagging every manifest —
+    // the name-gated patterns (AWS_SECRET_ACCESS_KEY) need a VALUE to fire, and
+    // a manifest that tripped them would make the scanner unusable on itself.
+    const dir = tmpProjectWith({
+      '.secretless': [
+        'GITHUB_TOKEN                 # required, GitHub API access',
+        'DATABASE_URL                 # required, PostgreSQL connection',
+        'ANTHROPIC_API_KEY',
+        'AWS_SECRET_ACCESS_KEY',
+        'STRIPE_SECRET_KEY  optional  # only needed for payments',
+        '',
+      ].join('\n'),
+    });
+    expect(scan(dir, { scanGlobal: false })).toEqual([]);
+  });
+});
+
+describe('scan() — a truncated scan does not render as a clean scan (fail-open)', () => {
+  // walkConfigFiles stops at maxFiles and returns quietly, so an incomplete scan
+  // was indistinguishable from a complete one: fewer findings, no signal, exit 0.
+  const GKEY = ['AIzaSy', 'B7xK2mNvPwQ4tZ8hLcDfGjHkMnOpQrStU'].join('');
+
+  function tmpProjectWith(files: Record<string, string>): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-trunc-'));
+    for (const [rel, content] of Object.entries(files)) {
+      const full = path.join(dir, rel);
+      fs.mkdirSync(path.dirname(full), { recursive: true });
+      fs.writeFileSync(full, content);
+    }
+    return dir;
+  }
+
+  const THREE_CONFIGS = {
+    'a/config.json': `{"key": "${GKEY}"}\n`,
+    'b/config.json': `{"key": "${GKEY}"}\n`,
+    'c/config.json': `{"key": "${GKEY}"}\n`,
+  };
+
+  it('CONTROL: uncapped, all three config files are found and nothing is flagged', () => {
+    const dir = tmpProjectWith(THREE_CONFIGS);
+    const stats = { placeholdersSuppressed: 0, truncated: false };
+    const findings = scan(dir, { scanGlobal: false }, stats);
+    expect(findings.length).toBe(3);
+    expect(stats.truncated).toBe(false);
+  });
+
+  it('sets the truncation flag when the config walk hits the cap', () => {
+    const dir = tmpProjectWith(THREE_CONFIGS);
+    const stats = { placeholdersSuppressed: 0, truncated: false };
+    const findings = scan(dir, { scanGlobal: false, maxSourceFiles: 2 }, stats);
+    // The dropped file is the defect; the FLAG is what makes it visible.
+    expect(findings.length).toBeLessThan(3);
+    expect(stats.truncated).toBe(true);
+  });
+
+  it('sets the truncation flag when the SOURCE walk hits the cap', () => {
+    const SKEY = ['sk-proj-', 'M1N2B3V4C5X6Z7L8K9J0H1G2F3D4S5A6P7O8I9U0Y1T2'].join('');
+    const dir = tmpProjectWith({
+      'a.js': `const k = "${SKEY}";\n`,
+      'b.js': `const k = "${SKEY}";\n`,
+      'c.js': `const k = "${SKEY}";\n`,
+    });
+    const stats = { placeholdersSuppressed: 0, truncated: false };
+    scan(dir, { scanGlobal: false, maxSourceFiles: 2 }, stats);
+    expect(stats.truncated).toBe(true);
+  });
+
+  it('sets the truncation flag when the KEY-file walk hits the cap', () => {
+    const dir = tmpProjectWith({
+      'a.pem': 'x\n', 'b.pem': 'x\n', 'c.pem': 'x\n',
+      'd.pem': 'x\n', 'e.pem': 'x\n', 'f.pem': 'x\n',
+    });
+    const stats = { placeholdersSuppressed: 0, truncated: false };
+    scan(dir, { scanGlobal: false, maxSourceFiles: 2 }, stats);
+    expect(stats.truncated).toBe(true);
+  });
+});
+
 describe('scan() — a single-file finding reports a path that resolves (re-test P2)', () => {
   it('reports the path relative to cwd, not the bare basename', () => {
     // The basename alone does not resolve from the caller's cwd, so a CI job

--- a/src/scan.test.ts
+++ b/src/scan.test.ts
@@ -810,6 +810,67 @@ describe('scan() — a symlinked config file or directory is followed (0.21.1 re
   });
 });
 
+describe('scan() — an unreadable file is not reported as clean (#116 P2-1)', () => {
+  // "Could not read" is a third state. Rendering it as "clean" is the same
+  // fail-open class as the truncation defect: the same content, readable,
+  // produces a finding, so silence here is an answer we never got.
+  const KEY = ['sk-proj-', 'M1N2B3V4C5X6Z7L8K9J0H1G2F3D4S5A6P7O8I9U0Y1T2'].join('');
+
+  // chmod 000 does not restrict root, and CI often runs as root.
+  const canDenyReads = (() => {
+    if (process.platform === 'win32') return false;
+    try {
+      return typeof process.getuid === 'function' && process.getuid() !== 0;
+    } catch {
+      return false;
+    }
+  })();
+
+  function tmpWithUnreadable(): { dir: string; file: string } {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-noread-'));
+    const file = path.join(dir, 'noread.js');
+    fs.writeFileSync(file, `const k = "${KEY}";\n`);
+    fs.chmodSync(file, 0o000);
+    return { dir, file };
+  }
+
+  it.skipIf(!canDenyReads)('flags an unreadable file in a DIRECTORY scan', () => {
+    const { dir, file } = tmpWithUnreadable();
+    try {
+      const stats = { placeholdersSuppressed: 0, truncated: false, unreadable: [] as string[] };
+      const findings = scan(dir, { scanGlobal: false }, stats);
+      // The credential is genuinely unreachable, so no finding is correct...
+      expect(findings).toEqual([]);
+      // ...but silence about it is not.
+      expect(stats.unreadable.length).toBe(1);
+    } finally {
+      fs.chmodSync(file, 0o644);
+    }
+  });
+
+  it.skipIf(!canDenyReads)('flags an unreadable file named DIRECTLY', () => {
+    const { dir, file } = tmpWithUnreadable();
+    try {
+      const stats = { placeholdersSuppressed: 0, truncated: false, unreadable: [] as string[] };
+      scan(file, { scanGlobal: false }, stats);
+      expect(stats.unreadable.length).toBe(1);
+    } finally {
+      fs.chmodSync(file, 0o644);
+    }
+  });
+
+  it.skipIf(!canDenyReads)('CONTROL: the same file, readable, produces a finding and no warning', () => {
+    // Pins that the assertions above measure READABILITY and not merely "a .js
+    // file exists" — without this the fix could pass by warning on everything.
+    const { dir, file } = tmpWithUnreadable();
+    fs.chmodSync(file, 0o644);
+    const stats = { placeholdersSuppressed: 0, truncated: false, unreadable: [] as string[] };
+    const findings = scan(dir, { scanGlobal: false }, stats);
+    expect(findings.length).toBe(1);
+    expect(stats.unreadable).toEqual([]);
+  });
+});
+
 describe('scan() — a credential pasted into .secretless is detected', () => {
   // The manifest is documented "safe to commit" and holds names only, so a value
   // there is a mistake nothing caught: the parse-error path was the ONLY reader

--- a/src/scan.test.ts
+++ b/src/scan.test.ts
@@ -795,20 +795,19 @@ describe('scan() — a symlinked config file or directory is followed (0.21.1 re
     expect(findings.filter(f => f.file.endsWith('config.json')).length).toBe(1);
   });
 
-  it('a symlink pointing OUTSIDE the scan root is NOT followed, but IS reported', () => {
-    // Containment. Following out-of-root links makes `scan .` on a repo holding
-    // `link -> $HOME` traverse the entire home directory, and it contradicts the
-    // policy transcript.ts already states for its own walk. Reporting the skip is
-    // what keeps this from being a fail-open of its own: the user is told the
-    // boundary was hit and given the command to scan the target directly.
+  it('an out-of-root symlinked FILE is still read', () => {
+    // Containment applies to directories, not files. Reading one file the repo
+    // explicitly names is bounded work, and `pkg/.env -> ../../shared/.env` is
+    // what stow/chezmoi and monorepo-root env files actually produce — refusing
+    // it would drop a credential the repo is asking us to treat as its own.
     const outside = tmpdir('scan-symout-target-');
     fs.writeFileSync(path.join(outside, 'payload.json'), `{"key": "${GKEY}"}\n`);
     const dir = tmpdir('scan-symout-');
     fs.symlinkSync(path.join(outside, 'payload.json'), path.join(dir, 'config.json'));
 
     const stats = { placeholdersSuppressed: 0, truncated: false, outOfRoot: [] as string[] };
-    expect(scan(dir, { scanGlobal: false }, stats).map(f => f.file)).not.toContain('config.json');
-    expect(stats.outOfRoot).toEqual(['config.json']);
+    expect(scan(dir, { scanGlobal: false }, stats).map(f => f.file)).toContain('config.json');
+    expect(stats.outOfRoot).toEqual([]);
   });
 
   it('an out-of-root symlinked DIRECTORY is not traversed', () => {
@@ -838,6 +837,62 @@ describe('scan() — a symlinked config file or directory is followed (0.21.1 re
     fs.symlinkSync(path.join(dir, 'shared'), path.join(dir, 'pkg/.claude'), 'dir');
 
     expect(scan(dir, { scanGlobal: false }).map(f => f.file)).toContain('pkg/.claude/settings.json');
+  });
+
+  it('reports ONE finding for a credential reachable by several in-tree paths', () => {
+    // Following links means the same real file is reachable more than once, and
+    // per-ancestry cycle detection deliberately walks each route. A monorepo
+    // where 12 packages each link to a shared config turned one leaked key into
+    // 13 criticals, so `summary.total` counted PATHS, not credentials.
+    const dir = tmpdir('scan-dupe-');
+    fs.mkdirSync(path.join(dir, 'common'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'common/config.json'), `{"key": "${GKEY}"}\n`);
+    for (const pkg of ['a', 'b', 'c', 'd']) {
+      fs.mkdirSync(path.join(dir, 'packages', pkg), { recursive: true });
+      fs.symlinkSync(path.join(dir, 'common'), path.join(dir, 'packages', pkg, 'shared'), 'dir');
+    }
+    const findings = scan(dir, { scanGlobal: false });
+    expect(findings.length).toBe(1);
+  });
+
+  it('does NOT report a pruned directory as an out-of-root boundary', () => {
+    // The containment check used to run before the skip filters, so a
+    // `node_modules -> /pnpm-store` link was reported as an unfollowed boundary
+    // and the user was told to go scan their whole package store — about a
+    // directory that was never going to be walked.
+    const outside = tmpdir('scan-store-');
+    fs.writeFileSync(path.join(outside, 'config.json'), `{"key": "${GKEY}"}\n`);
+    const dir = tmpdir('scan-pruned-');
+    fs.symlinkSync(outside, path.join(dir, 'node_modules'), 'dir');
+
+    const stats = { placeholdersSuppressed: 0, truncated: false, outOfRoot: [] as string[] };
+    expect(scan(dir, { scanGlobal: false }, stats)).toEqual([]);
+    expect(stats.outOfRoot).toEqual([]);
+  });
+
+  it('bounds a lattice of links instead of walking exponentially many paths', () => {
+    // A 31-directory link lattice produced 2047 traversals, 45s and 289 MB.
+    // A repo is a hostile input; the multiplicity cap makes this bounded, and
+    // crossing it must SAY so rather than pass silently.
+    const dir = tmpdir('scan-lattice-');
+    let prev = dir;
+    for (let level = 0; level < 12; level++) {
+      const next = path.join(prev, 'd');
+      fs.mkdirSync(next, { recursive: true });
+      fs.symlinkSync(next, path.join(prev, 'l1'), 'dir');
+      fs.symlinkSync(next, path.join(prev, 'l2'), 'dir');
+      prev = next;
+    }
+    fs.writeFileSync(path.join(prev, 'config.json'), `{"key": "${GKEY}"}\n`);
+
+    const started = process.hrtime.bigint();
+    const stats = { placeholdersSuppressed: 0, truncated: false };
+    const findings = scan(dir, { scanGlobal: false }, stats);
+    const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+
+    expect(elapsedMs).toBeLessThan(10_000);
+    // One real credential, however many routes reach it.
+    expect(findings.length).toBe(1);
   });
 
   it('an unreadable DIRECTORY is reported, not counted as clean', () => {

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -148,6 +148,15 @@ export interface ScanStats {
    * this exists to close.
    */
   truncated: boolean;
+  /**
+   * Paths that matched the scan but could not be read (permissions, I/O). "Could
+   * not read" is a THIRD state: the same content, readable, produces a finding,
+   * so dropping these silently reports a file we never opened as clean.
+   *
+   * Optional so an existing caller still compiles; `scan()` only appends when
+   * the caller supplies the array, and the CLI always does.
+   */
+  unreadable?: string[];
 }
 
 /**
@@ -283,6 +292,7 @@ function scanSingleFile(
   filePath: string,
   options: ScanOptions | undefined,
   matchOpts: { includeExamples: boolean; onSuppressed: () => void },
+  stats?: ScanStats,
 ): ScanFinding[] {
   const findings: ScanFinding[] = [];
   const name = path.basename(filePath);
@@ -347,7 +357,10 @@ function scanSingleFile(
       }
     }
   } catch {
-    // Unreadable — no findings rather than a crash.
+    // Unreadable — no findings rather than a crash, but say so. A named target
+    // that cannot be opened used to print "No hardcoded credentials found" and
+    // exit 0, which is a green CI gate over a file nobody read.
+    stats?.unreadable?.push(display);
   }
   return findings;
 }
@@ -375,7 +388,7 @@ export function scan(projectDir: string, options?: ScanOptions, stats?: ScanStat
   // being noisy, and there is no walk here.
   try {
     if (fs.statSync(projectDir).isFile()) {
-      return scanSingleFile(projectDir, options, matchOpts);
+      return scanSingleFile(projectDir, options, matchOpts, stats);
     }
   } catch {
     // Unreadable/nonexistent — fall through to the directory path, which
@@ -510,7 +523,9 @@ export function scan(projectDir: string, options?: ScanOptions, stats?: ScanStat
         }
       }
     } catch {
-      // Skip unreadable files
+      // Not "clean" — a file we could not open. Silently dropping it from the
+      // count is how an unreadable config rendered as a passing scan.
+      stats?.unreadable?.push(configFile);
     }
   }
 
@@ -562,7 +577,7 @@ export function scan(projectDir: string, options?: ScanOptions, stats?: ScanStat
           }
         }
       } catch {
-        // Skip unreadable files
+        stats?.unreadable?.push(relPath.replace(/\\/g, '/'));
       }
     }
   }
@@ -614,7 +629,9 @@ export function scan(projectDir: string, options?: ScanOptions, stats?: ScanStat
           }
         }
       } catch {
-        // Skip unreadable / non-UTF8 files
+        // Non-UTF8 is expected for .p12/.pfx and handled above, so reaching here
+        // means the file could not be opened at all.
+        stats?.unreadable?.push(relPath.replace(/\\/g, '/'));
       }
     }
   }

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -157,6 +157,13 @@ export interface ScanStats {
    * the caller supplies the array, and the CLI always does.
    */
   unreadable?: string[];
+  /**
+   * Symlinks whose target resolves outside the scan root. These are NOT
+   * followed — otherwise `link -> $HOME` makes `scan .` traverse the whole home
+   * directory — but they are reported, because silently skipping them would be
+   * the same fail-open in a new place.
+   */
+  outOfRoot?: string[];
 }
 
 /**
@@ -485,8 +492,29 @@ export function scan(projectDir: string, options?: ScanOptions, stats?: ScanStat
   // runs first. A scanner that answers "clean" for a tree it never walked is
   // worse than one that errors.
   const scannedConfigFiles: string[] = [];
+  /**
+   * Fold every coverage shortfall a walk reported into the caller's stats.
+   *
+   * Deduplicated: the three walkers cover the same tree with different filters,
+   * so one unreadable directory or one out-of-root link is seen by all three and
+   * would otherwise be reported three times — turning "1 path could not be read"
+   * into "3 paths could not be read" for a single underlying cause.
+   */
+  const seenUnreadable = new Set<string>();
+  const seenOutOfRoot = new Set<string>();
+  const absorbWalk = (walk: WalkResult) => {
+    if (!stats) return;
+    if (walk.truncated) stats.truncated = true;
+    for (const p of walk.unreadable) {
+      if (stats.unreadable && !seenUnreadable.has(p)) { seenUnreadable.add(p); stats.unreadable.push(p); }
+    }
+    for (const p of walk.outOfRoot) {
+      if (stats.outOfRoot && !seenOutOfRoot.has(p)) { seenOutOfRoot.add(p); stats.outOfRoot.push(p); }
+    }
+  };
+
   const configWalk = walkConfigFiles(projectDir, options?.maxSourceFiles ?? 5000, includeTestsOpt, ignore);
-  if (configWalk.truncated && stats) stats.truncated = true;
+  absorbWalk(configWalk);
   for (const configFile of configWalk.files) {
     if (ignore && ignore.matches(configFile)) continue;
     const fullPath = path.join(projectDir, configFile);
@@ -535,7 +563,7 @@ export function scan(projectDir: string, options?: ScanOptions, stats?: ScanStat
     const maxFiles = options?.maxSourceFiles ?? 5000;
     const includeTests = options?.includeTests ?? false;
     const sourceWalk = walkSourceFiles(projectDir, maxFiles, includeTests, ignore);
-    if (sourceWalk.truncated && stats) stats.truncated = true;
+    absorbWalk(sourceWalk);
 
     for (const filePath of sourceWalk.files) {
       const relPath = path.relative(projectDir, filePath);
@@ -591,7 +619,7 @@ export function scan(projectDir: string, options?: ScanOptions, stats?: ScanStat
     const includeTests = options?.includeTests ?? false;
     const pemPattern = CREDENTIAL_PATTERNS.find(p => p.id === 'pem-private-key')!;
     const keyWalk = walkKeyFiles(projectDir, options?.maxSourceFiles ?? 5000, includeTests, ignore);
-    if (keyWalk.truncated && stats) stats.truncated = true;
+    absorbWalk(keyWalk);
     for (const filePath of keyWalk.files) {
       const relPath = path.relative(projectDir, filePath);
       if (ignore && ignore.matches(relPath.replace(/\\/g, '/'))) continue;
@@ -677,7 +705,7 @@ function isTestFile(name: string): boolean {
 /** Private-key file extensions scanned in addition to source/config files. */
 const KEY_FILE_EXTENSIONS = new Set(['.pem', '.key', '.crt', '.p12', '.pfx']);
 
-/** What a walker collected, and whether the file cap cut the walk short. */
+/** What a walker collected, and every reason its coverage fell short. */
 interface WalkResult {
   files: string[];
   /**
@@ -686,6 +714,19 @@ interface WalkResult {
    * must never render as a clean scan — see `ScanStats.truncated`.
    */
   truncated: boolean;
+  /**
+   * Directories that could not be listed and entries that could not be stat'd.
+   * A `readdirSync` that throws used to `continue` with nothing recorded, so an
+   * unreadable directory produced findings=0 with `truncated:false` — the scan
+   * actively asserted it was complete over a subtree it never opened.
+   */
+  unreadable: string[];
+  /**
+   * Symlinks whose target resolves outside the scan root, which are not
+   * followed. Reported rather than dropped: silently skipping them would be the
+   * same fail-open in a new place.
+   */
+  outOfRoot: string[];
 }
 
 /**
@@ -701,17 +742,25 @@ interface WalkResult {
  * Returns 'skip' for a broken link, a socket/fifo/device, or anything we cannot
  * stat, so an unresolvable link is dropped rather than throwing mid-walk.
  */
-function classifyEntry(entryPath: string, entry: fs.Dirent): 'dir' | 'file' | 'skip' {
+function classifyEntry(entryPath: string, entry: fs.Dirent): 'dir' | 'file' | 'skip' | 'unreadable' {
   if (entry.isDirectory()) return 'dir';
   if (entry.isFile()) return 'file';
+  // Sockets, FIFOs and device files are deliberately never opened: a read on a
+  // FIFO blocks forever, so this is what keeps a config-named pipe from hanging
+  // the scan.
   if (!entry.isSymbolicLink()) return 'skip';
   try {
     const target = fs.statSync(entryPath); // follows the link
     if (target.isDirectory()) return 'dir';
     if (target.isFile()) return 'file';
     return 'skip';
-  } catch {
-    return 'skip';
+  } catch (err) {
+    // A link we cannot resolve splits two ways. ENOENT is a broken link and
+    // there is nothing to scan, so it is genuinely a skip. EACCES/ELOOP/EMFILE
+    // mean something IS there and we could not look at it, which must be
+    // reported rather than counted as clean.
+    const code = (err as NodeJS.ErrnoException)?.code;
+    return code === 'ENOENT' ? 'skip' : 'unreadable';
   }
 }
 
@@ -747,19 +796,6 @@ export function isEnvFile(basename: string): boolean {
     .some(segment => ENV_TEMPLATE_SUFFIXES.has(segment));
 }
 
-/**
- * Config files this tool scans on top of the shared `CONFIG_FILES` catalog.
- *
- * `.secretless` is OUR OWN manifest, not a third-party credential surface, so it
- * does not belong in `@opena2a/credential-patterns` (a cross-tool catalog whose
- * copy here is held byte-identical by `lockstep.test.ts`). It still has to be
- * scanned: the file is documented "safe to commit" and holds NAMES only, so a
- * pasted value is a likely mistake that nothing detected — before this, the
- * parse-error path was the only surface that ever read the file, and it printed
- * the value instead of flagging it.
- */
-const LOCAL_CONFIG_FILES = ['.secretless'];
-
 interface ConfigNameMatcher {
   byBasename: Set<string>;
   bySuffix: string[];
@@ -769,7 +805,7 @@ interface ConfigNameMatcher {
 function buildConfigNameMatcher(): ConfigNameMatcher {
   const byBasename = new Set<string>();
   const bySuffix: string[] = [];
-  for (const entry of [...CONFIG_FILES, ...LOCAL_CONFIG_FILES]) {
+  for (const entry of CONFIG_FILES) {
     if (entry.includes('/')) bySuffix.push(entry.toLowerCase());
     else byBasename.add(entry.toLowerCase());
   }
@@ -796,19 +832,126 @@ function matchesConfigName(
   return matcher.bySuffix.some(sfx => lowerRel === sfx || lowerRel.endsWith('/' + sfx));
 }
 
-function makeVisitedGuard(): (dir: string) => boolean {
-  const seen = new Set<string>();
-  return (dir: string) => {
-    let key: string;
+/**
+ * Upper bound on directories dequeued in one walk.
+ *
+ * Cycle detection is per-ancestry (see `walkTree`), which deliberately allows
+ * the same real directory to be reached by two different paths — but that means
+ * a fan of N links to one subtree costs N traversals. `maxFiles` alone does not
+ * bound this, because a fan of directories yielding no matching files collects
+ * nothing while still walking. Exhausting this budget sets `truncated`, so the
+ * bound is reported rather than silently applied.
+ */
+const MAX_DIRS_VISITED = 50_000;
+
+/** Is `target` the root itself or inside it? Both must already be real paths. */
+function isWithinRoot(target: string, rootReal: string): boolean {
+  return target === rootReal || target.startsWith(rootReal + path.sep);
+}
+
+/** Resolve a path to its real location, or null when it cannot be resolved. */
+function realpathOrNull(p: string): string | null {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return null;
+  }
+}
+
+/** Per-walk behaviour: which directories to descend, which files to keep. */
+interface WalkSpec {
+  /** True to NOT descend into this directory. */
+  skipDir(name: string, relFromRoot: string): boolean;
+  /** True to keep this file. */
+  acceptFile(name: string, relFromRoot: string): boolean;
+  /** What to push into `files` — an absolute path or a root-relative one. */
+  collect(entryPath: string, relFromRoot: string): string;
+}
+
+/**
+ * One breadth-first tree walk, shared by all three walkers.
+ *
+ * The three used to be separate copies of the same loop, and they drifted: the
+ * config copy gained recursion while losing the symlink support the others
+ * never had, which is the defect this release exists to fix. Sharing the
+ * traversal means a fix to link handling, cycle safety or coverage reporting
+ * lands in all three by construction; only the filters differ.
+ *
+ * **Cycle detection is per-ancestry, not global.** A global visited-realpath set
+ * terminates just as well, but it also drops a directory reachable by a SECOND
+ * path once the first has been seen — and which path wins depends on readdir
+ * order. That silently re-broke the headline case: with `pkg/.claude -> shared/`
+ * where `shared/` is also in the tree, BFS reaches `shared/` first, marks the
+ * realpath seen, then skips `pkg/.claude` — and only the `.claude` path matches
+ * the `.claude/settings.json` config entry. A directory is a cycle only when it
+ * appears in its OWN ancestor chain, which is what is checked here.
+ */
+function walkTree(dir: string, maxFiles: number, spec: WalkSpec): WalkResult {
+  const files: string[] = [];
+  const unreadable: string[] = [];
+  const outOfRoot: string[] = [];
+  let truncated = false;
+
+  const rootReal = realpathOrNull(dir) ?? path.resolve(dir);
+  // Each entry carries the realpath chain of the directories above it.
+  const queue: Array<{ dir: string; ancestors: string[] }> = [{ dir, ancestors: [] }];
+  let dirsVisited = 0;
+
+  const rel = (p: string) => path.relative(dir, p).replace(/\\/g, '/');
+
+  while (queue.length > 0) {
+    if (files.length >= maxFiles) { truncated = true; break; }
+    if (dirsVisited >= MAX_DIRS_VISITED) { truncated = true; break; }
+    const { dir: current, ancestors } = queue.shift()!;
+
+    const currentReal = realpathOrNull(current);
+    if (currentReal === null) { unreadable.push(rel(current)); continue; }
+    // A directory inside its own ancestry is a genuine loop.
+    if (ancestors.includes(currentReal)) continue;
+    const childAncestors = [...ancestors, currentReal];
+    dirsVisited += 1;
+
+    let entries: fs.Dirent[];
     try {
-      key = fs.realpathSync(dir);
+      entries = fs.readdirSync(current, { withFileTypes: true });
     } catch {
-      key = path.resolve(dir);
+      // Was a bare `continue`: an unreadable directory vanished from the result
+      // while the scan still reported itself complete.
+      unreadable.push(rel(current));
+      continue;
     }
-    if (seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  };
+
+    for (const entry of entries) {
+      const entryPath = path.join(current, entry.name);
+      const relFromRoot = rel(entryPath);
+      const kind = classifyEntry(entryPath, entry);
+
+      if (kind === 'unreadable') { unreadable.push(relFromRoot); continue; }
+      if (kind === 'skip') continue;
+
+      // Containment. A link out of the tree is not followed: `link -> $HOME`
+      // would otherwise make `scan .` traverse the whole home directory. This
+      // matches the policy transcript.ts already states for its own walk.
+      if (entry.isSymbolicLink()) {
+        const target = realpathOrNull(entryPath);
+        if (target === null) { continue; }         // broken link: nothing to scan
+        if (!isWithinRoot(target, rootReal)) { outOfRoot.push(relFromRoot); continue; }
+      }
+
+      if (kind === 'dir') {
+        if (spec.skipDir(entry.name, relFromRoot)) continue;
+        // Checked AFTER the filters, so only a real candidate trips the cap.
+        if (files.length >= maxFiles) { truncated = true; break; }
+        queue.push({ dir: entryPath, ancestors: childAncestors });
+      } else {
+        if (!spec.acceptFile(entry.name, relFromRoot)) continue;
+        if (files.length >= maxFiles) { truncated = true; break; }
+        files.push(spec.collect(entryPath, relFromRoot));
+      }
+    }
+  }
+
+  return { files, truncated, unreadable, outOfRoot };
 }
 
 /**
@@ -822,64 +965,22 @@ function walkKeyFiles(
   includeTests: boolean,
   ignore: IgnoreMatcher | null,
 ): WalkResult {
-  const results: string[] = [];
-  const queue: string[] = [dir];
-  const visit = makeVisitedGuard();
-  let truncated = false;
-
-  while (queue.length > 0) {
-    // Queued directories left unvisited are unscanned tree, not a clean result.
-    if (results.length >= maxFiles) { truncated = true; break; }
-    const current = queue.shift()!;
-    if (!visit(current)) continue;
-    let entries: fs.Dirent[];
-    try {
-      entries = fs.readdirSync(current, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-
-    for (const entry of entries) {
-      const entryPath = path.join(current, entry.name);
-      const relFromRoot = path.relative(dir, entryPath).replace(/\\/g, '/');
-      const kind = classifyEntry(entryPath, entry);
-
-      if (kind === 'dir') {
-        // Unlike source files, key files commonly live in HIDDEN directories (`.ssh/`,
-        // `.certs/`, `.aws/`), so we do NOT blanket-skip dot-dirs here. We still skip the
-        // heavy/irrelevant ones (node_modules, .git) and honor the ignore matcher.
-        if (SOURCE_SKIP_DIRS.has(entry.name) || entry.name === '.git') continue;
-        if (!includeTests && TEST_DIRS.has(entry.name)) continue;
-        if (ignore && ignore.matches(relFromRoot + '/.')) continue;
-        // Cap checked AFTER the filters, so only a real candidate trips it.
-        if (results.length >= maxFiles) { truncated = true; break; }
-        queue.push(entryPath);
-      } else if (kind === 'file') {
-        if (!KEY_FILE_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) continue;
-        if (!includeTests && isTestFile(entry.name)) continue;
-        if (ignore && ignore.matches(relFromRoot)) continue;
-        if (results.length >= maxFiles) { truncated = true; break; }
-        results.push(entryPath);
-      }
-    }
-  }
-
-  return { files: results, truncated };
+  return walkTree(dir, maxFiles, {
+    // Unlike source files, key files commonly live in HIDDEN directories (`.ssh/`,
+    // `.certs/`, `.aws/`), so we do NOT blanket-skip dot-dirs here. We still skip the
+    // heavy/irrelevant ones (node_modules, .git) and honor the ignore matcher.
+    skipDir: (name, rel) =>
+      SOURCE_SKIP_DIRS.has(name) || name === '.git'
+      || (!includeTests && TEST_DIRS.has(name))
+      || !!(ignore && ignore.matches(rel + '/.')),
+    acceptFile: (name, rel) =>
+      KEY_FILE_EXTENSIONS.has(path.extname(name).toLowerCase())
+      && (includeTests || !isTestFile(name))
+      && !(ignore && ignore.matches(rel)),
+    collect: (entryPath) => entryPath,
+  });
 }
 
-/**
- * Walk a directory tree and return paths (relative, POSIX) of project config
- * files at ANY depth.
- *
- * Config files used to be looked up only at the scan root while source files
- * recursed, so a monorepo's per-package config, `deploy/`, and `infra/` were
- * invisible to the root invocation. Entries containing a slash
- * (`.cursor/mcp.json`) match as a path suffix; the rest match on basename.
- *
- * Unlike source files, config files commonly live in HIDDEN directories
- * (`.claude/`, `.cursor/`, `.vscode/`), so dot-dirs are walked — mirroring
- * walkKeyFiles rather than walkSourceFiles.
- */
 function walkConfigFiles(
   dir: string,
   maxFiles: number,
@@ -887,44 +988,16 @@ function walkConfigFiles(
   ignore: IgnoreMatcher | null,
 ): WalkResult {
   const matcher = buildConfigNameMatcher();
-
-  const results: string[] = [];
-  const queue: string[] = [dir];
-  const visit = makeVisitedGuard();
-  let truncated = false;
-
-  while (queue.length > 0) {
-    if (results.length >= maxFiles) { truncated = true; break; }
-    const current = queue.shift()!;
-    if (!visit(current)) continue;
-    let entries: fs.Dirent[];
-    try {
-      entries = fs.readdirSync(current, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-
-    for (const entry of entries) {
-      const entryPath = path.join(current, entry.name);
-      const relFromRoot = path.relative(dir, entryPath).replace(/\\/g, '/');
-      const kind = classifyEntry(entryPath, entry);
-
-      if (kind === 'dir') {
-        if (SOURCE_SKIP_DIRS.has(entry.name) || entry.name === '.git') continue;
-        if (!includeTests && TEST_DIRS.has(entry.name)) continue;
-        if (ignore && ignore.matches(relFromRoot + '/.')) continue;
-        if (results.length >= maxFiles) { truncated = true; break; }
-        queue.push(entryPath);
-      } else if (kind === 'file') {
-        if (!matchesConfigName(entry.name, relFromRoot, matcher)) continue;
-        if (ignore && ignore.matches(relFromRoot)) continue;
-        if (results.length >= maxFiles) { truncated = true; break; }
-        results.push(relFromRoot);
-      }
-    }
-  }
-
-  return { files: results, truncated };
+  return walkTree(dir, maxFiles, {
+    skipDir: (name, rel) =>
+      SOURCE_SKIP_DIRS.has(name) || name === '.git'
+      || (!includeTests && TEST_DIRS.has(name))
+      || !!(ignore && ignore.matches(rel + '/.')),
+    acceptFile: (name, rel) =>
+      matchesConfigName(name, rel, matcher)
+      && !(ignore && ignore.matches(rel)),
+    collect: (_entryPath, rel) => rel,
+  });
 }
 
 function walkSourceFiles(
@@ -933,46 +1006,17 @@ function walkSourceFiles(
   includeTests: boolean,
   ignore: IgnoreMatcher | null,
 ): WalkResult {
-  const results: string[] = [];
-  const queue: string[] = [dir];
-  const visit = makeVisitedGuard();
-  let truncated = false;
-
-  while (queue.length > 0) {
-    if (results.length >= maxFiles) { truncated = true; break; }
-    const current = queue.shift()!;
-    if (!visit(current)) continue;
-    let entries: fs.Dirent[];
-    try {
-      entries = fs.readdirSync(current, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-
-    for (const entry of entries) {
-      const entryPath = path.join(current, entry.name);
-      const relFromRoot = path.relative(dir, entryPath).replace(/\\/g, '/');
-      const kind = classifyEntry(entryPath, entry);
-
-      if (kind === 'dir') {
-        if (SOURCE_SKIP_DIRS.has(entry.name) || entry.name.startsWith('.')) continue;
-        if (!includeTests && TEST_DIRS.has(entry.name)) continue;
-        // Prune whole-tree ignored directories. The matcher's directory
-        // patterns end with `/`, so we test the dir path with a trailing
-        // segment; equivalently, append `/dummy`.
-        if (ignore && ignore.matches(relFromRoot + '/.')) continue;
-        if (results.length >= maxFiles) { truncated = true; break; }
-        queue.push(entryPath);
-      } else if (kind === 'file') {
-        const ext = path.extname(entry.name);
-        if (!SOURCE_FILE_EXTENSIONS.has(ext)) continue;
-        if (!includeTests && isTestFile(entry.name)) continue;
-        if (ignore && ignore.matches(relFromRoot)) continue;
-        if (results.length >= maxFiles) { truncated = true; break; }
-        results.push(entryPath);
-      }
-    }
-  }
-
-  return { files: results, truncated };
+  return walkTree(dir, maxFiles, {
+    // Prune whole-tree ignored directories. The matcher's directory patterns
+    // end with `/`, so we test the dir path with a trailing segment.
+    skipDir: (name, rel) =>
+      SOURCE_SKIP_DIRS.has(name) || name.startsWith('.')
+      || (!includeTests && TEST_DIRS.has(name))
+      || !!(ignore && ignore.matches(rel + '/.')),
+    acceptFile: (name, rel) =>
+      SOURCE_FILE_EXTENSIONS.has(path.extname(name))
+      && (includeTests || !isTestFile(name))
+      && !(ignore && ignore.matches(rel)),
+    collect: (entryPath) => entryPath,
+  });
 }

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -500,16 +500,23 @@ export function scan(projectDir: string, options?: ScanOptions, stats?: ScanStat
    * would otherwise be reported three times — turning "1 path could not be read"
    * into "3 paths could not be read" for a single underlying cause.
    */
+  // Keyed on the RESOLVED path, not the path we walked: one unreadable directory
+  // reachable through eight in-tree links reported nine separate entries, and
+  // since a non-empty list sets exit 1, that is nine lines of noise for one
+  // cause.
   const seenUnreadable = new Set<string>();
   const seenOutOfRoot = new Set<string>();
+  const dedupeKey = (p: string) => realpathOrNull(path.resolve(projectDir, p)) ?? p;
   const absorbWalk = (walk: WalkResult) => {
     if (!stats) return;
     if (walk.truncated) stats.truncated = true;
     for (const p of walk.unreadable) {
-      if (stats.unreadable && !seenUnreadable.has(p)) { seenUnreadable.add(p); stats.unreadable.push(p); }
+      const k = dedupeKey(p);
+      if (stats.unreadable && !seenUnreadable.has(k)) { seenUnreadable.add(k); stats.unreadable.push(p); }
     }
     for (const p of walk.outOfRoot) {
-      if (stats.outOfRoot && !seenOutOfRoot.has(p)) { seenOutOfRoot.add(p); stats.outOfRoot.push(p); }
+      const k = dedupeKey(p);
+      if (stats.outOfRoot && !seenOutOfRoot.has(k)) { seenOutOfRoot.add(k); stats.outOfRoot.push(p); }
     }
   };
 
@@ -673,7 +680,32 @@ export function scan(projectDir: string, options?: ScanOptions, stats?: ScanStat
     return a.file.localeCompare(b.file);
   });
 
-  return findings;
+  // One credential, one finding. Following symlinks means the same underlying
+  // file is reachable by more than one path — twelve packages each linking to a
+  // shared config turned one leaked key into thirteen criticals, so `total`
+  // counted PATHS rather than credentials and a triage queue read thirteen
+  // incidents. Deduplicated on the resolved file plus its position, after the
+  // sort, so the surviving path is the highest-confidence one.
+  return dedupeByRealFile(findings, projectDir);
+}
+
+/** Collapse findings that resolve to the same real file, line and pattern. */
+function dedupeByRealFile(findings: ScanFinding[], projectDir: string): ScanFinding[] {
+  const realOf = new Map<string, string>();
+  const seen = new Set<string>();
+  const out: ScanFinding[] = [];
+  for (const f of findings) {
+    let real = realOf.get(f.file);
+    if (real === undefined) {
+      real = realpathOrNull(path.resolve(projectDir, f.file)) ?? f.file;
+      realOf.set(f.file, real);
+    }
+    const key = `${real} ${f.line} ${f.patternId}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(f);
+  }
+  return out;
 }
 
 /**
@@ -759,8 +791,11 @@ function classifyEntry(entryPath: string, entry: fs.Dirent): 'dir' | 'file' | 's
     // there is nothing to scan, so it is genuinely a skip. EACCES/ELOOP/EMFILE
     // mean something IS there and we could not look at it, which must be
     // reported rather than counted as clean.
+    // ENOENT is a broken link and ENOTDIR is a link through a non-directory —
+    // both point at nothing, so there is no content we failed to examine.
+    // EACCES/ELOOP/EMFILE mean something IS there that we could not look at.
     const code = (err as NodeJS.ErrnoException)?.code;
-    return code === 'ENOENT' ? 'skip' : 'unreadable';
+    return code === 'ENOENT' || code === 'ENOTDIR' ? 'skip' : 'unreadable';
   }
 }
 
@@ -844,9 +879,39 @@ function matchesConfigName(
  */
 const MAX_DIRS_VISITED = 50_000;
 
-/** Is `target` the root itself or inside it? Both must already be real paths. */
+/**
+ * How many distinct paths to the SAME real directory one walk will follow.
+ *
+ * Per-ancestry cycle detection deliberately allows a directory to be reached by
+ * more than one path — that is what makes `pkg/.claude -> shared/` work when
+ * `shared/` is also in the tree. But the number of paths through a lattice of
+ * links is exponential: a hand-built 31-directory fixture produced 2,047 walks,
+ * 45s of wall clock and 289 MB of RSS. A repo is a hostile input to a scanner,
+ * so the multiplicity is capped. Twelve packages each linking to a shared
+ * directory is the realistic high-water mark; well past that is pathological,
+ * and crossing the cap sets `truncated` rather than passing silently.
+ */
+const MAX_PATHS_PER_DIR = 32;
+
+/**
+ * Is `target` the root itself or inside it? Both must already be real paths.
+ *
+ * `path.sep` is appended for the prefix test so `/tmp/rootx` is not read as
+ * inside `/tmp/root` — but a root of `/` already ends in the separator, and
+ * appending a second one made every absolute path test as OUTSIDE it.
+ *
+ * On a case-insensitive filesystem `realpathSync` does NOT canonicalise case, so
+ * scanning `ROOT` when the directory is `root` leaves an in-tree link resolving
+ * to a path that fails a case-sensitive prefix test — and the subtree it reaches
+ * would be dropped. Compare case-insensitively where the platform is.
+ */
 function isWithinRoot(target: string, rootReal: string): boolean {
-  return target === rootReal || target.startsWith(rootReal + path.sep);
+  const prefix = rootReal.endsWith(path.sep) ? rootReal : rootReal + path.sep;
+  if (target === rootReal || target.startsWith(prefix)) return true;
+  if (process.platform !== 'darwin' && process.platform !== 'win32') return false;
+  const t = target.toLowerCase();
+  const r = rootReal.toLowerCase();
+  return t === r || t.startsWith(r.endsWith(path.sep) ? r : r + path.sep);
 }
 
 /** Resolve a path to its real location, or null when it cannot be resolved. */
@@ -895,6 +960,7 @@ function walkTree(dir: string, maxFiles: number, spec: WalkSpec): WalkResult {
   const rootReal = realpathOrNull(dir) ?? path.resolve(dir);
   // Each entry carries the realpath chain of the directories above it.
   const queue: Array<{ dir: string; ancestors: string[] }> = [{ dir, ancestors: [] }];
+  const visitsByReal = new Map<string, number>();
   let dirsVisited = 0;
 
   const rel = (p: string) => path.relative(dir, p).replace(/\\/g, '/');
@@ -908,6 +974,11 @@ function walkTree(dir: string, maxFiles: number, spec: WalkSpec): WalkResult {
     if (currentReal === null) { unreadable.push(rel(current)); continue; }
     // A directory inside its own ancestry is a genuine loop.
     if (ancestors.includes(currentReal)) continue;
+    // Bound how many distinct routes to one directory we follow (see the
+    // constant): the path count through a link lattice is exponential.
+    const seenCount = visitsByReal.get(currentReal) ?? 0;
+    if (seenCount >= MAX_PATHS_PER_DIR) { truncated = true; continue; }
+    visitsByReal.set(currentReal, seenCount + 1);
     const childAncestors = [...ancestors, currentReal];
     dirsVisited += 1;
 
@@ -929,22 +1000,33 @@ function walkTree(dir: string, maxFiles: number, spec: WalkSpec): WalkResult {
       if (kind === 'unreadable') { unreadable.push(relFromRoot); continue; }
       if (kind === 'skip') continue;
 
-      // Containment. A link out of the tree is not followed: `link -> $HOME`
-      // would otherwise make `scan .` traverse the whole home directory. This
-      // matches the policy transcript.ts already states for its own walk.
-      if (entry.isSymbolicLink()) {
-        const target = realpathOrNull(entryPath);
-        if (target === null) { continue; }         // broken link: nothing to scan
-        if (!isWithinRoot(target, rootReal)) { outOfRoot.push(relFromRoot); continue; }
-      }
-
       if (kind === 'dir') {
+        // Filters run BEFORE containment, so a pruned tree never produces a
+        // coverage warning. Reporting `node_modules -> /pnpm-store` as an
+        // unfollowed boundary — and telling the user to go scan it — is noise
+        // about a directory that was never going to be walked.
         if (spec.skipDir(entry.name, relFromRoot)) continue;
+
+        // Containment applies to DIRECTORY links only. Following one is
+        // unbounded: a repo holding `link -> $HOME` would pull the whole home
+        // directory into the scan.
+        if (entry.isSymbolicLink()) {
+          const target = realpathOrNull(entryPath);
+          if (target === null) continue;
+          if (!isWithinRoot(target, rootReal)) { outOfRoot.push(relFromRoot); continue; }
+        }
+
         // Checked AFTER the filters, so only a real candidate trips the cap.
         if (files.length >= maxFiles) { truncated = true; break; }
         queue.push({ dir: entryPath, ancestors: childAncestors });
       } else {
         if (!spec.acceptFile(entry.name, relFromRoot)) continue;
+        // A symlinked FILE is NOT contained, even out of the root. Reading one
+        // file the repository explicitly names is bounded work, and it is the
+        // shape every dotfile manager produces: `pkg/.env -> ../../shared/.env`
+        // under stow/chezmoi, or a package pointing at the monorepo root env.
+        // Refusing it would drop a credential the repo is asking us to treat as
+        // its own — the opposite of the unbounded-traversal risk above.
         if (files.length >= maxFiles) { truncated = true; break; }
         files.push(spec.collect(entryPath, relFromRoot));
       }

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -138,6 +138,16 @@ export interface ScanOptions {
 export interface ScanStats {
   /** Count of pattern matches suppressed as known examples / placeholders. */
   placeholdersSuppressed: number;
+  /**
+   * True when a file walk stopped at `maxSourceFiles` with tree left unvisited,
+   * so the findings are a SUBSET and "no credentials found" is not a verdict.
+   *
+   * `scan()` writes this unconditionally (false on a complete walk), so a caller
+   * that passes a bare object still gets a correct value rather than
+   * `undefined` — an absent flag reads as falsy, which is the fail-open shape
+   * this exists to close.
+   */
+  truncated: boolean;
 }
 
 /**
@@ -351,6 +361,9 @@ export function scan(projectDir: string, options?: ScanOptions, stats?: ScanStat
   };
   const findings: ScanFinding[] = [];
   const scanGlobal = options?.scanGlobal !== false;
+  // Written unconditionally so a complete walk actively reports "not truncated"
+  // rather than leaving a stale or absent flag for the caller to misread.
+  if (stats) stats.truncated = false;
 
   // A FILE target is scanned as that file. It used to be accepted, checked for
   // existence, then walked as a directory — which found nothing and reported
@@ -459,7 +472,9 @@ export function scan(projectDir: string, options?: ScanOptions, stats?: ScanStat
   // runs first. A scanner that answers "clean" for a tree it never walked is
   // worse than one that errors.
   const scannedConfigFiles: string[] = [];
-  for (const configFile of walkConfigFiles(projectDir, options?.maxSourceFiles ?? 5000, includeTestsOpt, ignore)) {
+  const configWalk = walkConfigFiles(projectDir, options?.maxSourceFiles ?? 5000, includeTestsOpt, ignore);
+  if (configWalk.truncated && stats) stats.truncated = true;
+  for (const configFile of configWalk.files) {
     if (ignore && ignore.matches(configFile)) continue;
     const fullPath = path.join(projectDir, configFile);
     if (!fs.existsSync(fullPath)) continue;
@@ -504,9 +519,10 @@ export function scan(projectDir: string, options?: ScanOptions, stats?: ScanStat
     const configFileSet = new Set(scannedConfigFiles);
     const maxFiles = options?.maxSourceFiles ?? 5000;
     const includeTests = options?.includeTests ?? false;
-    const sourceFiles = walkSourceFiles(projectDir, maxFiles, includeTests, ignore);
+    const sourceWalk = walkSourceFiles(projectDir, maxFiles, includeTests, ignore);
+    if (sourceWalk.truncated && stats) stats.truncated = true;
 
-    for (const filePath of sourceFiles) {
+    for (const filePath of sourceWalk.files) {
       const relPath = path.relative(projectDir, filePath);
       // Skip files already covered by config scan
       if (configFileSet.has(relPath)) continue;
@@ -559,8 +575,9 @@ export function scan(projectDir: string, options?: ScanOptions, stats?: ScanStat
   if (options?.scanSource !== false) {
     const includeTests = options?.includeTests ?? false;
     const pemPattern = CREDENTIAL_PATTERNS.find(p => p.id === 'pem-private-key')!;
-    const keyFiles = walkKeyFiles(projectDir, options?.maxSourceFiles ?? 5000, includeTests, ignore);
-    for (const filePath of keyFiles) {
+    const keyWalk = walkKeyFiles(projectDir, options?.maxSourceFiles ?? 5000, includeTests, ignore);
+    if (keyWalk.truncated && stats) stats.truncated = true;
+    for (const filePath of keyWalk.files) {
       const relPath = path.relative(projectDir, filePath);
       if (ignore && ignore.matches(relPath.replace(/\\/g, '/'))) continue;
       try {
@@ -643,6 +660,140 @@ function isTestFile(name: string): boolean {
 /** Private-key file extensions scanned in addition to source/config files. */
 const KEY_FILE_EXTENSIONS = new Set(['.pem', '.key', '.crt', '.p12', '.pfx']);
 
+/** What a walker collected, and whether the file cap cut the walk short. */
+interface WalkResult {
+  files: string[];
+  /**
+   * True when a real candidate was dropped because `maxFiles` was already
+   * reached, or when queued directories were left unvisited. A truncated walk
+   * must never render as a clean scan — see `ScanStats.truncated`.
+   */
+  truncated: boolean;
+}
+
+/**
+ * Classify a directory entry, FOLLOWING symlinks.
+ *
+ * `Dirent.isDirectory()` / `isFile()` are lstat-based: a symlink is NEITHER, so
+ * classifying from the Dirent alone drops every symlinked entry on the floor.
+ * 0.21.0 reached config files through `existsSync`/`statSync`, which follow
+ * links; making the config walk recursive in 0.21.1 silently removed symlink
+ * support, so a symlinked `.claude/` — what a dotfile manager or a shared
+ * monorepo config produces — reported "No hardcoded credentials found."
+ *
+ * Returns 'skip' for a broken link, a socket/fifo/device, or anything we cannot
+ * stat, so an unresolvable link is dropped rather than throwing mid-walk.
+ */
+function classifyEntry(entryPath: string, entry: fs.Dirent): 'dir' | 'file' | 'skip' {
+  if (entry.isDirectory()) return 'dir';
+  if (entry.isFile()) return 'file';
+  if (!entry.isSymbolicLink()) return 'skip';
+  try {
+    const target = fs.statSync(entryPath); // follows the link
+    if (target.isDirectory()) return 'dir';
+    if (target.isFile()) return 'file';
+    return 'skip';
+  } catch {
+    return 'skip';
+  }
+}
+
+/**
+ * Cycle guard for a symlink-following walk.
+ *
+ * Following symlinks without one trades a fail-open for a hang: no walker has a
+ * depth bound, so `a/loop -> a` recurses until the file cap and a cross-linked
+ * pair of directories never terminates. Keyed on the RESOLVED real path, so two
+ * routes to the same directory are walked once. Returns false if already seen.
+ */
+/**
+ * `.env` suffixes that hold placeholders by convention and are meant to be
+ * committed. Everything else after `.env.` is treated as a REAL env file.
+ *
+ * The polarity matters: an unrecognised `.env.whatever` is scanned rather than
+ * skipped, so the unknown case fails closed. The previous allowlist named only
+ * `.env` and `.env.local`, which missed `.env.development`, `.env.production`,
+ * `.env.staging`, `.env.test` and `.env.prod` — the exact set the CLAUDE.md
+ * block Secretless itself installs tells the user it protects (#116 P2-3).
+ */
+const ENV_TEMPLATE_SUFFIXES = new Set(['example', 'sample', 'template', 'dist']);
+
+/** True for a real `.env` file; false for a committed template. */
+export function isEnvFile(basename: string): boolean {
+  if (basename === '.env') return true;
+  if (!basename.startsWith('.env.')) return false;
+  // A template marker in ANY segment wins, so `.env.example.local` stays out.
+  return !basename
+    .slice('.env.'.length)
+    .toLowerCase()
+    .split('.')
+    .some(segment => ENV_TEMPLATE_SUFFIXES.has(segment));
+}
+
+/**
+ * Config files this tool scans on top of the shared `CONFIG_FILES` catalog.
+ *
+ * `.secretless` is OUR OWN manifest, not a third-party credential surface, so it
+ * does not belong in `@opena2a/credential-patterns` (a cross-tool catalog whose
+ * copy here is held byte-identical by `lockstep.test.ts`). It still has to be
+ * scanned: the file is documented "safe to commit" and holds NAMES only, so a
+ * pasted value is a likely mistake that nothing detected — before this, the
+ * parse-error path was the only surface that ever read the file, and it printed
+ * the value instead of flagging it.
+ */
+const LOCAL_CONFIG_FILES = ['.secretless'];
+
+interface ConfigNameMatcher {
+  byBasename: Set<string>;
+  bySuffix: string[];
+}
+
+/** Split the config catalogs into basename and path-suffix forms, lowercased once. */
+function buildConfigNameMatcher(): ConfigNameMatcher {
+  const byBasename = new Set<string>();
+  const bySuffix: string[] = [];
+  for (const entry of [...CONFIG_FILES, ...LOCAL_CONFIG_FILES]) {
+    if (entry.includes('/')) bySuffix.push(entry.toLowerCase());
+    else byBasename.add(entry.toLowerCase());
+  }
+  return { byBasename, bySuffix };
+}
+
+/**
+ * Does this entry name a project config file?
+ *
+ * Matched case-insensitively: on a case-insensitive filesystem (macOS, Windows)
+ * `Claude.md` and `CLAUDE.md` are the SAME file to the OS but not to an
+ * exact-match Set, so an exact comparison skipped a file the user can plainly
+ * see. On a case-sensitive filesystem this widens the match to case variants of
+ * the same config name, which is the safe direction for a scanner.
+ */
+function matchesConfigName(
+  basename: string,
+  relFromRoot: string,
+  matcher: ConfigNameMatcher,
+): boolean {
+  if (matcher.byBasename.has(basename.toLowerCase())) return true;
+  if (isEnvFile(basename)) return true;
+  const lowerRel = relFromRoot.toLowerCase();
+  return matcher.bySuffix.some(sfx => lowerRel === sfx || lowerRel.endsWith('/' + sfx));
+}
+
+function makeVisitedGuard(): (dir: string) => boolean {
+  const seen = new Set<string>();
+  return (dir: string) => {
+    let key: string;
+    try {
+      key = fs.realpathSync(dir);
+    } catch {
+      key = path.resolve(dir);
+    }
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  };
+}
+
 /**
  * Walk a directory tree and return standalone key files (`*.pem`, `*.key`, `*.p12`, ...).
  * Mirrors walkSourceFiles' directory pruning, test-skipping, and ignore semantics so a
@@ -653,12 +804,17 @@ function walkKeyFiles(
   maxFiles: number,
   includeTests: boolean,
   ignore: IgnoreMatcher | null,
-): string[] {
+): WalkResult {
   const results: string[] = [];
   const queue: string[] = [dir];
+  const visit = makeVisitedGuard();
+  let truncated = false;
 
-  while (queue.length > 0 && results.length < maxFiles) {
+  while (queue.length > 0) {
+    // Queued directories left unvisited are unscanned tree, not a clean result.
+    if (results.length >= maxFiles) { truncated = true; break; }
     const current = queue.shift()!;
+    if (!visit(current)) continue;
     let entries: fs.Dirent[];
     try {
       entries = fs.readdirSync(current, { withFileTypes: true });
@@ -667,28 +823,31 @@ function walkKeyFiles(
     }
 
     for (const entry of entries) {
-      if (results.length >= maxFiles) break;
       const entryPath = path.join(current, entry.name);
       const relFromRoot = path.relative(dir, entryPath).replace(/\\/g, '/');
+      const kind = classifyEntry(entryPath, entry);
 
-      if (entry.isDirectory()) {
+      if (kind === 'dir') {
         // Unlike source files, key files commonly live in HIDDEN directories (`.ssh/`,
         // `.certs/`, `.aws/`), so we do NOT blanket-skip dot-dirs here. We still skip the
         // heavy/irrelevant ones (node_modules, .git) and honor the ignore matcher.
         if (SOURCE_SKIP_DIRS.has(entry.name) || entry.name === '.git') continue;
         if (!includeTests && TEST_DIRS.has(entry.name)) continue;
         if (ignore && ignore.matches(relFromRoot + '/.')) continue;
+        // Cap checked AFTER the filters, so only a real candidate trips it.
+        if (results.length >= maxFiles) { truncated = true; break; }
         queue.push(entryPath);
-      } else if (entry.isFile()) {
+      } else if (kind === 'file') {
         if (!KEY_FILE_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) continue;
         if (!includeTests && isTestFile(entry.name)) continue;
         if (ignore && ignore.matches(relFromRoot)) continue;
+        if (results.length >= maxFiles) { truncated = true; break; }
         results.push(entryPath);
       }
     }
   }
 
-  return results;
+  return { files: results, truncated };
 }
 
 /**
@@ -709,19 +868,18 @@ function walkConfigFiles(
   maxFiles: number,
   includeTests: boolean,
   ignore: IgnoreMatcher | null,
-): string[] {
-  const byBasename = new Set<string>();
-  const bySuffix: string[] = [];
-  for (const entry of CONFIG_FILES) {
-    if (entry.includes('/')) bySuffix.push(entry);
-    else byBasename.add(entry);
-  }
+): WalkResult {
+  const matcher = buildConfigNameMatcher();
 
   const results: string[] = [];
   const queue: string[] = [dir];
+  const visit = makeVisitedGuard();
+  let truncated = false;
 
-  while (queue.length > 0 && results.length < maxFiles) {
+  while (queue.length > 0) {
+    if (results.length >= maxFiles) { truncated = true; break; }
     const current = queue.shift()!;
+    if (!visit(current)) continue;
     let entries: fs.Dirent[];
     try {
       entries = fs.readdirSync(current, { withFileTypes: true });
@@ -730,26 +888,26 @@ function walkConfigFiles(
     }
 
     for (const entry of entries) {
-      if (results.length >= maxFiles) break;
       const entryPath = path.join(current, entry.name);
       const relFromRoot = path.relative(dir, entryPath).replace(/\\/g, '/');
+      const kind = classifyEntry(entryPath, entry);
 
-      if (entry.isDirectory()) {
+      if (kind === 'dir') {
         if (SOURCE_SKIP_DIRS.has(entry.name) || entry.name === '.git') continue;
         if (!includeTests && TEST_DIRS.has(entry.name)) continue;
         if (ignore && ignore.matches(relFromRoot + '/.')) continue;
+        if (results.length >= maxFiles) { truncated = true; break; }
         queue.push(entryPath);
-      } else if (entry.isFile()) {
-        const isConfig = byBasename.has(entry.name)
-          || bySuffix.some(sfx => relFromRoot === sfx || relFromRoot.endsWith('/' + sfx));
-        if (!isConfig) continue;
+      } else if (kind === 'file') {
+        if (!matchesConfigName(entry.name, relFromRoot, matcher)) continue;
         if (ignore && ignore.matches(relFromRoot)) continue;
+        if (results.length >= maxFiles) { truncated = true; break; }
         results.push(relFromRoot);
       }
     }
   }
 
-  return results;
+  return { files: results, truncated };
 }
 
 function walkSourceFiles(
@@ -757,12 +915,16 @@ function walkSourceFiles(
   maxFiles: number,
   includeTests: boolean,
   ignore: IgnoreMatcher | null,
-): string[] {
+): WalkResult {
   const results: string[] = [];
   const queue: string[] = [dir];
+  const visit = makeVisitedGuard();
+  let truncated = false;
 
-  while (queue.length > 0 && results.length < maxFiles) {
+  while (queue.length > 0) {
+    if (results.length >= maxFiles) { truncated = true; break; }
     const current = queue.shift()!;
+    if (!visit(current)) continue;
     let entries: fs.Dirent[];
     try {
       entries = fs.readdirSync(current, { withFileTypes: true });
@@ -771,28 +933,29 @@ function walkSourceFiles(
     }
 
     for (const entry of entries) {
-      if (results.length >= maxFiles) break;
-
       const entryPath = path.join(current, entry.name);
       const relFromRoot = path.relative(dir, entryPath).replace(/\\/g, '/');
+      const kind = classifyEntry(entryPath, entry);
 
-      if (entry.isDirectory()) {
+      if (kind === 'dir') {
         if (SOURCE_SKIP_DIRS.has(entry.name) || entry.name.startsWith('.')) continue;
         if (!includeTests && TEST_DIRS.has(entry.name)) continue;
         // Prune whole-tree ignored directories. The matcher's directory
         // patterns end with `/`, so we test the dir path with a trailing
         // segment; equivalently, append `/dummy`.
         if (ignore && ignore.matches(relFromRoot + '/.')) continue;
+        if (results.length >= maxFiles) { truncated = true; break; }
         queue.push(entryPath);
-      } else if (entry.isFile()) {
+      } else if (kind === 'file') {
         const ext = path.extname(entry.name);
         if (!SOURCE_FILE_EXTENSIONS.has(ext)) continue;
         if (!includeTests && isTestFile(entry.name)) continue;
         if (ignore && ignore.matches(relFromRoot)) continue;
+        if (results.length >= maxFiles) { truncated = true; break; }
         results.push(entryPath);
       }
     }
   }
 
-  return results;
+  return { files: results, truncated };
 }

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -900,26 +900,43 @@ const MAX_PATHS_PER_DIR = 32;
  * inside `/tmp/root` — but a root of `/` already ends in the separator, and
  * appending a second one made every absolute path test as OUTSIDE it.
  *
- * On a case-insensitive filesystem `realpathSync` does NOT canonicalise case, so
- * scanning `ROOT` when the directory is `root` leaves an in-tree link resolving
- * to a path that fails a case-sensitive prefix test — and the subtree it reaches
- * would be dropped. Compare case-insensitively where the platform is.
+ * A pure string comparison is sound here ONLY because both sides come from
+ * `realpathOrNull`, which resolves `..` and every intermediate symlink first: a
+ * traversal string cannot survive that, so `<root>/link -> <root>/../../etc`
+ * arrives as `/etc` and is rejected on its own merits.
  */
 function isWithinRoot(target: string, rootReal: string): boolean {
   const prefix = rootReal.endsWith(path.sep) ? rootReal : rootReal + path.sep;
-  if (target === rootReal || target.startsWith(prefix)) return true;
-  if (process.platform !== 'darwin' && process.platform !== 'win32') return false;
-  const t = target.toLowerCase();
-  const r = rootReal.toLowerCase();
-  return t === r || t.startsWith(r.endsWith(path.sep) ? r : r + path.sep);
+  return target === rootReal || target.startsWith(prefix);
 }
 
-/** Resolve a path to its real location, or null when it cannot be resolved. */
+/**
+ * Resolve a path to its real location, or null when it cannot be resolved.
+ *
+ * `realpathSync.native` rather than `realpathSync`, because it also canonicalises
+ * CASE. That matters for `isWithinRoot`: on a case-insensitive volume, scanning
+ * `ROOT` when the directory is `root` otherwise leaves an in-tree link resolving
+ * to a differently-cased string that fails the prefix test, silently dropping
+ * the subtree it reaches.
+ *
+ * This replaced a platform-keyed case-insensitive comparison, which was wrong in
+ * the other direction: macOS can host case-SENSITIVE volumes, where `/repo` and
+ * /REPO` are genuinely different directories and lowercasing would have let a
+ * link escape the root. Asking the filesystem is correct on both volume types;
+ * guessing from `process.platform` is correct on neither reliably.
+ */
 function realpathOrNull(p: string): string | null {
   try {
-    return fs.realpathSync(p);
+    return fs.realpathSync.native(p);
   } catch {
-    return null;
+    // `.native` can fail where the portable implementation succeeds (and is
+    // absent on some runtimes), so fall back rather than treating a resolvable
+    // path as unreadable.
+    try {
+      return fs.realpathSync(p);
+    } catch {
+      return null;
+    }
   }
 }
 

--- a/src/setup.test.ts
+++ b/src/setup.test.ts
@@ -165,10 +165,34 @@ describe('runSetup — an unparseable manifest is not a missing-secrets count (#
 
     const printed = errSpy.mock.calls.flat().join('');
     expect(printed).toContain('line 2');
-    expect(printed).toContain('bad:line');
+    // The line itself is NOT echoed: a manifest line is where a pasted
+    // credential lands, and this stderr is what CI logs capture. The line
+    // number plus the reason locate it without reading the file back.
     expect(printed).toContain('one secret name per line');
     // Must not imply the store was consulted.
     expect(printed).toContain('No secrets were checked');
+  });
+
+  it('does not echo a credential VALUE from an unparseable manifest to stderr', async () => {
+    // `.secretless` is documented "safe to commit", so this parse-error path is
+    // the surface that reads it — and `setup --check` stderr is exactly what
+    // lands in CI logs. Both leaking shapes are covered: NAME=VALUE and
+    // NAME VALUE (which leaked twice, text and reason).
+    const ANTHROPIC = ['sk-ant-api03-', 'FAKEvalueLEAKEDdonotprint'].join('');
+    const GITHUB = ['ghp_', 'FAKEtokenLEAKEDdonotprint'].join('');
+    fs.writeFileSync(path.join(tmpDir, '.secretless'),
+      `ANTHROPIC_API_KEY=${ANTHROPIC}\nGITHUB_TOKEN ${GITHUB}\n`);
+
+    await runSetup(tmpDir, { check: true, backend });
+
+    const printed = errSpy.mock.calls.flat().join('');
+    expect(printed).not.toContain(ANTHROPIC);
+    expect(printed).not.toContain(GITHUB);
+    // Still actionable: both lines are located and both declared names shown.
+    expect(printed).toContain('line 1');
+    expect(printed).toContain('line 2');
+    expect(printed).toContain('ANTHROPIC_API_KEY');
+    expect(printed).toContain('GITHUB_TOKEN');
   });
 
   it('CONTROL: a valid manifest still produces a real count', async () => {

--- a/src/setup.test.ts
+++ b/src/setup.test.ts
@@ -188,10 +188,12 @@ describe('runSetup — an unparseable manifest is not a missing-secrets count (#
     const printed = errSpy.mock.calls.flat().join('');
     expect(printed).not.toContain(ANTHROPIC);
     expect(printed).not.toContain(GITHUB);
-    // Still actionable: both lines are located and both declared names shown.
+    // Still actionable: both lines are located, and the line whose NAME position
+    // holds a real name still shows it. The `NAME=VALUE` line does not, because
+    // `=` is also base64 padding and the left side can be the whole secret.
     expect(printed).toContain('line 1');
     expect(printed).toContain('line 2');
-    expect(printed).toContain('ANTHROPIC_API_KEY');
+    expect(printed).toContain('dotenv');
     expect(printed).toContain('GITHUB_TOKEN');
   });
 

--- a/src/status.ts
+++ b/src/status.ts
@@ -15,6 +15,13 @@ export interface StatusResult {
   hookInstalled: boolean;
   denyRuleCount: number;
   secretsFound: number;
+  /**
+   * True when the scan behind `secretsFound` could not cover the whole tree, so
+   * the count is a lower bound rather than a verdict. `scan()` discards this
+   * when no stats object is passed, which is how `status --json` reported
+   * `secretsFound: 0` over a subtree it never opened.
+   */
+  scanIncomplete: boolean;
   transcriptProtection: {
     stopHookInstalled: boolean;
     watcherRunning: boolean;
@@ -33,6 +40,7 @@ export function status(projectDir: string): StatusResult {
     hookInstalled: false,
     denyRuleCount: 0,
     secretsFound: 0,
+    scanIncomplete: false,
     transcriptProtection: {
       stopHookInstalled: false,
       watcherRunning: false,
@@ -92,8 +100,10 @@ export function status(projectDir: string): StatusResult {
   }
 
   // Scan for secrets (project-level only for status report)
-  const findings = scan(projectDir, { scanGlobal: false });
+  const scanStats = { placeholdersSuppressed: 0, truncated: false, unreadable: [] as string[] };
+  const findings = scan(projectDir, { scanGlobal: false }, scanStats);
   result.secretsFound = findings.length;
+  result.scanIncomplete = scanStats.truncated || scanStats.unreadable.length > 0;
 
   // Transcript protection metrics
   try {

--- a/src/vault-core.ts
+++ b/src/vault-core.ts
@@ -499,8 +499,21 @@ export async function vaultScan(targetDir?: string): Promise<void> {
 
   console.log(`\n  Scanning ${dir} for credentials to migrate to vault...\n`);
 
-  const findings = scan(dir, { includeTests: false });
+  // Coverage shortfalls are collected here too. `scan()` discards them when no
+  // stats object is passed, so this command printed the same unqualified
+  // "No hardcoded credentials found" over a truncated or unreadable tree that
+  // `scan` itself was fixed to stop printing.
+  const stats = { placeholdersSuppressed: 0, truncated: false, unreadable: [] as string[] };
+  const findings = scan(dir, { includeTests: false }, stats);
+  const incomplete = stats.truncated || stats.unreadable.length > 0;
   if (findings.length === 0) {
+    if (incomplete) {
+      console.log('  No credentials found in the files scanned.');
+      if (stats.truncated) console.log('  Scan incomplete: stopped at the file cap, so files were left unscanned.');
+      if (stats.unreadable.length > 0) console.log(`  ${stats.unreadable.length} path(s) could not be read, so they are not known to be clean.`);
+      console.log('  Check coverage: secretless-ai scan --json | jq .summary\n');
+      return;
+    }
     console.log('  No hardcoded credentials found.\n');
     return;
   }


### PR DESCRIPTION
Fixes the three P1 fail-opens that shipped in 0.21.1, two of them regressions introduced by that release's own fixes, plus the defects two independent adversarial reviews then found in these fixes.

Every defect here is the same shape: the scanner reported a clean or complete result for work it had not done.

## The three P1s

**A symlinked config file or directory was silently skipped.** `Dirent.isDirectory()`/`isFile()` are lstat-based, so a symlink is neither and fell through both branches. 0.21.0 reached config files via `existsSync`/`statSync`, which follow links; making the config walk recursive removed symlink support. A symlinked `.claude/` reported `No hardcoded credentials found` with exit 0.

**A walk that hit the file cap reported clean.** The walkers stopped at `maxSourceFiles` and returned quietly, so an incomplete scan was indistinguishable from a complete one. Truncation is now reported and exits 1, with `--max-files` so the warning has a runnable fix.

**Manifest parse errors echoed credential values to stderr, twice** — once as the echoed line and once interpolated into the reason, which was also unbounded, so a 200 KB token flooded stderr through a field the line limit did not cover.

Also fixes #116 P2-1 (unreadable file read as clean) and P2-3 (`.env.*` variants missed).

## What the reviews changed

The first review found the symlink fix did not reliably fix the case it advertises: the cycle guard was a global visited-realpath set, so a directory reachable by two paths was walked once and which path won depended on readdir order. The regression test passed only because APFS ordered the entries favourably. Cycle detection is now per-ancestry.

The second review, scoped to the fix round, found containment had been applied to file links as well as directory links (dropping a previously-caught credential behind a stow/chezmoi `.env`), a copy-paste command injection in the printed `Fix:` lines, and an exponential path count through a lattice of links.

The three tree walks are collapsed onto one shared traversal. They were separate copies that drifted, which is how the config copy gained recursion while losing symlink handling — the defect this release exists to fix.

## Behavior change

A scan that could not read everything no longer exits 0. A CI job over a tree larger than the 5000-file cap that was passing will now fail until `--max-files` is raised or the path narrowed. Those passes were not earned.

## Verification

- 1333 tests / 74 files pass (1302 baseline). Every new regression test confirmed failing pre-fix: 23 fail against the 0.21.1 release code.
- Two vacuous tests rewritten and their mutants killed. One asserted a pattern that accepted the unfixed value it claimed to guard against; the other computed its expectation by calling the function under test.
- Two independent adversarial reviews, each in its own `git archive` tree, every finding classified regression-vs-pre-existing by building the base.
- HackMyAgent `secure --ci`: 100/100, 194 files read by static checks.
- Deferred findings recorded in #120.
