### PR TITLE
Credential disclosure and integrity: stop leaking, stop masking corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog
 
+## [Unreleased]
+
+Credential disclosure and integrity. Three defects a credential manager should
+not carry, plus what sweeping their shape across the code turned up.
+
+**Behavior change worth reading before you upgrade.** Reads that used to return
+"nothing" on failure now fail closed. If the local store cannot be decrypted, if
+the keychain will not answer, or if the name index is malformed, the command
+exits non-zero and says so instead of reporting an empty store. If you have
+automation that treats "no secrets" as a normal outcome, it will now see an
+error in the cases where the tool never actually read anything.
+
+**`secret set` now refuses a mangled value.** Null bytes, U+FFFD and control
+characters other than tab, newline and carriage return are rejected rather than
+stored. Multi-line secrets (PEM keys, service-account JSON) are unaffected.
+
+**Your cache is invalidated once on upgrade.** Cached values are now tied to the
+build that read them, so the first resolve after upgrading re-reads from the
+backend. Expect one extra unlock prompt.
+
+### Fixed
+
+- **The on-disk cache served values written by a previous build ([#118](https://github.com/opena2a-org/secretless-ai/issues/118)).** Upgrading specifically to fix a corrupted credential returned the corrupted credential for another five minutes, because the cache had no idea which build wrote what. The TTL bounds how stale a value may be and says nothing about how it was read; #107 fixed a read path that corrupted most 32-hex secrets and changed no file format, so nothing invalidated what the broken build had cached. A fix the user cannot observe is indistinguishable from no fix, and this one actively taught them the tool was broken. Entries now carry the identity of the build that wrote them and are dropped unless it matches. Version alone is not the build — a working tree, a global install and an `npx` unpack can report the same version while running different code — so the install location is folded in.
+
+- **`cache clear` cleared a directory the cache stopped using in 0.12.3.** It deleted the abandoned file, printed `Cache cleared`, and left every live entry in place. It is also the workaround #118 documents, so the one published remedy for a stale cached credential was a no-op that reported success. Both locations are cleared now, off the same default the backend writes to. Clearing the pre-0.12.3 file matters on its own: it is an encrypted file of credential values that nothing reads and nothing expires.
+
+- **A cache marker that outlived its entries reported a successful resolve of nothing.** The marker asserts "this prefix is fully resolved" and was guarded by a condition that is true for every possible value, so `run` could inject no secrets at all and exit 0. Measured on 0.21.3. The marker now carries the count it was written with.
+
+- **An unreadable local store was read as an empty one ([#104](https://github.com/opena2a-org/secretless-ai/issues/104)).** `resolve` caught every failure and returned nothing, so `run`, `status`, `verify` and manifest checks all reported success over a credential set they never saw, with exit 0 and empty stderr. Empty and unreadable are different states and the code cannot tell them apart by guessing. A store that is absent is still empty — that is a real first-run state — but one that is present and will not decrypt now fails closed, naming the store, the reason, and the two inputs its key derives from.
+
+- **`secret set` destroyed the store when it could not read it.** The read failure was swallowed with "start fresh" and a one-entry store was written over the top. Measured: three secrets stored, then one `set` from an account that could not decrypt the store, and all three are gone — while the command printed `Stored: NAME` and exited 0. The original account's key still worked right up to that write, so the data was recoverable until the tool destroyed it.
+
+- **The store format version was written on every save and checked nowhere.** A store written in a format this build does not understand would be decrypted, parsed as whatever it parsed as, and served. It is now checked before the decrypt, and a store with no version file is still read — that is a store from a build that never wrote one, not a mismatch.
+
+- **`doctor` and `verify` called the local store healthy because the file existed.** Presence was the entire check, so the one state it exists to catch — a store that is there and unreadable — was the state it called healthy. `secret rm` likewise reported "no such secret" against a store it could not read.
+
+- **A locked keychain made every secret read as missing.** `security` exits 44 for "the specified item could not be found"; every other failure, including a locked login keychain and a dismissed approval dialog, was read the same way. Only 44 means absent now.
+
+- **A malformed name index reported an empty keychain.** The index is how the backends answer "what secrets exist", since the OS keychain has no such query. Any failure reading it returned an empty list, so `secret list` printed nothing and `run` injected nothing over a keychain that still held every secret. Only a missing file means "no secrets yet".
+
+- **A keychain read that could not establish the encoding returned the raw value.** macOS hex-encodes binary passwords, and `-w` output alone cannot say whether it did. When the check that settles it does not complete, returning the raw value hands back the hex transcript of the credential rather than the credential — silently, exit 0. There are three answers to that question, not two, and the third is now a refusal.
+
+- **`run` printed a secret value to stderr ([#117](https://github.com/opena2a-org/secretless-ai/issues/117)).** Node rejects an environment value containing a null byte and puts the value in the message. The throw is synchronous, so the handler meant to catch spawn failures never saw it, and the message went to stderr unredacted — which is what CI logs capture. Such a value is not exotic: macOS returns binary passwords hex-encoded, and they decode to bytes containing a null. Values are now checked before the spawn, so the error names every unusable secret and only its name, and the spawn is wrapped for anything a different Node version rejects that we did not anticipate.
+
+- **The redaction backstop missed escaped and truncated values.** It compared whole values and whole lines, and runtimes embed neither: Node escapes control bytes and truncates long values, `JSON.parse` quotes the first ten characters. Measured against all three throws this tool actually hits, whole-value containment reports no leak over a message displaying most of the credential. Detection now works on runs of the value, in any escaping, and the macOS Keychain write path uses the same detector.
+
+- **A mangled paste was stored without comment ([#104](https://github.com/opena2a-org/secretless-ai/issues/104)).** A 40-character hex token pasted at the interactive prompt was stored as 19 bytes of control characters and U+FFFD — the terminal's own bracketed-paste sequences captured into the value — and surfaced much later as a type error inside an unrelated consumer. Values are validated at the store boundary, so `set`, `import` and the MCP write path are all covered. Every successful write now prints the shape: length and character class, never content.
+
+### Known issues
+
+- On Linux, `secret-tool` failures are still read as "not found". Separating that from "could not read" needs exit codes that could not be measured on the machine this was fixed on, and a guessed mapping is worse than a recorded gap. The macOS path is fixed.
+
 ## [0.21.3] - 2026-08-11
 
 Closes the `init` data-loss defect disclosed as a known issue in 0.21.2, plus

--- a/src/backends/cache.test.ts
+++ b/src/backends/cache.test.ts
@@ -2,11 +2,50 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { CachedBackend, clearCacheFile } from './cache';
+import * as crypto from 'crypto';
+import { CachedBackend, clearCacheFile, defaultWriterStamp } from './cache';
 import type { WritableSecretBackend, BackendHealth } from './types';
 
 function tmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-cache-test-'));
+}
+
+/**
+ * Write a cache file by hand, in the on-disk format, so a test can stage a
+ * cache state that no single run of the current code produces — an entry from
+ * before writer stamps existed, or a marker that outlived its entries.
+ *
+ * This mirrors the implementation's key derivation deliberately: it is building
+ * an INPUT, not computing an expected output. If the derivation ever changes,
+ * these tests fail loudly rather than quietly staging a file nothing reads.
+ */
+function writeCacheFile(dir: string, store: unknown): void {
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const saltPath = path.join(dir, '.salt');
+  let salt: Buffer;
+  try {
+    salt = fs.readFileSync(saltPath);
+    if (salt.length !== 16) throw new Error('bad salt');
+  } catch {
+    salt = crypto.randomBytes(16);
+    fs.writeFileSync(saltPath, salt, { mode: 0o600 });
+  }
+
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? '/tmp';
+  const keyMaterial = `${home}-secretless-cache-${process.env.USER ?? 'default'}`;
+  const key = crypto.scryptSync(keyMaterial, salt, 32, { N: 16384, r: 8, p: 1 });
+
+  const iv = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+  const body = Buffer.concat([
+    cipher.update(JSON.stringify(store), 'utf-8'),
+    cipher.final(),
+  ]);
+  fs.writeFileSync(
+    path.join(dir, '.secret-cache'),
+    Buffer.concat([iv, cipher.getAuthTag(), body]),
+    { mode: 0o600 },
+  );
 }
 
 function cleanup(dir: string): void {
@@ -273,5 +312,165 @@ describe('clearCacheFile', () => {
 
   it('returns false when no cache file exists', () => {
     expect(clearCacheFile(dir)).toBe(false);
+  });
+});
+
+/**
+ * #118 — a cached value written by a different build is a value read by code we
+ * may already have fixed. The TTL bounds staleness in time; nothing bounded it
+ * across an upgrade, so upgrading to fix a corrupted credential returned the
+ * corrupted credential for another five minutes.
+ */
+describe('CachedBackend writer provenance (#118)', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = tmpDir();
+  });
+
+  afterEach(() => {
+    cleanup(dir);
+  });
+
+  it('does not serve an entry written by a different build', async () => {
+    const secrets = { 'secret/HIBP_PRO': 'corrupted-by-the-old-read-path' };
+
+    // The build with the broken read path caches what it read.
+    const before = new CachedBackend(createMockBackend(secrets), {
+      ttlMs: 60_000,
+      storeDir: dir,
+      writerStamp: '0.18.2+aaaaaaaa',
+    });
+    expect(await before.resolve('secret')).toEqual({
+      'secret/HIBP_PRO': 'corrupted-by-the-old-read-path',
+    });
+
+    // The user upgrades. The backend now reads the value correctly — which is
+    // the entire reason they upgraded.
+    secrets['secret/HIBP_PRO'] = '0123456789abcdef0123456789abcdef';
+    const inner = createMockBackend(secrets);
+    const after = new CachedBackend(inner, {
+      ttlMs: 60_000,
+      storeDir: dir,
+      writerStamp: '0.21.4+bbbbbbbb',
+    });
+
+    expect(await after.resolve('secret')).toEqual({
+      'secret/HIBP_PRO': '0123456789abcdef0123456789abcdef',
+    });
+    expect(inner.resolveCalls).toBe(1);
+  });
+
+  it('still serves an entry written by this same build', async () => {
+    // The other direction. Without it, a "fix" that simply never reads the
+    // cache would pass the test above while deleting the feature.
+    const secrets = { 'secret/K': 'v1' };
+    const inner = createMockBackend(secrets);
+    const opts = { ttlMs: 60_000, storeDir: dir, writerStamp: '0.21.4+bbbbbbbb' };
+
+    await new CachedBackend(inner, opts).resolve('secret');
+    expect(inner.resolveCalls).toBe(1);
+
+    secrets['secret/K'] = 'v2-not-yet-visible';
+    const second = new CachedBackend(inner, opts);
+    expect(await second.resolve('secret')).toEqual({ 'secret/K': 'v1' });
+    expect(inner.resolveCalls).toBe(1);
+  });
+
+  it('treats an entry with no writer stamp as a miss', async () => {
+    // Every entry on disk today is one of these. The upgrade that introduces
+    // the stamp has to invalidate what the previous build left behind, or the
+    // fix does not take effect until the caches happen to expire.
+    const legacyCache = {
+      entries: {
+        'secret/K': { value: 'written-before-stamps-existed', cachedAt: Date.now() },
+        '__resolved__secret': { value: '', cachedAt: Date.now() },
+      },
+    };
+    writeCacheFile(dir, legacyCache);
+
+    const inner = createMockBackend({ 'secret/K': 'current' });
+    const cached = new CachedBackend(inner, { ttlMs: 60_000, storeDir: dir });
+
+    expect(await cached.resolve('secret')).toEqual({ 'secret/K': 'current' });
+    expect(inner.resolveCalls).toBe(1);
+  });
+
+  it('pins the default stamp to the real package version', () => {
+    // The tests above inject a stamp. That proves the comparison works, not
+    // that the value being compared is the build. This is the wire to reality:
+    // production passes no stamp, so the default is what actually ships.
+    const pkgVersion = String(
+      (JSON.parse(
+        fs.readFileSync(path.join(__dirname, '..', '..', 'package.json'), 'utf-8'),
+      ) as { version: string }).version,
+    );
+    expect(defaultWriterStamp().startsWith(pkgVersion + '+')).toBe(true);
+    expect(defaultWriterStamp()).not.toBe(pkgVersion);
+  });
+
+  it('treats a resolved-marker with missing entries as a miss, not an empty success', async () => {
+    // The marker asserts "this prefix is fully resolved". The condition guarding
+    // it was `matchingCached.length >= 0`, true for every possible value, so a
+    // marker that outlived its entries reported success and returned {} —
+    // `run` would inject nothing and exit 0.
+    const stamp = '0.21.4+bbbbbbbb';
+    writeCacheFile(dir, {
+      entries: {
+        '__resolved__secret': { value: '', cachedAt: Date.now(), writer: stamp, count: 2 },
+      },
+    });
+
+    const inner = createMockBackend({ 'secret/A': 'a', 'secret/B': 'b' });
+    const cached = new CachedBackend(inner, { ttlMs: 60_000, storeDir: dir, writerStamp: stamp });
+
+    expect(await cached.resolve('secret')).toEqual({ 'secret/A': 'a', 'secret/B': 'b' });
+    expect(inner.resolveCalls).toBe(1);
+  });
+});
+
+/**
+ * #118 — `cache clear` is the workaround the issue documents for a stale cached
+ * credential. It cleared a directory the cache stopped using in 0.12.3.
+ */
+describe('clearCacheFile default location', () => {
+  let home: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    home = tmpDir();
+    originalHome = process.env.HOME;
+    process.env.HOME = home;
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    cleanup(home);
+  });
+
+  it('clears the cache the backend actually writes', async () => {
+    const secrets = { 'secret/K': 'stale' };
+    // No storeDir — this is the production path, the one that has to match.
+    const first = new CachedBackend(createMockBackend(secrets), { ttlMs: 60_000 });
+    await first.resolve('secret');
+
+    expect(clearCacheFile()).toBe(true);
+
+    secrets['secret/K'] = 'fresh';
+    const inner = createMockBackend(secrets);
+    const second = new CachedBackend(inner, { ttlMs: 60_000 });
+    expect(await second.resolve('secret')).toEqual({ 'secret/K': 'fresh' });
+    expect(inner.resolveCalls).toBe(1);
+  });
+
+  it('also clears the pre-0.12.3 cache left beside the store', () => {
+    const legacyDir = path.join(home, '.secretless-ai', 'store');
+    fs.mkdirSync(legacyDir, { recursive: true, mode: 0o700 });
+    const legacyFile = path.join(legacyDir, '.secret-cache');
+    fs.writeFileSync(legacyFile, Buffer.from('abandoned encrypted credential cache'));
+
+    expect(clearCacheFile()).toBe(true);
+    expect(fs.existsSync(legacyFile)).toBe(false);
   });
 });

--- a/src/backends/cache.ts
+++ b/src/backends/cache.ts
@@ -23,10 +23,79 @@ const SALT_FILE = '.salt';
 interface CacheEntry {
   value: string;
   cachedAt: number; // epoch ms
+  /** Writer stamp — see WRITER_STAMP. Absent on entries written before 0.21.4. */
+  writer?: string;
+  /**
+   * On a prefix marker only: how many entries the resolve that wrote this marker
+   * actually cached. The marker claims "this prefix is fully resolved"; without
+   * the count it cannot tell a complete cache from one whose entries are gone.
+   */
+  count?: number;
 }
 
 interface CacheStore {
   entries: Record<string, CacheEntry>;
+}
+
+/**
+ * Identity of the build that wrote a cache entry. A cached value is only served
+ * back to the same build that produced it.
+ *
+ * A TTL bounds how STALE a value may be; it says nothing about how it was READ.
+ * #107 fixed a read path that corrupted most 32-hex secrets, and the fix changed
+ * no file format at all — so a format-version constant would not have been
+ * bumped, and the corrupted value would still have been served. The build
+ * boundary is the one place a value's provenance actually changes, which makes
+ * it the thing to record (#118).
+ *
+ * Version alone is not the build: a working tree, a global install and an `npx`
+ * unpack can all report the same version while running different code, and the
+ * working tree is where a read path is most likely to be mid-fix. The install
+ * root is folded in (hashed, so no path is written into the file) to separate
+ * them. The cost of that precision is at most one extra unlock prompt when a
+ * user alternates between two installs of the same version; the cost of missing
+ * it is serving a credential read by code we already know was wrong.
+ */
+const WRITER_STAMP: string = computeWriterStamp();
+
+function computeWriterStamp(): string {
+  let version = 'unknown';
+  try {
+    version = String((require('../../package.json') as { version: string }).version);
+  } catch {
+    // Version is unreadable only in an unpacked-wrong install; an "unknown"
+    // stamp is stable within that install and still separates it from a real
+    // one, which is the property that matters.
+  }
+  const root = path.resolve(__dirname, '..', '..');
+  const rootHash = crypto.createHash('sha256').update(root).digest('hex').slice(0, 8);
+  return `${version}+${rootHash}`;
+}
+
+/**
+ * The stamp production actually uses. Exported so a test can assert the default
+ * is derived from the real package version rather than from whatever a test
+ * injected — an injected stamp proves the comparison works, not that the thing
+ * being compared is real.
+ */
+export function defaultWriterStamp(): string {
+  return WRITER_STAMP;
+}
+
+/** Default cache directory. Shared so `clearCacheFile` cannot drift off it. */
+function defaultCacheDir(): string {
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? '/tmp';
+  return path.join(home, '.secretless-ai', 'cache');
+}
+
+/**
+ * Where the cache lived until 0.12.3, alongside the store itself. Still cleared,
+ * because a machine that ran an older build is carrying an encrypted file full
+ * of credential values that nothing reads and nothing expires.
+ */
+function legacyCacheDir(): string {
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? '/tmp';
+  return path.join(home, '.secretless-ai', 'store');
 }
 
 /**
@@ -54,20 +123,28 @@ export class CachedBackend implements WritableSecretBackend {
   private readonly cacheDir: string;
   private readonly encryptionKey: Buffer;
   private readonly ttlMs: number;
+  /**
+   * Overridable ONLY so a test can play two builds against one cache file.
+   * Production never passes it — `defaultWriterStamp` pins the default to the
+   * real package version, so an injected stamp cannot make a broken default
+   * look correct.
+   */
+  private readonly writerStamp: string;
 
   /** In-memory mirror — avoids decrypting the file on every resolve(). */
   private memCache: CacheStore | null = null;
 
   constructor(
     inner: WritableSecretBackend,
-    options?: { ttlMs?: number; storeDir?: string },
+    options?: { ttlMs?: number; storeDir?: string; writerStamp?: string },
   ) {
     this.inner = inner;
     this.name = `cached(${inner.name})`;
     this.ttlMs = options?.ttlMs ?? 5 * 60 * 1000; // default 5 minutes
+    this.writerStamp = options?.writerStamp ?? WRITER_STAMP;
 
     const home = process.env.HOME ?? process.env.USERPROFILE ?? '/tmp';
-    const storeDir = options?.storeDir ?? path.join(home, '.secretless-ai', 'cache');
+    const storeDir = options?.storeDir ?? defaultCacheDir();
     fs.mkdirSync(storeDir, { recursive: true, mode: 0o700 });
     this.cacheDir = storeDir;
     this.cachePath = path.join(storeDir, CACHE_FILENAME);
@@ -77,8 +154,7 @@ export class CachedBackend implements WritableSecretBackend {
     const salt = loadOrCreateCacheSalt(storeDir);
     this.encryptionKey = crypto.scryptSync(keyMaterial, salt, 32, { N: 16384, r: 8, p: 1 });
 
-    // Migration: try to read existing cache with legacy SHA-256 key
-    this.migrateCacheIfNeeded(keyMaterial);
+    this.discardUnreadableCache();
   }
 
   /** Zero the encryption key buffer. Call when the backend is no longer needed. */
@@ -87,37 +163,22 @@ export class CachedBackend implements WritableSecretBackend {
   }
 
   /**
-   * If cache file exists but cannot be decrypted with the new key,
-   * try the legacy SHA-256 key and re-encrypt if successful.
+   * Drop a cache file this build cannot read.
+   *
+   * This used to re-encrypt a cache written under the pre-scrypt SHA-256 key so
+   * its entries survived the key change. That migration is now unreachable by
+   * construction: every entry it recovered was written by an older build, and
+   * `loadCache` drops entries whose writer stamp is not ours — so the recovered
+   * plaintext could never be served. What it did do was keep a second decryption
+   * path over live credential values alive for no observable gain. A cache is
+   * disposable; the whole cost of discarding one is a single unlock prompt.
    */
-  private migrateCacheIfNeeded(keyMaterial: string): void {
+  private discardUnreadableCache(): void {
     if (!fs.existsSync(this.cachePath)) return;
-
     try {
-      const data = fs.readFileSync(this.cachePath);
-      this.decrypt(data);
-      // New key works — no migration needed
+      this.decrypt(fs.readFileSync(this.cachePath));
     } catch {
-      try {
-        const data = fs.readFileSync(this.cachePath);
-        const legacyKey = crypto.createHash('sha256').update(keyMaterial).digest();
-        const iv = data.subarray(0, 16);
-        const tag = data.subarray(16, 32);
-        const ciphertext = data.subarray(32);
-        const decipher = crypto.createDecipheriv('aes-256-gcm', legacyKey, iv);
-        decipher.setAuthTag(tag);
-        const plaintext = decipher.update(ciphertext) + decipher.final('utf-8');
-        legacyKey.fill(0);
-
-        // Re-encrypt with new key
-        const encrypted = this.encrypt(plaintext);
-        const tmpPath = this.cachePath + '.tmp';
-        fs.writeFileSync(tmpPath, encrypted, { mode: 0o600 });
-        fs.renameSync(tmpPath, this.cachePath);
-      } catch {
-        // Neither key works — discard corrupted cache
-        try { fs.unlinkSync(this.cachePath); } catch { /* ignore */ }
-      }
+      try { fs.unlinkSync(this.cachePath); } catch { /* ignore */ }
     }
   }
 
@@ -148,9 +209,20 @@ export class CachedBackend implements WritableSecretBackend {
 
     // If we have a cache marker indicating this prefix was fully resolved,
     // we can trust the cached entries. The marker is the prefix itself.
+    //
+    // The marker's claim is completeness, so it has to carry the count it was
+    // written with. The old condition here was `matchingCached.length >= 0` —
+    // true for every possible value — so a surviving marker over missing entries
+    // reported "fully resolved" and returned {}. That is the worst shape this
+    // class has: `run` would inject NOTHING and still exit 0. Any shortfall is
+    // now a miss.
     const prefixMarker = `__resolved__${secretPath}`;
     const markerEntry = cache.entries[prefixMarker];
-    if (markerEntry && now - markerEntry.cachedAt < this.ttlMs && matchingCached.length >= 0) {
+    if (
+      markerEntry &&
+      now - markerEntry.cachedAt < this.ttlMs &&
+      matchingCached.length === (markerEntry.count ?? -1)
+    ) {
       allCached = true;
       for (const [key, entry] of matchingCached) {
         cachedResults[key] = entry.value;
@@ -165,11 +237,18 @@ export class CachedBackend implements WritableSecretBackend {
     const results = await this.inner.resolve(secretPath);
 
     // Store results in cache
+    let cachedCount = 0;
     for (const [key, value] of Object.entries(results)) {
-      cache.entries[key] = { value, cachedAt: now };
+      cache.entries[key] = { value, cachedAt: now, writer: this.writerStamp };
+      cachedCount++;
     }
     // Mark the prefix as fully resolved
-    cache.entries[prefixMarker] = { value: '', cachedAt: now };
+    cache.entries[prefixMarker] = {
+      value: '',
+      cachedAt: now,
+      writer: this.writerStamp,
+      count: cachedCount,
+    };
 
     this.saveCache(cache);
     return results;
@@ -180,7 +259,7 @@ export class CachedBackend implements WritableSecretBackend {
 
     // Update cache with new value
     const cache = this.loadCache();
-    cache.entries[key] = { value, cachedAt: Date.now() };
+    cache.entries[key] = { value, cachedAt: Date.now(), writer: this.writerStamp };
     // Invalidate prefix markers that cover this key
     this.invalidatePrefixMarkers(cache, key);
     this.saveCache(cache);
@@ -254,10 +333,16 @@ export class CachedBackend implements WritableSecretBackend {
       const decrypted = this.decrypt(encrypted);
       this.memCache = JSON.parse(decrypted) as CacheStore;
 
-      // Evict expired entries on load
+      // Evict on load: too old, or not written by this build.
+      //
+      // Both checks live here, at the single point every read and write goes
+      // through, so no caller can consult a stale entry by taking a different
+      // route. Markers are entries too and are dropped by the same rule — a
+      // marker that outlived its entries is the fail-open described in
+      // resolve().
       const now = Date.now();
       for (const [key, entry] of Object.entries(this.memCache.entries)) {
-        if (now - entry.cachedAt >= this.ttlMs) {
+        if (now - entry.cachedAt >= this.ttlMs || entry.writer !== this.writerStamp) {
           delete this.memCache.entries[key];
         }
       }
@@ -303,19 +388,30 @@ export class CachedBackend implements WritableSecretBackend {
 /**
  * Clear the secret cache file without needing a backend instance.
  * Used by the CLI `cache clear` command.
+ *
+ * The default directory has to be the one `CachedBackend` actually writes to.
+ * It was not: the cache moved to `cache/` in 0.12.3 and this function was left
+ * pointing at `store/`, so from 0.12.3 to 0.21.3 `cache clear` deleted the
+ * abandoned pre-0.12.3 file, printed "Cache cleared", and left every live entry
+ * in place. #118 names `cache clear` as the remedy for a stale cached
+ * credential, which made the one documented workaround a no-op that reported
+ * success. Both paths are cleared now, and both share `CachedBackend`'s own
+ * default so they cannot drift apart again.
  */
 export function clearCacheFile(storeDir?: string): boolean {
-  const home = process.env.HOME ?? process.env.USERPROFILE ?? '/tmp';
-  const dir = storeDir ?? path.join(home, '.secretless-ai', 'store');
-  const cachePath = path.join(dir, CACHE_FILENAME);
+  const dirs = storeDir ? [storeDir] : [defaultCacheDir(), legacyCacheDir()];
 
-  try {
-    if (fs.existsSync(cachePath)) {
-      fs.unlinkSync(cachePath);
-      return true;
+  let removed = false;
+  for (const dir of dirs) {
+    const cachePath = path.join(dir, CACHE_FILENAME);
+    try {
+      if (fs.existsSync(cachePath)) {
+        fs.unlinkSync(cachePath);
+        removed = true;
+      }
+    } catch {
+      // Best effort per path — an unreadable directory must not stop the others.
     }
-    return false;
-  } catch {
-    return false;
   }
+  return removed;
 }

--- a/src/backends/key-index.test.ts
+++ b/src/backends/key-index.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { readKeyIndex } from './key-index';
+
+/**
+ * #104 — the index is the answer to "what secrets exist". An unreadable answer
+ * was returned as an empty one, so `secret list` printed nothing and `run`
+ * injected nothing over a keychain that still held every secret.
+ */
+describe('readKeyIndex fails closed on an unreadable index (#104)', () => {
+  let dir: string;
+  let indexPath: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-index-test-'));
+    indexPath = path.join(dir, 'keychain-index.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns nothing when the index does not exist yet', () => {
+    // The one cause for which the old catch-all was right, and the reason this
+    // cannot simply throw on every failure: a machine with no secrets yet.
+    expect(readKeyIndex(indexPath)).toEqual([]);
+  });
+
+  it('returns the names when the index is readable', () => {
+    fs.writeFileSync(indexPath, JSON.stringify(['secret/A', 'mcp/x/y/B']));
+    expect(readKeyIndex(indexPath)).toEqual(['secret/A', 'mcp/x/y/B']);
+  });
+
+  it('throws on a truncated index instead of reporting no secrets', () => {
+    fs.writeFileSync(indexPath, '["secret/A", "secret/');
+    expect(() => readKeyIndex(indexPath)).toThrow(/could not be read/i);
+  });
+
+  it('throws when the index is not a list', () => {
+    fs.writeFileSync(indexPath, JSON.stringify({ names: ['secret/A'] }));
+    expect(() => readKeyIndex(indexPath)).toThrow(/not a JSON array/);
+  });
+
+  it('throws rather than silently dropping an entry that is not a name', () => {
+    // Filtering the bad element out would lose a secret from every listing —
+    // the same fail-open in a smaller shape.
+    fs.writeFileSync(indexPath, JSON.stringify(['secret/A', 42, 'secret/B']));
+    expect(() => readKeyIndex(indexPath)).toThrow(/not a name/);
+  });
+
+  it('does not put index contents in the error', () => {
+    // The names are the user's; a parse error would quote them.
+    fs.writeFileSync(indexPath, '["secret/PRIVATE_PROJECT_KEY", "secret/');
+    try {
+      readKeyIndex(indexPath);
+      throw new Error('expected readKeyIndex to throw');
+    } catch (err) {
+      expect((err as Error).message).not.toContain('PRIVATE_PROJECT_KEY');
+    }
+  });
+});

--- a/src/backends/key-index.ts
+++ b/src/backends/key-index.ts
@@ -1,0 +1,71 @@
+/**
+ * The name index both OS-keychain backends keep beside the keychain itself.
+ *
+ * The OS keychain has no "list everything this tool stored" query, so the
+ * backends record the names they wrote in a plain JSON array and enumerate from
+ * it. That makes this file the answer to "what secrets exist" — and an
+ * unreadable answer used to be returned as an empty one.
+ *
+ * `catch { return [] }` is correct for exactly one cause, a file that is not
+ * there yet, and wrong for every other. A truncated or malformed index made
+ * `secret list` print nothing, `resolve` return nothing and `run` inject
+ * nothing, all with exit 0, over a keychain that still held every secret (#104).
+ */
+
+import * as fs from 'fs';
+
+function unreadableIndexError(indexPath: string, reason: string): Error {
+  return new Error(
+    [
+      'The secret name index could not be read.',
+      '',
+      '  Nothing was listed. Refusing to report an empty keychain, because an',
+      '  empty index and an unreadable one are not the same thing.',
+      '',
+      `  Index:   ${indexPath}`,
+      `  Reason:  ${reason}`,
+      '',
+      '  Your secrets are in the OS keychain and are untouched. This file only',
+      '  records which names belong to this tool.',
+      '',
+      `  Verify:  cat ${indexPath}`,
+      '  Fix:     repair it — it is a JSON array of names, e.g. ["secret/API_KEY"]',
+      '           or delete it and re-add names with  secretless-ai secret set NAME',
+    ].join('\n'),
+  );
+}
+
+/**
+ * Read the index, or throw.
+ *
+ * Returns [] only when the file does not exist. Every other failure is a state
+ * this function cannot describe, so it does not try.
+ */
+export function readKeyIndex(indexPath: string): string[] {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(indexPath, 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw unreadableIndexError(indexPath, (err as Error).message);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // The parse error quotes the input, and the input is a list of the user's
+    // secret names. Not shown.
+    throw unreadableIndexError(indexPath, 'not valid JSON');
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw unreadableIndexError(indexPath, 'not a JSON array');
+  }
+  // Filtering non-strings out would silently drop a secret from the listing,
+  // which is the same fail-open in a smaller shape.
+  if (!parsed.every((k) => typeof k === 'string')) {
+    throw unreadableIndexError(indexPath, 'contains an entry that is not a name');
+  }
+  return parsed as string[];
+}

--- a/src/backends/keychain-linux.ts
+++ b/src/backends/keychain-linux.ts
@@ -17,6 +17,7 @@ import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { WritableSecretBackend, BackendHealth } from './types';
+import { readKeyIndex } from './key-index';
 
 const LEGACY_SERVICE_NAME = 'secretless';
 const INDEX_FILENAME = 'keychain-index.json';
@@ -160,13 +161,7 @@ export class LinuxKeychainBackend implements WritableSecretBackend {
   }
 
   private readIndex(): string[] {
-    try {
-      const raw = fs.readFileSync(this.indexPath, 'utf-8');
-      const parsed = JSON.parse(raw);
-      return Array.isArray(parsed) ? parsed : [];
-    } catch {
-      return [];
-    }
+    return readKeyIndex(this.indexPath);
   }
 
   private writeIndex(keys: string[]): void {

--- a/src/backends/keychain-macos.test.ts
+++ b/src/backends/keychain-macos.test.ts
@@ -140,18 +140,42 @@ describe('MacOSKeychainBackend', () => {
       expect(result).toEqual({});
     });
 
-    it('skips keys that fail to retrieve', async () => {
+    it('skips keys the Keychain says are absent', async () => {
+      const backend = new MacOSKeychainBackend({ storeDir: dir });
+
+      const indexPath = path.join(dir, 'keychain-index.json');
+      fs.writeFileSync(indexPath, JSON.stringify(['mcp/client/server/KEY1']));
+
+      // 44 is what `security` exits with for "The specified item could not be
+      // found in the keychain". This one really is absent.
+      mockExecFileSync.mockImplementation(() => {
+        throw Object.assign(new Error('item could not be found'), { status: 44 });
+      });
+
+      const result = await backend.resolve('mcp/client/server');
+      expect(result).toEqual({});
+    });
+
+    it('refuses to report a key absent when the Keychain would not answer', async () => {
+      // This test replaces one titled "skips keys that fail to retrieve", which
+      // asserted {} for ANY failure — the fail-open in #104 written down as the
+      // expected behaviour. A locked Keychain, or a dismissed approval dialog,
+      // made every secret read as missing with exit 0.
       const backend = new MacOSKeychainBackend({ storeDir: dir });
 
       const indexPath = path.join(dir, 'keychain-index.json');
       fs.writeFileSync(indexPath, JSON.stringify(['mcp/client/server/KEY1']));
 
       mockExecFileSync.mockImplementation(() => {
-        throw new Error('not found');
+        throw Object.assign(
+          new Error('User interaction is not allowed'),
+          { status: 51 },
+        );
       });
 
-      const result = await backend.resolve('mcp/client/server');
-      expect(result).toEqual({});
+      await expect(backend.resolve('mcp/client/server')).rejects.toThrow(
+        /would not return "mcp\/client\/server\/KEY1"/,
+      );
     });
   });
 
@@ -252,14 +276,39 @@ describe('decodeKeychainValue', () => {
     expect(decodeKeychainValue(encoded, () => true)).toBe('line1\nline2');
   });
 
-  it('fails closed when the encoding cannot be established', () => {
-    // No probe available, and a probe that throws, both leave the value alone.
-    expect(decodeKeychainValue(HEX32_TOKEN, undefined)).toBe(HEX32_TOKEN);
-    expect(
+  it('refuses when the encoding cannot be established', () => {
+    // This test used to be called "fails closed" and asserted the raw value was
+    // returned. Returning the raw value is not failing closed, it is answering
+    // "not encoded" to a question nobody answered — and when the value IS
+    // encoded, that answer hands back the hex transcript of the credential
+    // instead of the credential.
+    expect(() => decodeKeychainValue(HEX32_TOKEN, () => null, 'secret/K'))
+      .toThrow(/Could not determine how the macOS Keychain stored "secret\/K"/);
+    expect(() =>
       decodeKeychainValue(HEX32_TOKEN, () => {
         throw new Error('security unavailable');
-      }),
-    ).toBe(HEX32_TOKEN);
+      }, 'secret/K'),
+    ).toThrow(/Could not determine/);
+  });
+
+  it('does not refuse a value that is not shaped like hex, even when unanswered', () => {
+    // The other direction: an unanswered probe only matters for a value the
+    // probe would have been asked about. Refusing more widely would turn every
+    // read on a locked Keychain into a failure for no gain.
+    expect(decodeKeychainValue('not-hex-at-all', () => null, 'secret/K'))
+      .toBe('not-hex-at-all');
+  });
+
+  it('never puts the value in the refusal', () => {
+    try {
+      decodeKeychainValue(HEX32_TOKEN, () => null, 'secret/K');
+      throw new Error('expected decodeKeychainValue to throw');
+    } catch (err) {
+      const message = (err as Error).message;
+      for (let i = 0; i + 4 <= HEX32_TOKEN.length; i++) {
+        expect(message).not.toContain(HEX32_TOKEN.slice(i, i + 4));
+      }
+    }
   });
 
   it('never probes a value that is not shaped like hex output', () => {
@@ -314,6 +363,9 @@ describe('resolve() hex handling', () => {
       });
       // macOS reports it as plain text (quoted, no 0x), so it must not decode.
       mockSpawnSync.mockReturnValue({
+        // A real successful spawnSync sets status 0. The mock omitted it, and a
+        // probe that cannot report success is a probe that did not complete.
+        status: 0,
         stdout: '',
         stderr: `password: "${HEX32_TOKEN}"`,
       } as unknown as ReturnType<typeof child_process.spawnSync>);
@@ -344,6 +396,9 @@ describe('resolve() hex handling', () => {
         throw new Error('not found');
       });
       mockSpawnSync.mockReturnValue({
+        // A real successful spawnSync sets status 0. The mock omitted it, and a
+        // probe that cannot report success is a probe that did not complete.
+        status: 0,
         stdout: '',
         stderr: `password: 0x${encoded.toUpperCase()}  "line1\\012line2"`,
       } as unknown as ReturnType<typeof child_process.spawnSync>);

--- a/src/backends/keychain-macos.ts
+++ b/src/backends/keychain-macos.ts
@@ -15,6 +15,7 @@ import { execFileSync, spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { WritableSecretBackend, BackendHealth } from './types';
+import { leaksAny, redactValues } from '../redact';
 
 const LEGACY_SERVICE_NAME = 'secretless';
 const INDEX_FILENAME = 'keychain-index.json';
@@ -111,36 +112,16 @@ export function keychainOutputIsHexEncoded(stderrAndStdout: string): boolean {
  * from whatever remains. The final guard is unconditional: if the value can
  * still be found in the message, the message is discarded rather than trimmed.
  */
-/**
- * True if `detail` still contains the whole value, or any individual line of a
- * multi-line value.
- *
- * Defence in depth behind the scrub: `security` can echo part of a value back
- * in a form that no longer matches it byte for byte, and a per-line check
- * catches the fragment the whole-value comparison would miss. Lines shorter
- * than four characters are ignored, or a secret containing a line like "1"
- * would blank every error message the backend ever produces.
- */
-function leaksAnyLineOf(detail: string, value: string): boolean {
-  if (detail.includes(value)) return true;
-  for (const line of value.split('\n')) {
-    const trimmed = line.trim();
-    if (trimmed.length >= 4 && detail.includes(trimmed)) return true;
-  }
-  return false;
-}
-
 export function redactSecurityError(err: unknown, value: string, key: string): Error {
   const raw = err instanceof Error ? err.message : String(err);
+  const values = value.length > 0 ? [value] : [];
 
   // Scrub BEFORE any line filtering. A secret may contain newlines — that is
   // exactly why the read path has to handle hex-encoded values — and dropping
   // lines first can split the value across the boundary, leaving a fragment
   // that no longer matches `value` and so survives both the replace and the
   // containment backstop. Replace it while it is still contiguous.
-  let detail = value.length > 0
-    ? raw.split(value).join('[REDACTED]')
-    : raw;
+  let detail = redactValues(raw, values);
 
   detail = detail
     .split('\n')
@@ -148,10 +129,11 @@ export function redactSecurityError(err: unknown, value: string, key: string): E
     .join('\n')
     .trim();
 
-  // Unconditional backstop, checked against every line the value could have
-  // been split across. Any path that would still expose it loses the detail
-  // instead — a vaguer error is always preferable to a leaked one.
-  if (value.length > 0 && leaksAnyLineOf(detail, value)) {
+  // Unconditional backstop. Any path that would still expose the value loses
+  // the detail instead — a vaguer error is always preferable to a leaked one.
+  // The line-based check this used to run missed escaped and truncated forms;
+  // `leaksAny` works on runs, so it does not. See src/redact.ts.
+  if (leaksAny(detail, values)) {
     detail = '';
   }
 

--- a/src/backends/keychain-macos.ts
+++ b/src/backends/keychain-macos.ts
@@ -15,6 +15,7 @@ import { execFileSync, spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { WritableSecretBackend, BackendHealth } from './types';
+import { readKeyIndex } from './key-index';
 import { leaksAny, redactValues } from '../redact';
 
 const LEGACY_SERVICE_NAME = 'secretless';
@@ -57,33 +58,66 @@ function serviceNameFor(key: string): string {
  * So: take the exact bytes from `-w`, and consult `-g` only when the shape is
  * ambiguous, which leaves the common case at one `security` call.
  *
- * Fails CLOSED on any doubt: if `-g` cannot be read, or does not clearly say
- * `0x`, the raw `-w` value is returned unchanged. Handing back a secret verbatim
- * is always safe; decoding one that was never encoded is the bug being fixed.
+ * There are THREE answers, not two. `-g` can say encoded, say not encoded, or
+ * not complete at all — and the third is not the second. This used to return
+ * the raw `-w` value whenever the probe failed, reasoning that "handing back a
+ * secret verbatim is always safe". That reasoning holds against #107, which was
+ * over-decoding, and fails in the other direction: when the value IS encoded
+ * and the probe cannot say so, the raw value is the hex transcript of the
+ * credential, not the credential. Injecting it is `run` handing a command a
+ * value that is not the stored one, silently, exit 0 — the #104 complaint
+ * exactly.
+ *
+ * So the old rationale is kept as a hazard rather than a rule: never decode on
+ * an unanswered question. This code does not decode. It refuses.
+ *
+ * The refusal is narrow by construction. It needs a value shaped like hex AND a
+ * `-g` that will not complete on an entry `-w` just read successfully — which
+ * on a working machine does not happen.
  */
 function looksLikeKeychainHex(raw: string): boolean {
   return raw.length >= 2 && raw.length % 2 === 0 && /^[0-9a-fA-F]+$/.test(raw);
 }
 
+/**
+ * @param isHexEncoded true / false / null, where null means "could not
+ *   determine". Required, not optional: an omitted probe was a door back to
+ *   guessing, and only tests ever went through it.
+ */
 export function decodeKeychainValue(
   raw: string,
-  isHexEncoded?: () => boolean,
+  isHexEncoded: () => boolean | null,
+  key?: string,
 ): string {
   if (!looksLikeKeychainHex(raw)) return raw;
-  if (!isHexEncoded) return raw;
-  // The probe shells out, so it can throw for reasons that have nothing to do
-  // with this secret (keychain locked, `security` missing, spawn limit). Any of
-  // those must leave the value alone rather than decode on an unanswered
-  // question. Caught here as well as inside the probe: this function is
-  // exported and its contract should not depend on who supplies the callback.
-  let encoded = false;
+
+  let encoded: boolean | null;
   try {
+    // Caught here as well as inside the probe: this function is exported and
+    // its contract should not depend on who supplies the callback.
     encoded = isHexEncoded();
   } catch {
-    return raw;
+    encoded = null;
   }
-  if (!encoded) return raw;
-  return Buffer.from(raw, 'hex').toString('utf-8');
+
+  if (encoded === null) throw undeterminedEncodingError(key);
+  return encoded ? Buffer.from(raw, 'hex').toString('utf-8') : raw;
+}
+
+function undeterminedEncodingError(key?: string): Error {
+  return new Error(
+    [
+      `Could not determine how the macOS Keychain stored ${key ? `"${key}"` : 'this secret'}.`,
+      '',
+      '  Nothing was read. The stored value is shaped like the hex transcript',
+      '  macOS returns for a binary secret, and the check that settles it did not',
+      '  complete. Returned either way, it may not be the value you stored.',
+      '',
+      '  Verify:  security default-keychain',
+      '  Fix:     unlock the login keychain and retry, or run',
+      '           secretless-ai backend set local  to use the encrypted file store',
+    ].join('\n'),
+  );
 }
 
 /**
@@ -161,6 +195,52 @@ export function redactSecurityError(err: unknown, value: string, key: string): E
   return new Error(lines.join('\n'));
 }
 
+/**
+ * macOS `security` exit status for "The specified item could not be found in
+ * the keychain". Measured, not assumed:
+ *
+ *   $ security find-generic-password -s no-such -a no-such -w; echo $?
+ *   security: SecKeychainSearchCopyNext: The specified item could not be found...
+ *   44
+ *
+ * The other statuses this tool can see are a locked or declined Keychain
+ * (-25308 "User interaction is not allowed", -128 "User canceled"), and a usage
+ * error (2). None of those mean the entry is absent.
+ */
+const SECURITY_ITEM_NOT_FOUND = 44;
+
+function isItemNotFound(err: unknown): boolean {
+  return (err as { status?: unknown } | null)?.status === SECURITY_ITEM_NOT_FOUND;
+}
+
+/**
+ * The Keychain would not answer for this entry.
+ *
+ * Carries no `security` output: the failing command is `find-generic-password`,
+ * whose argv holds no value, but its stderr is not ours to reason about and the
+ * entry name says everything the user needs.
+ */
+function keychainUnreadableError(account: string, err: unknown): Error {
+  const status = (err as { status?: unknown } | null)?.status;
+  return new Error(
+    [
+      `The macOS Keychain would not return "${account}".`,
+      '',
+      '  Nothing was read. Refusing to report the secret as missing, because a',
+      '  Keychain that will not answer is not a Keychain without the entry.',
+      '',
+      `  security exit status: ${typeof status === 'number' ? status : 'unknown'}`,
+      '',
+      '  The login keychain is usually locked, or an approval dialog was',
+      '  dismissed or could not be shown.',
+      '',
+      '  Verify:  security default-keychain',
+      '  Fix:     unlock the login keychain and retry, or run',
+      '           secretless-ai backend set local  to use the encrypted file store',
+    ].join('\n'),
+  );
+}
+
 export class MacOSKeychainBackend implements WritableSecretBackend {
   readonly name = 'keychain-macos';
   private readonly indexPath: string;
@@ -235,7 +315,7 @@ export class MacOSKeychainBackend implements WritableSecretBackend {
       }
       if (raw !== null) {
         const from = service;
-        results[key] = decodeKeychainValue(raw, () => this.isHexEncoded(from, key));
+        results[key] = decodeKeychainValue(raw, () => this.isHexEncoded(from, key), key);
       }
     }
     return results;
@@ -300,9 +380,13 @@ export class MacOSKeychainBackend implements WritableSecretBackend {
    * `-g` password line. Only called when `-w` output is ambiguously shaped.
    *
    * `-g` prints the password line to STDERR, so both streams are captured.
-   * Any failure returns false, which leaves the value undecoded.
+   *
+   * Returns null for "could not determine". A non-zero exit means `security`
+   * did not answer the question — it did not answer "no". Reading a failed
+   * probe as "not encoded" is how a binary secret came back as its own hex
+   * transcript, with nothing to indicate it.
    */
-  private isHexEncoded(service: string, account: string): boolean {
+  private isHexEncoded(service: string, account: string): boolean | null {
     try {
       const res = spawnSync('security', [
         'find-generic-password',
@@ -310,13 +394,27 @@ export class MacOSKeychainBackend implements WritableSecretBackend {
         '-a', account,
         '-g',
       ], { encoding: 'utf-8' });
-      if (res.error) return false;
+      if (res.error) return null;
+      if (res.status !== 0) return null;
       return keychainOutputIsHexEncoded(`${res.stderr ?? ''}\n${res.stdout ?? ''}`);
     } catch {
-      return false;
+      return null;
     }
   }
 
+  /**
+   * The stored value, or null when the entry genuinely is not there.
+   *
+   * `catch { return null }` conflated "no such entry" with "could not read this
+   * entry", and the second is the one that matters: a locked Keychain, or a
+   * dismissed approval dialog, made every secret read as absent. `resolve`
+   * returned {}, `run` injected nothing, exit 0 — over a Keychain holding every
+   * credential (#104).
+   *
+   * Measured on macOS: `security` exits 44 for "The specified item could not be
+   * found in the keychain". Only 44 is absence; every other status is a
+   * question we did not get an answer to.
+   */
   private findPassword(service: string, account: string): string | null {
     try {
       return execFileSync('security', [
@@ -325,19 +423,14 @@ export class MacOSKeychainBackend implements WritableSecretBackend {
         '-a', account,
         '-w',
       ], { stdio: ['pipe', 'pipe', 'pipe'], encoding: 'utf-8' }).trimEnd();
-    } catch {
-      return null;
+    } catch (err) {
+      if (isItemNotFound(err)) return null;
+      throw keychainUnreadableError(account, err);
     }
   }
 
   private readIndex(): string[] {
-    try {
-      const raw = fs.readFileSync(this.indexPath, 'utf-8');
-      const parsed = JSON.parse(raw);
-      return Array.isArray(parsed) ? parsed : [];
-    } catch {
-      return [];
-    }
+    return readKeyIndex(this.indexPath);
   }
 
   private writeIndex(keys: string[]): void {

--- a/src/backends/local.test.ts
+++ b/src/backends/local.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { LocalBackend } from './local';
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-local-test-'));
+}
+
+const KEY = 'fixed-test-key-material';
+
+function backend(dir: string): LocalBackend {
+  return new LocalBackend({ storeDir: dir, key: KEY });
+}
+
+/** A store file this build cannot decrypt, in the place the real one lives. */
+function corruptStore(dir: string): string {
+  const storePath = path.join(dir, 'secrets.enc');
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(storePath, Buffer.from('not a valid aes-256-gcm payload at all'));
+  return storePath;
+}
+
+/**
+ * #104 §1 — an unreadable store read as an empty one. Exit 0, empty stderr, and
+ * every consumer downstream believing the machine has no secrets.
+ */
+describe('LocalBackend fails closed on an unreadable store (#104)', () => {
+  let dir: string;
+
+  beforeEach(() => { dir = tmpDir(); });
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+  it('resolve throws instead of reporting no secrets', async () => {
+    corruptStore(dir);
+    await expect(backend(dir).resolve('secret')).rejects.toThrow(/could not be decrypted/i);
+  });
+
+  it('resolve still returns nothing when there genuinely is no store', async () => {
+    // The other direction. A backend that throws unconditionally would satisfy
+    // every test above this one while making a first run impossible.
+    expect(await backend(dir).resolve('secret')).toEqual({});
+  });
+
+  it('resolve returns stored secrets when the store is readable', async () => {
+    const b = backend(dir);
+    await b.store('secret/A', 'value-a');
+    await b.store('secret/B', 'value-b');
+    expect(await backend(dir).resolve('secret')).toEqual({
+      'secret/A': 'value-a',
+      'secret/B': 'value-b',
+    });
+  });
+
+  it('store refuses to write over a store it could not read', async () => {
+    const storePath = corruptStore(dir);
+    const before = fs.readFileSync(storePath);
+
+    await expect(backend(dir).store('secret/NEW', 'v')).rejects.toThrow(/could not be decrypted/i);
+
+    // The failure mode this replaces was not a bad error message. It was
+    // "Stored: NEW", exit 0, and every other secret gone.
+    expect(fs.readFileSync(storePath).equals(before)).toBe(true);
+  });
+
+  it('delete throws rather than claiming the secret was not there', async () => {
+    corruptStore(dir);
+    await expect(backend(dir).delete('secret/A')).rejects.toThrow(/could not be decrypted/i);
+  });
+
+  it('delete still reports false for a secret that really is absent', async () => {
+    const b = backend(dir);
+    await b.store('secret/A', 'value-a');
+    expect(await b.delete('secret/MISSING')).toBe(false);
+    expect(await b.delete('secret/A')).toBe(true);
+  });
+
+  it('healthCheck reports unhealthy for a store it cannot decrypt', async () => {
+    corruptStore(dir);
+    const health = await backend(dir).healthCheck();
+    // The check was `fs.existsSync(storePath)`, so the one state it needed to
+    // catch — a store that is there and unreadable — was the state it called
+    // healthy.
+    expect(health.healthy).toBe(false);
+  });
+
+  it('healthCheck reports healthy for a store it can decrypt', async () => {
+    const b = backend(dir);
+    await b.store('secret/A', 'value-a');
+    expect((await backend(dir).healthCheck()).healthy).toBe(true);
+  });
+
+  it('never puts store contents in the error, even when they decrypt', async () => {
+    // A store that decrypts to something that is not JSON. `JSON.parse` quotes
+    // the input it failed on, and the input here is the decrypted store — so
+    // reporting the parse error verbatim writes secret material into an error
+    // message. Same class as #117, reached through the integrity fix.
+    const b = backend(dir);
+    await b.store('secret/A', 'x');
+    // Re-encrypt a non-JSON plaintext under the same key by going through the
+    // backend's own writer, then corrupting the plaintext it wrote.
+    //
+    // Node quotes only the FIRST TEN characters of what it choked on:
+    //   Unexpected token 's', "sk-live-NO"... is not valid JSON
+    // so an assertion on a marker further into the string passes over a message
+    // displaying the head of the credential. Measured, and it is why the check
+    // below is on runs of the fixture rather than on chosen substrings.
+    const plaintext = 'sk-live-QQ7ZX9WKPV4RJT2MHB6NDY8FGC3L';
+    const enc = (b as unknown as { encrypt(s: string): Buffer }).encrypt(plaintext);
+    fs.writeFileSync(path.join(dir, 'secrets.enc'), enc);
+
+    const err = await backend(dir).resolve('secret').then(
+      () => null,
+      (e: Error) => e,
+    );
+    expect(err).not.toBeNull();
+    for (let i = 0; i + 4 <= plaintext.length; i++) {
+      expect(err!.message).not.toContain(plaintext.slice(i, i + 4));
+    }
+    expect(err!.message).toMatch(/not valid JSON/);
+  });
+});
+
+/**
+ * #104 §1 — "the CLI should detect a vault or entry format version it cannot
+ * handle and fail closed". The version was written on every store and compared
+ * nowhere.
+ */
+describe('LocalBackend store format version (#104)', () => {
+  let dir: string;
+
+  beforeEach(() => { dir = tmpDir(); });
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+  it('stamps the format version on write, so there is something to check', async () => {
+    await backend(dir).store('secret/A', 'value-a');
+    const meta = JSON.parse(fs.readFileSync(path.join(dir, 'secrets.meta.json'), 'utf-8'));
+    expect(meta.version).toBe('1');
+  });
+
+  it('refuses to read a store written in a newer format', async () => {
+    const b = backend(dir);
+    await b.store('secret/A', 'value-a');
+
+    const metaPath = path.join(dir, 'secrets.meta.json');
+    const meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+    meta.version = '2';
+    fs.writeFileSync(metaPath, JSON.stringify(meta));
+
+    // Decryption would succeed here. That is the point: a format this build does
+    // not know decodes to bytes that are not the stored value, and nothing
+    // downstream can tell.
+    await expect(backend(dir).resolve('secret')).rejects.toThrow(/version 2/);
+  });
+
+  it('reads a store that predates the metadata file', async () => {
+    // Absent metadata is not a mismatch — a store carried over from a build that
+    // never wrote one is fine, and failing closed on it would lock users out of
+    // their own secrets on upgrade.
+    const b = backend(dir);
+    await b.store('secret/A', 'value-a');
+    fs.unlinkSync(path.join(dir, 'secrets.meta.json'));
+
+    expect(await backend(dir).resolve('secret')).toEqual({ 'secret/A': 'value-a' });
+  });
+});

--- a/src/backends/local.ts
+++ b/src/backends/local.ts
@@ -6,9 +6,71 @@ import type { WritableSecretBackend, BackendHealth } from './types';
 const STORE_FILE = 'secrets.enc';
 const META_FILE = 'secrets.meta.json';
 
+/**
+ * Store format this build can read. Written into the metadata on every write
+ * and checked on every read.
+ *
+ * The check has always been the point of recording a version, and it was never
+ * made: `version: '1'` was stamped and never compared, so a store written in a
+ * format this build does not understand would be decrypted, parsed as whatever
+ * it happened to parse as, and served with exit 0 (#104). A version that is
+ * never read is not a version, it is a comment.
+ */
+const SUPPORTED_STORE_VERSION = '1';
+
 interface StoreMeta {
   version: string;
   entries: Record<string, { createdAt: string }>;
+}
+
+/**
+ * The store exists and this build cannot read it.
+ *
+ * Returning "no secrets" here is the failure #104 describes: every consumer
+ * downstream — `run`, `status`, `verify`, a manifest check — reads an empty
+ * store as a store with nothing in it, and reports success over a credential
+ * set it never saw. There is no safe guess, so there is no guess.
+ */
+function unreadableStoreError(storePath: string, detail: string): Error {
+  return new Error(
+    [
+      'The local secret store could not be decrypted.',
+      '',
+      '  Nothing was read. Refusing to report an empty store, because an empty',
+      '  store and an unreadable one are not the same thing.',
+      '',
+      `  Store:   ${storePath}`,
+      `  Reason:  ${detail}`,
+      '',
+      '  The encryption key is derived from your home directory and username, so',
+      '  this is usually a store written under a different account, or copied',
+      '  from another machine.',
+      '',
+      // Not `doctor`: it reports on shell profiles and env vars and would say
+      // nothing at all about this. The two inputs to the key are what a user
+      // can actually check, and a changed HOME is the common cause (sudo, a
+      // container, a renamed account).
+      '  Verify:  printf \'%s %s\\n\' "$HOME" "$USER"   (the key derives from these)',
+      '  Fix:     run under the account that wrote the store — or start a new one:',
+      '           secretless-ai backend set keychain   (then re-add your secrets)',
+    ].join('\n'),
+  );
+}
+
+/** The store is readable but written in a format this build does not know. */
+function unsupportedStoreVersionError(found: string): Error {
+  return new Error(
+    [
+      `The local secret store is version ${found}; this build reads version ${SUPPORTED_STORE_VERSION}.`,
+      '',
+      '  Nothing was read. A newer store format decoded by an older build returns',
+      '  bytes that are not the stored value, and every consumer downstream',
+      '  believes them.',
+      '',
+      '  Verify:  secretless-ai --version',
+      '  Fix:     npm install -g secretless-ai@latest',
+    ].join('\n'),
+  );
 }
 
 const SALT_FILE = '.salt';
@@ -115,37 +177,100 @@ export class LocalBackend implements WritableSecretBackend {
     }
   }
 
-  async resolve(secretPath: string): Promise<Record<string, string>> {
+  /**
+   * Read and decrypt the store.
+   *
+   * The single read path, so no caller can reach the contents by a route that
+   * treats a failure differently. Absent is `{}` — a machine with no secrets yet
+   * is a real, healthy state. Present-but-unreadable throws.
+   */
+  private readStore(): Record<string, string> {
     const storePath = path.join(this.storeDir, STORE_FILE);
     if (!fs.existsSync(storePath)) return {};
 
-    try {
-      const encrypted = fs.readFileSync(storePath);
-      const decrypted = this.decrypt(encrypted);
-      const store = JSON.parse(decrypted);
-
-      // Empty prefix returns all secrets; otherwise match exact key or prefix/
-      const results: Record<string, string> = {};
-      for (const [key, value] of Object.entries(store)) {
-        if (!secretPath || key === secretPath || key.startsWith(secretPath + '/')) {
-          results[key] = value as string;
-        }
-      }
-      return results;
-    } catch {
-      return {};
+    // Version first: a store this build cannot interpret must not be decoded on
+    // the chance that it parses.
+    const version = this.readStoreVersion();
+    if (version !== null && version !== SUPPORTED_STORE_VERSION) {
+      throw unsupportedStoreVersionError(version);
     }
+
+    // Decrypt and parse are separated so the `Reason` line can quote one and
+    // never the other. A cipher error describes the ciphertext and is safe to
+    // show; `JSON.parse` quotes the input it choked on, and here that input is
+    // the decrypted store — so a malformed store would print secret material
+    // into an error message, which is the #117 class arriving by another door.
+    let plaintext: string;
+    try {
+      plaintext = this.decrypt(fs.readFileSync(storePath));
+    } catch (err) {
+      throw unreadableStoreError(storePath, err instanceof Error ? err.message : String(err));
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(plaintext);
+    } catch {
+      throw unreadableStoreError(storePath, 'decrypted contents are not valid JSON');
+    }
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw unreadableStoreError(storePath, 'decrypted contents are not a secret map');
+    }
+    return parsed as Record<string, string>;
+  }
+
+  /**
+   * Store format version, or null when there is no metadata to read.
+   *
+   * Null is not a mismatch: metadata is only written on `store()`, so a store
+   * carried over from a build that never wrote it has none. Treating that as a
+   * mismatch would fail closed on a store that is fine.
+   */
+  private readStoreVersion(): string | null {
+    const metaPath = path.join(this.storeDir, META_FILE);
+    if (!fs.existsSync(metaPath)) return null;
+    try {
+      const meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8')) as Partial<StoreMeta>;
+      return typeof meta.version === 'string' ? meta.version : null;
+    } catch {
+      // Unparseable metadata says nothing about the store's format. The store
+      // itself is the thing that has to decrypt, and it is checked next.
+      return null;
+    }
+  }
+
+  async resolve(secretPath: string): Promise<Record<string, string>> {
+    const store = this.readStore();
+
+    // Empty prefix returns all secrets; otherwise match exact key or prefix/
+    const results: Record<string, string> = {};
+    for (const [key, value] of Object.entries(store)) {
+      if (!secretPath || key === secretPath || key.startsWith(secretPath + '/')) {
+        results[key] = value as string;
+      }
+    }
+    return results;
   }
 
   async healthCheck(): Promise<BackendHealth> {
     const start = Date.now();
     const storePath = path.join(this.storeDir, STORE_FILE);
-    const exists = fs.existsSync(storePath);
-    return {
-      healthy: exists,
-      latencyMs: Date.now() - start,
-      message: exists ? 'Local store available' : 'No local store found',
-    };
+    if (!fs.existsSync(storePath)) {
+      return { healthy: false, latencyMs: Date.now() - start, message: 'No local store found' };
+    }
+    // Presence was the whole check, so `doctor` and `verify` called a store
+    // healthy on the strength of a file existing — including the store they
+    // could not decrypt, which is the one case the check exists to catch.
+    try {
+      this.readStore();
+    } catch (err) {
+      return {
+        healthy: false,
+        latencyMs: Date.now() - start,
+        message: err instanceof Error ? err.message.split('\n')[0] : 'Local store unreadable',
+      };
+    }
+    return { healthy: true, latencyMs: Date.now() - start, message: 'Local store available' };
   }
 
   /** Store a secret locally */
@@ -153,16 +278,11 @@ export class LocalBackend implements WritableSecretBackend {
     fs.mkdirSync(this.storeDir, { recursive: true, mode: 0o700 });
 
     const storePath = path.join(this.storeDir, STORE_FILE);
-    let store: Record<string, string> = {};
-
-    if (fs.existsSync(storePath)) {
-      try {
-        const encrypted = fs.readFileSync(storePath);
-        store = JSON.parse(this.decrypt(encrypted));
-      } catch {
-        // Corrupted store — start fresh
-      }
-    }
+    // "Corrupted store — start fresh" used to sit here, swallowing the read
+    // failure and writing a one-entry store over the top. Storing one secret
+    // silently deleted every other one, and the command printed "Stored: NAME"
+    // and exited 0. A write is the worst possible moment to guess.
+    const store: Record<string, string> = this.readStore();
 
     store[key] = value;
     const encrypted = this.encrypt(JSON.stringify(store));
@@ -172,13 +292,18 @@ export class LocalBackend implements WritableSecretBackend {
 
     // Update metadata
     const metaPath = path.join(this.storeDir, META_FILE);
-    let meta: StoreMeta = { version: '1', entries: {} };
+    let meta: StoreMeta = { version: SUPPORTED_STORE_VERSION, entries: {} };
     try {
       if (fs.existsSync(metaPath)) {
         meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
       }
     } catch { /* ignore */ }
 
+    // This build just wrote the store, so this build's format is what it is in.
+    // Carrying forward whatever the file said would let an unstamped store stay
+    // unstamped forever, and the version check has nothing to read.
+    meta.version = SUPPORTED_STORE_VERSION;
+    meta.entries = meta.entries ?? {};
     meta.entries[key] = { createdAt: new Date().toISOString() };
     const tmpMetaPath = metaPath + '.tmp';
     fs.writeFileSync(tmpMetaPath, JSON.stringify(meta, null, 2), { mode: 0o600 });
@@ -190,13 +315,10 @@ export class LocalBackend implements WritableSecretBackend {
     const storePath = path.join(this.storeDir, STORE_FILE);
     if (!fs.existsSync(storePath)) return false;
 
-    let store: Record<string, string> = {};
-    try {
-      const encrypted = fs.readFileSync(storePath);
-      store = JSON.parse(this.decrypt(encrypted));
-    } catch {
-      return false;
-    }
+    // `false` here means "there was no such secret", and an unreadable store
+    // cannot support that claim. `secret rm` reported the entry gone while it
+    // sat in the store untouched.
+    const store: Record<string, string> = this.readStore();
 
     if (!(key in store)) return false;
 

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import { SecretStore } from '../secret-store';
 import { getShellHookLine, SHELL_HOOK_MARKER } from '../env';
 import { CLI, CLI_BARE } from './utils';
+import { describeSecretShape } from '../secret-value';
 
 /**
  * Ensure the shell profile has the eval hook for auto-loading secrets.
@@ -76,7 +77,9 @@ export async function runSecret(args: string[]): Promise<number> {
         const store = new SecretStore();
         try {
           await store.setSecret(name, value);
-          console.log(`  Stored: ${name}`);
+          // Shape, never content. A capture that lost most of the value reads
+          // as "19 chars" next to a token the user knows is 40 (#104).
+          console.log(`  Stored: ${name} (${describeSecretShape(value)})`);
           ensureShellHook();
           return 0;
         } catch (err) {
@@ -102,7 +105,7 @@ export async function runSecret(args: string[]): Promise<number> {
       const store = new SecretStore();
       try {
         await store.setSecret(name, value);
-        console.log(`  Stored: ${name}`);
+        console.log(`  Stored: ${name} (${describeSecretShape(value)})`);
         ensureShellHook();
         return 0;
       } catch (err) {

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -1,0 +1,84 @@
+/**
+ * Keeping secret values out of error messages.
+ *
+ * Error messages are the tool's own worst leak surface: they are printed to
+ * stderr, stderr is what CI captures, and a failing command is exactly what a
+ * user pastes into a chat window to ask why it failed. Every path that holds a
+ * resolved secret and can throw goes through here.
+ *
+ * The hard part is not the scrub, it is the detector. Runtimes do not embed a
+ * value verbatim — they escape it and they truncate it. Measured against the
+ * two throws this tool actually hits:
+ *
+ *   spawn, value containing a NUL byte
+ *     Received 'sk-fake-DEADBEEF\x00-tail'      <- \x00 is four literal chars
+ *   spawn, value longer than ~120 chars
+ *     Received 'sk-live-AAAA...'                <- truncated, then "..."
+ *   JSON.parse of a decrypted store
+ *     Unexpected token 's', "sk-live-NO"... is not valid JSON
+ *
+ * In ALL of those, `message.includes(value)` is false. A detector built on
+ * whole-value containment reports "no leak" over a message displaying most of
+ * the credential, and a redactor built on whole-value replacement replaces
+ * nothing. So the detector works on RUNS: any window of the value long enough
+ * to matter, appearing anywhere in the text, is a leak.
+ *
+ * When the detector fires, the detail is dropped rather than trimmed. A partial
+ * scrub is the failure mode, not the fix — the residue is what leaks.
+ */
+
+/**
+ * Shortest run of a secret's own characters that counts as a leak.
+ *
+ * Four, matching the floor the Keychain backend has used since #108. Below it,
+ * a secret containing a common fragment would blank every message the tool
+ * produces. Above it, a truncated value gets through. A false positive here
+ * costs a vaguer error; a false negative costs the credential.
+ */
+const MIN_LEAK_RUN = 4;
+
+/**
+ * True if `text` still exposes any of `values` — whole, escaped, or truncated.
+ *
+ * Whole-value containment is checked first and at any length, so a secret
+ * shorter than the run floor is still caught outright.
+ */
+export function leaksAny(text: string, values: readonly string[]): boolean {
+  if (!text) return false;
+  for (const value of values) {
+    if (!value) continue;
+    if (text.includes(value)) return true;
+    for (let i = 0; i + MIN_LEAK_RUN <= value.length; i++) {
+      if (text.includes(value.slice(i, i + MIN_LEAK_RUN))) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Replace whole occurrences of each value with `[REDACTED]`.
+ *
+ * Longest first: a shorter secret that happens to be a substring of a longer
+ * one would otherwise cut the longer one in half and leave both fragments.
+ * This is the cheap pass that keeps ordinary messages readable; `scrubOrDrop`
+ * is what makes the result safe.
+ */
+export function redactValues(text: string, values: readonly string[]): string {
+  let out = text;
+  for (const value of [...values].filter(Boolean).sort((a, b) => b.length - a.length)) {
+    out = out.split(value).join('[REDACTED]');
+  }
+  return out;
+}
+
+/**
+ * Scrub `text`, and return '' if anything survives.
+ *
+ * The empty string is the signal that there is no safe detail to show. Callers
+ * keep their own framing — which names the secret and what to do — and simply
+ * omit the underlying message.
+ */
+export function scrubOrDrop(text: string, values: readonly string[]): string {
+  const scrubbed = redactValues(text, values);
+  return leaksAny(scrubbed, values) ? '' : scrubbed;
+}

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -126,3 +126,134 @@ describe('runWithSecrets --only (issue #110) — must not run short or empty', (
     expect(code).toBe(0);
   });
 });
+
+/**
+ * #117 — `run` printed a secret value to stderr. Node rejects an environment
+ * value containing a null byte and puts the value in the message; the throw is
+ * synchronous, so `child.on('error')` never saw it and it went out unredacted.
+ * stderr is what CI logs capture.
+ *
+ * Every assertion here is on the string AS SENT to stderr. Asserting on the
+ * error object would test a different string than the one that leaks.
+ */
+describe('run never writes a secret value to stderr (#117)', () => {
+  let tmpDir: string;
+  let backend: LocalBackend;
+  let written: string;
+  let restore: (() => void) | null = null;
+
+  const NUL = String.fromCharCode(0);
+  // High-entropy and dictionary-free, so a 4-character run of it appearing in
+  // the output means the value leaked, not that English happened.
+  const SECRET = 'sk-live-QQ7ZX9WKPV4RJT2MHB6NDY8FGC3L' + NUL + 'ZZTAIL';
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-run-117-'));
+    backend = new LocalBackend({ storeDir: tmpDir, key: 'test-key' });
+    written = '';
+    const original = process.stderr.write.bind(process.stderr);
+    (process.stderr as unknown as { write: unknown }).write = (chunk: unknown, ...rest: unknown[]) => {
+      written += String(chunk);
+      return (original as (...a: unknown[]) => boolean)(chunk, ...rest);
+    };
+    restore = () => { (process.stderr as unknown as { write: unknown }).write = original; };
+  });
+
+  afterEach(() => {
+    if (restore) restore();
+    restore = null;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /** Any run of the value long enough to identify it, in any escaping. */
+  function exposesSecret(text: string): boolean {
+    if (text.includes(SECRET)) return true;
+    for (let i = 0; i + 4 <= SECRET.length; i++) {
+      if (text.includes(SECRET.slice(i, i + 4))) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Everything this command puts on stderr — including a throw that escapes
+   * `run`, because `cli.ts` prints `err.message` to stderr and that is the
+   * shape the defect took. Folding it in is what makes these tests fail on
+   * their own assertion rather than on an unhandled rejection, which would
+   * report a crash and never check what leaked.
+   */
+  async function stderrOf(
+    cmd: string, cmdArgs: string[],
+  ): Promise<{ code: number | null; stderr: string }> {
+    try {
+      const code = await runWithSecrets(cmd, cmdArgs, { backend });
+      return { code, stderr: written };
+    } catch (err) {
+      return { code: null, stderr: written + (err instanceof Error ? err.message : String(err)) };
+    }
+  }
+
+  it('refuses to run and prints no part of the value', async () => {
+    const store = new SecretStore({ backend });
+    await store.setSecret('HIBP_PRO', SECRET);
+
+    const marker = path.join(tmpDir, 'child-ran');
+    const { code, stderr } = await stderrOf(
+      'node', ['-e', `require('fs').writeFileSync(${JSON.stringify(marker)}, 'ran')`],
+    );
+
+    expect(exposesSecret(stderr)).toBe(false);
+    // Not merely absent — the escaped form Node would have printed is absent too.
+    expect(stderr).not.toContain('\\x00');
+    expect(stderr).not.toContain('QQ7ZX9');
+
+    expect(code).toBe(1);
+    // Fail closed: a command that runs a credential short surfaces later as an
+    // auth error that never mentions secretless.
+    expect(fs.existsSync(marker)).toBe(false);
+
+    // And it still tells the user what to do about it.
+    expect(stderr).toContain('HIBP_PRO');
+    expect(stderr).toContain('secretless-ai secret set HIBP_PRO');
+  });
+
+  it('names every unusable secret, not just the first one Node reaches', async () => {
+    const store = new SecretStore({ backend });
+    await store.setSecret('ALPHA', 'aa' + NUL);
+    await store.setSecret('BETA', 'bb' + NUL);
+    await store.setSecret('FINE', 'ordinary-value');
+
+    const { code, stderr } = await stderrOf('node', ['-e', 'process.exit(0)']);
+    expect(stderr).toContain('ALPHA');
+    expect(stderr).toContain('BETA');
+    expect(code).toBe(1);
+  });
+
+  it('CONTROL: an ordinary secret still runs and is injected', async () => {
+    // Without this, refusing every run would satisfy the tests above.
+    const store = new SecretStore({ backend });
+    await store.setSecret('OK_SECRET', 'sk-live-QQ7ZX9WKPV4RJT2MHB6NDY8FGC3L');
+
+    const code = await runWithSecrets(
+      'node', ['-e', 'process.exit(process.env.OK_SECRET === "sk-live-QQ7ZX9WKPV4RJT2MHB6NDY8FGC3L" ? 0 : 3)'],
+      { backend },
+    );
+    expect(code).toBe(0);
+    expect(written).toBe('');
+  });
+
+  it('withholds a spawn failure that carries the value rather than trimming it', async () => {
+    // The catch-all, exercised on a value Node accepts so the pre-check does not
+    // fire: what has to hold is that the detail is dropped whole, never
+    // half-scrubbed. A residue is a leak.
+    const store = new SecretStore({ backend });
+    const value = 'sk-live-QQ7ZX9WKPV4RJT2MHB6NDY8FGC3L';
+    await store.setSecret('TOKEN', value);
+
+    const code = await runWithSecrets(
+      `no-such-command-${value}`, [], { backend },
+    );
+    expect(code).toBe(1);
+    expect(written).not.toContain(value);
+    expect(written).not.toContain('QQ7ZX9');
+  });
+});

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -193,8 +193,12 @@ describe('run never writes a secret value to stderr (#117)', () => {
   }
 
   it('refuses to run and prints no part of the value', async () => {
-    const store = new SecretStore({ backend });
-    await store.setSecret('HIBP_PRO', SECRET);
+    // Written straight to the backend, not via setSecret, because setSecret now
+    // refuses this value (#104). That is the realistic path anyway: a
+    // null-bearing value reaches the store from a backend read — macOS returns
+    // binary passwords hex-encoded and they decode to bytes containing 0x00 —
+    // or from a store an older build wrote.
+    await backend.store('secret/HIBP_PRO', SECRET);
 
     const marker = path.join(tmpDir, 'child-ran');
     const { code, stderr } = await stderrOf(
@@ -217,10 +221,9 @@ describe('run never writes a secret value to stderr (#117)', () => {
   });
 
   it('names every unusable secret, not just the first one Node reaches', async () => {
-    const store = new SecretStore({ backend });
-    await store.setSecret('ALPHA', 'aa' + NUL);
-    await store.setSecret('BETA', 'bb' + NUL);
-    await store.setSecret('FINE', 'ordinary-value');
+    await backend.store('secret/ALPHA', 'aa' + NUL);
+    await backend.store('secret/BETA', 'bb' + NUL);
+    await backend.store('secret/FINE', 'ordinary-value');
 
     const { code, stderr } = await stderrOf('node', ['-e', 'process.exit(0)']);
     expect(stderr).toContain('ALPHA');

--- a/src/run.ts
+++ b/src/run.ts
@@ -6,8 +6,10 @@
  */
 
 import { spawn } from 'child_process';
+import type { ChildProcess } from 'child_process';
 import { SecretStore } from './secret-store';
 import type { SecretStoreOptions } from './secret-store';
+import { leaksAny, scrubOrDrop } from './redact';
 
 export interface RunOptions extends SecretStoreOptions {
   /** Only inject these specific secret names. If undefined, inject all. */
@@ -51,10 +53,41 @@ export async function runWithSecrets(
 
   const childEnv = { ...process.env, ...secrets };
 
-  const child = spawn(command, args, {
-    env: childEnv,
-    stdio: 'inherit',
-  });
+  // Refuse a value the child environment cannot carry, BEFORE handing it to
+  // Node — because Node's own refusal prints the value.
+  //
+  // `ERR_INVALID_ARG_VALUE` embeds what it rejected: "must be a string without
+  // null bytes. Received 'sk-live-...'". The throw is synchronous, so the
+  // `child.on('error')` handler below is never reached and the message goes
+  // straight to the top-level handler and out to stderr — which is what CI
+  // logs capture (#117). A NUL-bearing value is not exotic: macOS returns some
+  // passwords hex-encoded precisely because they are binary, and the local
+  // backend imposes no constraint at all.
+  //
+  // Checking first also lets the error name every offending secret rather than
+  // whichever one Node reached first, and name only the NAME.
+  const unusable = Object.keys(secrets).filter(
+    (name) => name.includes('\0') || secrets[name].includes('\0'),
+  );
+  if (unusable.length > 0) {
+    process.stderr.write(unusableSecretMessage(unusable));
+    return 1;
+  }
+
+  let child: ChildProcess;
+  try {
+    child = spawn(command, args, {
+      env: childEnv,
+      stdio: 'inherit',
+    });
+  } catch (err) {
+    // The check above covers what this version of Node rejects today. This
+    // covers what it rejects tomorrow, on another platform, or for a reason
+    // nobody anticipated — with every resolved value scrubbed out, and the
+    // whole detail dropped if any survives.
+    process.stderr.write(spawnFailureMessage(command, err, Object.values(secrets)));
+    return 1;
+  }
 
   // Forward signals to child
   const signals: NodeJS.Signals[] = ['SIGTERM', 'SIGINT', 'SIGHUP'];
@@ -75,11 +108,70 @@ export async function runWithSecrets(
     });
 
     child.on('error', (err) => {
-      process.stderr.write(`secretless: Failed to start ${command}: ${err.message}\n`);
+      // Same redaction as the synchronous path. This message has never been
+      // observed carrying a value, but "has not been observed" is not a
+      // property of the error, and both paths print to the same stderr.
+      process.stderr.write(spawnFailureMessage(command, err, Object.values(secrets)));
       for (let i = 0; i < signals.length; i++) {
         process.removeListener(signals[i], handlers[i]);
       }
       resolve(1);
     });
   });
+}
+
+/**
+ * Names the secrets that cannot be passed, and nothing else about them.
+ *
+ * The name is safe — `secret list` prints it, and the Verify line points there.
+ * The value is the thing being protected, so it is not shown, not summarised,
+ * and not counted in bytes.
+ */
+function unusableSecretMessage(names: string[]): string {
+  const plural = names.length === 1 ? '' : 's';
+  return [
+    `secretless: ${names.join(', ')} cannot be passed in an environment variable.`,
+    '',
+    `  The stored value${plural} contain${names.length === 1 ? 's' : ''} a null byte. Nothing was injected and the`,
+    '  command was not run.',
+    '',
+    '  This is usually a value that was mangled when it was stored — a paste that',
+    '  captured terminal escape sequences, or a binary value read back as text.',
+    '',
+    '  Verify:  secretless-ai secret list',
+    `  Fix:     secretless-ai secret set ${names[0]}`,
+    '',
+  ].join('\n');
+}
+
+/**
+ * A spawn failure, with every resolved secret scrubbed out of the detail.
+ *
+ * If any value survives the scrub the detail is dropped entirely rather than
+ * trimmed — the residue is what leaks. The command name and our own framing
+ * always remain, so the message is never empty.
+ */
+function spawnFailureMessage(command: string, err: unknown, values: string[]): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  const detail = scrubOrDrop(raw, values);
+
+  // The command is echoed back, and it is user-supplied: a secret exported in
+  // the calling shell can be sitting in the argv we are about to print. Checked
+  // separately from the framing around it, so a run coinciding with our own
+  // wording ("secret", "list") cannot suppress a detail that was fine.
+  const shown = leaksAny(command, values) ? '<command>' : command;
+
+  const lines = [`secretless: Failed to start ${shown}.`];
+  lines.push(
+    detail
+      ? `  ${detail.split('\n').join('\n  ')}`
+      : '  The underlying error was withheld: it carried a stored secret value.',
+  );
+  lines.push(
+    '',
+    '  Verify:  secretless-ai secret list',
+    '  Fix:     secretless-ai run -- <command>',
+    '',
+  );
+  return lines.join('\n');
 }

--- a/src/secret-store.ts
+++ b/src/secret-store.ts
@@ -10,6 +10,7 @@ import { createBackend } from './backends/factory';
 import { resolveBackendType } from './backends/config';
 import type { WritableSecretBackend } from './backends/types';
 import type { SelectableBackendType } from './backends/config';
+import { findSecretValueProblem, unstorableSecretError } from './secret-value';
 
 const SECRET_PREFIX = 'secret';
 
@@ -47,9 +48,17 @@ export class SecretStore {
     return this.backend.name.replace(/^cached\((.*)\)$/, '$1');
   }
 
-  /** Store a secret by name. */
+  /**
+   * Store a secret by name.
+   *
+   * Validated here rather than in the prompt: `secret set`, `import` and the
+   * MCP write path all arrive at this method, and a rule enforced in one of
+   * three places is a rule with two ways around it (#104).
+   */
   async setSecret(name: string, value: string): Promise<void> {
     validateSecretName(name);
+    const problem = findSecretValueProblem(value);
+    if (problem) throw unstorableSecretError(name, problem);
     const key = `${SECRET_PREFIX}/${name}`;
     await this.backend.store(key, value);
   }

--- a/src/secret-value.test.ts
+++ b/src/secret-value.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { findSecretValueProblem, describeSecretShape } from './secret-value';
+import { SecretStore } from './secret-store';
+import { LocalBackend } from './backends/local';
+
+const ESC = String.fromCharCode(0x1b);
+const NUL = String.fromCharCode(0);
+
+/**
+ * #104 §2 — a 40-character hex token pasted at the interactive prompt was
+ * stored as 19 bytes of control characters and U+FFFD, with no warning, and
+ * surfaced much later as a TypeError inside an unrelated consumer.
+ */
+describe('findSecretValueProblem', () => {
+  it('rejects a bracketed paste that captured its own escape sequences', () => {
+    // What the terminal actually sends around a paste: ESC [ 2 0 0 ~ ... ~
+    const pasted = `${ESC}[200~sk-live-QQ7ZX9WKPV4${ESC}[201~`;
+    const problem = findSecretValueProblem(pasted);
+    expect(problem?.kind).toBe('control-char');
+    expect(problem?.at).toBe(1);
+  });
+
+  it('rejects U+FFFD, because the original bytes are already gone', () => {
+    expect(findSecretValueProblem('sk-live-�-tail')?.kind).toBe('replacement-char');
+  });
+
+  it('rejects a null byte', () => {
+    expect(findSecretValueProblem('sk-live' + NUL)?.kind).toBe('null-byte');
+  });
+
+  it('rejects DEL', () => {
+    expect(findSecretValueProblem('sk-live' + String.fromCharCode(0x7f))?.kind)
+      .toBe('control-char');
+  });
+
+  it('accepts the credentials people actually store', () => {
+    // The other direction, and the one that decides whether this rule is
+    // usable: rejecting too widely would block real secrets.
+    const real = [
+      'sk-ant-api03-QQ7ZX9WKPV4RJT2MHB6NDY8FGC3L',
+      'd41d8cd98f00b204e9800998ecf8427e',
+      'ghp_QQ7ZX9WKPV4RJT2MHB6NDY8FGC3Lab',
+      'postgres://user:p%40ss@host:5432/db?sslmode=require',
+      'eyJhbGciOiJIUzI1NiJ9.eyJhIjoxfQ.QQ7ZX9WKPV4RJT2MHB6NDY8FGC3L',
+      'p@ssw0rd! #$%^&*()_+-=[]{}|;:\'",.<>/?`~',
+    ];
+    for (const value of real) {
+      expect(findSecretValueProblem(value), value).toBeNull();
+    }
+  });
+
+  it('accepts a multi-line PEM key', () => {
+    // Newline, carriage return and tab are the reason the allowed set is not
+    // empty — a PEM piped in whole is a legitimate stored secret.
+    const pem = '-----BEGIN PRIVATE KEY-----\r\n\tMIIEvQIBADANBg\n-----END PRIVATE KEY-----';
+    expect(findSecretValueProblem(pem)).toBeNull();
+  });
+});
+
+describe('describeSecretShape', () => {
+  it('reports length and class, and no content', () => {
+    // The #104 token was 40 hex characters and was stored as 19. "19 chars"
+    // next to a token the user knows is 40 is the whole point.
+    expect(describeSecretShape('d41d8cd98f00b204e9800998ecf8427e')).toBe('32 chars, hex');
+    expect(describeSecretShape('sk-ant-QQ7ZX9')).toBe('13 chars, printable ASCII');
+    expect(describeSecretShape('QQ7ZX9WK')).toBe('8 chars, alphanumeric');
+    expect(describeSecretShape('a\nb')).toBe('3 chars, multi-line');
+  });
+
+  it('never includes the value itself', () => {
+    const value = 'sk-live-QQ7ZX9WKPV4RJT2MHB6NDY8FGC3L';
+    const shape = describeSecretShape(value);
+    for (let i = 0; i + 4 <= value.length; i++) {
+      expect(shape).not.toContain(value.slice(i, i + 4));
+    }
+  });
+});
+
+describe('SecretStore.setSecret rejects an unstorable value (#104)', () => {
+  let dir: string;
+  let store: SecretStore;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-setval-'));
+    store = new SecretStore({ backend: new LocalBackend({ storeDir: dir, key: 'k' }) });
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('refuses, names the character and position, and shows no value', async () => {
+    const mangled = `${ESC}[200~sk-live-QQ7ZX9WKPV4~`;
+    const err = await store.setSecret('API_KEY', mangled).then(() => null, (e: Error) => e);
+
+    expect(err).not.toBeNull();
+    expect(err!.message).toMatch(/API_KEY.*was not stored/);
+    expect(err!.message).toContain('escape character (0x1B)');
+    expect(err!.message).toContain('secretless-ai secret set API_KEY');
+    for (let i = 0; i + 4 <= mangled.length; i++) {
+      expect(err!.message).not.toContain(mangled.slice(i, i + 4));
+    }
+  });
+
+  it('stores nothing when it refuses', async () => {
+    await store.setSecret('API_KEY', ESC + 'x').catch(() => undefined);
+    expect(await store.listSecrets()).toEqual([]);
+  });
+
+  it('CONTROL: an ordinary value is still stored', async () => {
+    await store.setSecret('API_KEY', 'sk-live-QQ7ZX9WKPV4RJT2MHB6NDY8FGC3L');
+    expect(await store.listSecrets()).toEqual(['API_KEY']);
+  });
+});

--- a/src/secret-value.ts
+++ b/src/secret-value.ts
@@ -1,0 +1,110 @@
+/**
+ * What a stored secret is allowed to be, and how to describe one without
+ * showing it.
+ *
+ * A 40-character hex token pasted at the interactive prompt was stored as 19
+ * bytes containing control characters and U+FFFD — the shape of a bracketed
+ * paste whose escape sequences landed inside the captured value. Nothing
+ * checked, so nothing warned, and the corruption surfaced much later as a
+ * TypeError inside an unrelated consumer building an HTTP header (#104).
+ *
+ * The check belongs at the store boundary rather than in the prompt: `set`,
+ * `import` and the MCP write path all end at `setSecret`, and a rule enforced
+ * in one of three places is a rule with two ways around it.
+ */
+
+/**
+ * Control characters a real credential can legitimately contain.
+ *
+ * Newline is the reason this list is not empty — PEM keys and JSON service
+ * account blobs are multi-line and are piped in whole. Carriage return comes
+ * with them from Windows-authored files, and tab appears in some pasted blobs.
+ */
+const ALLOWED_CONTROLS = new Set(['\t', '\n', '\r']);
+
+/** U+FFFD. Its presence means bytes were already lost decoding the input. */
+const REPLACEMENT_CHAR = '�';
+
+export interface SecretValueProblem {
+  /** Machine-readable cause, for callers that branch on it. */
+  kind: 'null-byte' | 'replacement-char' | 'control-char';
+  /** Human-readable name of the offending character. Never the value. */
+  found: string;
+  /** 1-based character position, so a user can see where the paste went wrong. */
+  at: number;
+}
+
+/**
+ * The first thing wrong with this value, or null if nothing is.
+ *
+ * Order matters only for the message: a value can trip several of these and the
+ * earliest position is the most useful thing to report.
+ */
+export function findSecretValueProblem(value: string): SecretValueProblem | null {
+  for (let i = 0; i < value.length; i++) {
+    const ch = value[i];
+    if (ch === '\0') return { kind: 'null-byte', found: 'a null byte', at: i + 1 };
+    if (ch === REPLACEMENT_CHAR) {
+      return { kind: 'replacement-char', found: 'U+FFFD (replacement character)', at: i + 1 };
+    }
+    const code = ch.charCodeAt(0);
+    const isControl = code < 0x20 || code === 0x7f;
+    if (isControl && !ALLOWED_CONTROLS.has(ch)) {
+      const name = code === 0x1b ? 'an escape character (0x1B)' : `a control character (0x${code.toString(16).toUpperCase().padStart(2, '0')})`;
+      return { kind: 'control-char', found: name, at: i + 1 };
+    }
+  }
+  return null;
+}
+
+/**
+ * Error for a value that cannot be stored.
+ *
+ * Names the secret, the character and where it is. Never the value — the point
+ * of rejecting it is that it is a credential, mangled or not.
+ */
+export function unstorableSecretError(name: string, problem: SecretValueProblem): Error {
+  const cause = problem.kind === 'replacement-char'
+    ? [
+      '  U+FFFD is what a decoder writes when it has already lost the original',
+      '  bytes, so the value cannot be recovered from what was captured.',
+    ]
+    : [
+      '  Almost no real credential contains one. This is usually a paste that',
+      '  captured your terminal\'s bracketed-paste escape sequences along with',
+      '  the value.',
+    ];
+
+  return new Error(
+    [
+      `"${name}" was not stored: the value contains ${problem.found} at character ${problem.at}.`,
+      '',
+      ...cause,
+      '',
+      '  Verify:  secretless-ai secret list',
+      `  Fix:     secretless-ai secret set ${name}=<value>   (as an argument, not a paste)`,
+      '           or pipe it:  cat token.txt | secretless-ai secret set ' + name,
+    ].join('\n'),
+  );
+}
+
+/**
+ * A one-line shape summary: length and character class, never content.
+ *
+ * Printed on every successful write so a bad capture is visible at the moment
+ * it happens rather than at first use. The 40-character token in #104 was
+ * stored as 19 bytes; "19 chars" alone would have said so.
+ */
+export function describeSecretShape(value: string): string {
+  const chars = `${value.length} char${value.length === 1 ? '' : 's'}`;
+  if (value.includes('\n')) return `${chars}, multi-line`;
+  if (/^[0-9a-f]+$/i.test(value)) return `${chars}, hex`;
+  // Alphanumeric is checked before base64, and base64 requires a character
+  // only base64 has. Every alphanumeric string whose length is a multiple of
+  // four is also valid base64, so testing base64 first labels an ordinary
+  // 32-character API key as base64 — a guess dressed as a measurement.
+  if (/^[A-Za-z0-9]+$/.test(value)) return `${chars}, alphanumeric`;
+  if (/^[A-Za-z0-9+/]+={0,2}$/.test(value) && value.length % 4 === 0) return `${chars}, base64`;
+  if (/^[\x20-\x7e]+$/.test(value)) return `${chars}, printable ASCII`;
+  return chars;
+}


### PR DESCRIPTION
Closes #117, #104, #118.

Three defects a credential manager should not carry, fixed in the order they
interact. #118 first: a warm stale cache would let a correct fail-closed check
for #104 read the cache and pass anyway.

Each fix was swept by predicate rather than by issue number, and each regression
test was red-proofed on a `git archive` copy of `db565e9` — confirmed failing on
its own assertion, not on a missing import.

## What the sweep found that was not on the list

- **`secret set` destroyed the store it could not read.** The read failure was
  swallowed with "start fresh" and a one-entry store written over the top.
  Measured on the pre-fix tree: three secrets stored, one `set` from an account
  that could not decrypt the store, all three gone — `Stored: NAME`, exit 0. The
  original key still worked right up to that write, so recoverable data was
  destroyed by the tool. Present in every published version.
- **`cache clear` cleared the wrong directory since 0.12.3.** The cache moved to
  `cache/` and this was left on `store/`, so it deleted the abandoned file,
  printed `Cache cleared`, and left every live entry. It is the workaround #118
  documents, which made the one published remedy a no-op reporting success.
- **A cache marker outliving its entries reported a successful resolve of
  nothing.** Guarded by `matchingCached.length >= 0` — true for every possible
  value. `run` would inject no secrets and exit 0. Measured on 0.21.3.
- **A locked keychain read as "secret not found"**, and a malformed name index
  read as "no secrets stored", over a keychain holding everything.
- **A keychain read that could not establish the encoding returned the raw
  value** — for a binary secret, the hex transcript of the credential rather
  than the credential.
- **`healthCheck` called the local store healthy because the file existed**, so
  the one state it exists to catch was the state it passed.

## Two things worth reading in the diff

**The reuse #117 asks for did not survive measurement.** Against the three
throws this tool actually hits, `message.includes(value)` is false in all of
them — Node escapes control bytes and truncates long values, `JSON.parse` quotes
the first ten characters. So `redactSecurityError` copied to the spawn path
would have replaced nothing, and the `leaksAnyLineOf` backstop would have
reported no leak over a message displaying most of the credential. `src/redact.ts`
detects on runs instead, and the Keychain path now uses the same detector, which
closes the same gap there.

**One prior decision is reversed.** `decodeKeychainValue` returned the raw value
whenever the encoding probe failed, on the recorded reasoning that handing back
a value verbatim is always safe. That holds against #107, which was
over-decoding, and fails in the other direction. The old rule is kept in the
file as a hazard rather than deleted: never decode on an unanswered question.
This code does not decode — it refuses.

## Behaviour changes

Reads that returned "nothing" on failure now fail closed and exit non-zero.
`secret set` refuses null bytes, U+FFFD and control characters other than tab,
newline and carriage return (multi-line PEM keys are unaffected) and prints the
shape — length and character class, never content. Cached values are tied to the
build that read them, so upgrading costs one extra unlock prompt.

## Verification

- Suite 1437 green, up from 1383. No test was weakened; two were replaced
  because they asserted the fail-open as expected behaviour, and both
  replacements are named in the commit messages.
- Verified against the real store on macOS: 78 secrets, keychain backend,
  `secret list` clean with no prompts and no false alarms. The stricter paths do
  not break the healthy one.
- Every command cited in a new error message was run before it was cited.

## Not in this PR

Gate B (#110, #111, #112, #120 remainder, #124-#127) and gate C (#119).
The Linux half of the keychain fail-open is filed as #130 — it needs exit codes
that cannot be measured on macOS, and a guessed mapping would look fixed without
being fixed.