### PR TITLE
The broker enforces the policy it was given, and a flag never widens scope (0.22.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,31 @@ would be dropping.
   context file was skipped and the short report was printed as though it were
   the full one.
 
+### Known issues
+
+Found by this release's own walkthrough, each reproduced against published 0.22.0
+and carried rather than fixed. First carry for both. Named here because this
+release is about the tool telling the truth about what it did, and both of these
+are cases where it does not.
+
+- **`scan` has three ignore layers and one of them is unreachable by any flag
+  ([#136](https://github.com/opena2a-org/secretless-ai/issues/136)).** A tree whose
+  only credential sits in `dist/`, `build/`, `node_modules/`, `coverage/` or
+  `vendor/` reports `No hardcoded credentials found.` with exit 0 under every
+  documented flag combination. Worse, `--no-ignore` and `--include-tests` each
+  widen coverage on their own and, given together, narrow it back to the no-flag
+  baseline. `--help` describes the two layers that flags do reach and is silent
+  about the third. Fixed in **0.24.0**, with the rest of the selection work.
+
+- **A typo in a `scan` coverage flag yields a confident clean
+  ([#137](https://github.com/opena2a-org/secretless-ai/issues/137)).**
+  `scan --include-testss` warns on stderr, names the flag you meant, and then exits
+  0 with `No hardcoded credentials found.` over a tree it narrowed. The `--json`
+  summary carries no trace of the dropped flag, so a CI job gating on
+  `summary.total` cannot see it. `scan` warns rather than refuses by design — see
+  the behaviour note above — and the case that survives that design is the
+  coverage flags specifically. Fixed in **0.23.0**.
+
 ### Corrections to the 0.22.0 notes
 
 Found while re-checking the issues that release closed. Neither is fixed here —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,20 @@ would be dropping.
   now carry only `id`, `agentSelector`, `credentialSelector`, `constraints` and
   `effect`, and anything else refuses the file.
 
+- **The same silent drop existed at three further levels of the policy file.**
+  A pre-tag pass asked one question at every level of operator-authored input
+  rather than at the level the last defect turned up, and found: a sibling of
+  `rules` in the file envelope (`{"rules": [allow], "denyRules": [deny-all]}`
+  loaded the allow set, ignored the deny set, and served the credential); a
+  sub-key inside a structured constraint (`rateLimit` read `maxPerMinute` and
+  dropped `maxPerHour`, so a cap of 1/hour permitted 3600/hour, and a mistyped
+  `End` left a time window open); and an empty value that deletes the
+  restriction (`requireCapability: ""` skipped the capability check entirely,
+  including its fail-closed no-identity branch, because that branch tested
+  truthiness while its sibling tests `!== undefined`). An empty `agentSelector`
+  or `credentialSelector` matches nothing, so a deny rule carrying one never
+  fired. All refuse now.
+
 - **`scopeCheck` was documented as a deny and could not deny.** It was listed as
   "deny if credential permissions expanded since last baseline", counted among
   the loaded constraints, and advertised in the broker guide — while the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ not choose.
 the commands that do not implement it. Making that an error is a consumer-
 visible change and belongs to its own release.
 
+**A broker policy file with an unrecognised field now refuses to load, and the
+daemon will not start.** This includes documentation keys: a `comment` or
+`description` sitting beside `id` in a rule is refused. That is not
+hypothetical — it is what one hand-annotated policy file on our own machine
+carried, and it is how we found this. The remedy is to delete the key; the
+error names it and lists the five fields a rule may carry. An `x-` prefixed
+annotation namespace is planned so that notes have a supported home, and it is
+deliberately not being designed inside a security patch. The refusal is the
+strict direction on purpose: a field we do not read is a field whose meaning we
+would be dropping.
+
 ### Security
 
 - **The broker authorized more than the policy said.** The policy engine
@@ -38,6 +49,29 @@ visible change and belongs to its own release.
   exists but will not validate is a startup failure rather than a warning — a
   daemon warning is a silent failure with extra steps. Affects 0.9.2 through
   0.22.0.
+
+- **The same fail-open was reachable one level up, through a typo.** The check
+  above refuses a constraint it cannot apply, but nothing validated a rule's
+  top-level fields — so misspelling the container (`contraints`, `constraint`)
+  discarded the whole constraint block, and the rule loaded as an unconstrained
+  allow with every surface reporting it loaded. Measured with a control: the
+  correct spelling plus a closed time window denies; the typo allows. A rule may
+  now carry only `id`, `agentSelector`, `credentialSelector`, `constraints` and
+  `effect`, and anything else refuses the file.
+
+- **`scopeCheck` was documented as a deny and could not deny.** It was listed as
+  "deny if credential permissions expanded since last baseline", counted among
+  the loaded constraints, and advertised in the broker guide — while the
+  enforcement path compared an *empty* current-permission list against the
+  baseline, so expansion was false for every baseline and the deny branch was
+  unreachable. Measured: the same comparison reports an expansion when handed
+  real permissions, so the call site was what disabled it. An operator's
+  scope-drift gate was inert while every surface reported it enforced. The
+  constraint is removed rather than left accepted-and-unapplied: a rule naming
+  it is now refused with an error saying this build does not enforce it, so a
+  policy that depended on it fails visibly instead of appearing to hold. Real
+  enforcement needs live permission discovery in the resolve path and is
+  tracked separately.
 
 - **`run --only=NAME` injected every credential in the store.** The parser
   compared `args[i] === '--only'` by exact equality, so the GNU equals spelling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,24 @@ visible change and belongs to its own release.
   context file was skipped and the short report was printed as though it were
   the full one.
 
+### Corrections to the 0.22.0 notes
+
+Found while re-checking the issues that release closed. Neither is fixed here —
+0.22.1 is deliberately narrow — but a release note that claims more than the
+code does is the same defect class this release is about.
+
+- **"Values are validated at the store boundary, so `set`, `import` and the MCP
+  write path are all covered" is wider than the code.** The MCP write path does
+  not end at `setSecret`: `src/mcp/vault.ts` calls the backend directly and
+  bypasses the check, as does the backend migration path. Measured by storing a
+  value carrying bracketed-paste escape bytes through `McpVault` and reading it
+  back unchanged. The source comment asserting the same coverage is wrong in the
+  same way. Tracked on [#104](https://github.com/opena2a-org/secretless-ai/issues/104).
+
+- **"Every successful write now prints the shape" is only true of `secret set`.**
+  `setup` prompts for values interactively and prints no shape line; `import`
+  prints names only.
+
 ## [0.22.0] - 2026-08-12
 
 Credential disclosure and integrity. Three defects a credential manager should

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,13 @@ would be dropping.
   rather than starting an MCP server with none of the credentials the wrapper
   exists to inject.
 
+  **Migration consequence, if you hand-edited an MCP config.** A wrapper line
+  carrying `--vault-dir=/path` was reading the DEFAULT vault and will now read
+  the directory you named — which may be empty, in which case the server starts
+  without its secrets. The same applies to `--backend=`: it now uses the backend
+  named rather than the configured default. Configs written by `protect-mcp`
+  use the spaced form and are unaffected.
+
 - **`verify --alll` answered a narrower question than the one asked.** Any
   misspelling of `--all` was resolved as the project directory, so every project
   context file was skipped and the short report was printed as though it were

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,113 @@
 # Changelog
 
+## [0.22.1] - 2026-08-12
+
+A security patch. Three defects where the tool did something other than what it
+was asked, and reported success: a broker policy that authorized more than the
+operator wrote, a credential selector that injected the whole store when it was
+spelled with an equals sign, and a redaction that reported a completed removal
+over material still on disk.
+
+**Behavior change worth reading before you upgrade.** A command line the tool
+cannot bind is now refused with exit 2 instead of being partly ignored. This
+affects three shapes: an unrecognised flag on a command that WRITES (`clean`,
+`clean-history`, `run`, `backend`, `migrate`, `vault`, `init`, and the rest),
+a flag given a value it cannot use (`scan --max-files abc`), and a value-taking
+flag given no value at all. Read-only `scan` still warns and continues on an
+unknown flag, as it has since #81. If you have automation passing a flag this
+tool does not implement, it will now stop rather than run with a scope you did
+not choose.
+
+**`--json` is unchanged in this release.** It is still accepted and ignored by
+the commands that do not implement it. Making that an error is a consumer-
+visible change and belongs to its own release.
+
+### Security
+
+- **The broker authorized more than the policy said.** The policy engine
+  silently dropped any constraint it could not type-match, so the restrictive
+  half of an operator's rule evaporated and the permissive half survived, while
+  `loadPolicies()`, `getRules()` and `/health` all reported the rule loaded.
+  A `timeWindow` written with numeric hours instead of `"HH:MM"` strings, or
+  `rateLimit.maxPerMinute` as the string `"1"`, produced no constraints at all
+  and an unconditional allow. A numeric string is not a hypothetical: it is what
+  a YAML-to-JSON conversion, a templating layer or an env-var substitution
+  produces. The sharpest case is `minTrustScore: "80"`, where the trust floor
+  disappears and any agent matching the selector is served. A constraint this
+  build cannot apply is now refused rather than ignored, and a policy file that
+  exists but will not validate is a startup failure rather than a warning — a
+  daemon warning is a silent failure with extra steps. Affects 0.9.2 through
+  0.22.0.
+
+- **`run --only=NAME` injected every credential in the store.** The parser
+  compared `args[i] === '--only'` by exact equality, so the GNU equals spelling
+  was an unrecognised argument, silently discarded — and with no selector, the
+  child process receives everything. Nothing was printed on stdout or stderr and
+  the exit code was the child's. The refusal `env` prints when it detects an AI
+  agent runtime recommends `secretless-ai run --only NAME -- <command>` as the
+  safe alternative, so the tool's own recommended remedy was defeated by a
+  one-character difference in how it was typed. `env --only=NAME`, and `env
+  --only` with no value, exported the whole store the same way.
+
+### Fixed
+
+- **`clean --dryrun` performed the irreversible write it was asked to preview.**
+  `clean` is destructive by default and `--dry-run` is the only thing that makes
+  it a preview; the flag was read with `args.includes('--dry-run')` and nothing
+  validated the rest of the command line, so any misspelling silently degraded
+  to the destructive path and exited 0. The only signal was a missing "Mode:
+  dry-run" line, printed after the file had already been rewritten — and unlike
+  `clean-history`, this path writes no `.bak`. `clean-history --dryrun` had the
+  identical shape and targets your real shell history, which has no path flag at
+  all.
+
+- **`clean --path=DIR` cleaned every transcript on the machine.** The equals
+  spelling was unparsed, and the fallback for a missing scope is the maximum
+  scope. Measured: a target holding one file, against 9,119 files discovered and
+  205 that would have been rewritten in place. The header printed the unscoped
+  "Scanning Claude Code transcripts..." with no mention that the `--path` given
+  had been discarded. `--path` with no value did the same.
+
+- **`scan --max-files <path>` scanned the working directory instead.** The flag
+  consumed the path as its value, leaving no positional, so the scan silently
+  retargeted and printed "No hardcoded credentials found." over a tree it never
+  opened, with exit 0 and every coverage counter reading zero. The warning named
+  the invalid value; nothing said the path had been eaten or named the directory
+  actually scanned. A rejected flag value now refuses the run rather than
+  falling back to a default you did not ask for.
+
+- **`--min-confidence=`, `--max-files=` and `--max-file-size=` were dropped.**
+  Each was warned about as an unknown flag and the scan ran at the default, so
+  a raised cap was not raised and a confidence threshold was not applied.
+
+- **Redaction left the tail of a credential longer than its pattern's fixed
+  length ([#133](https://github.com/opena2a-org/secretless-ai/issues/133)).**
+  The redactors replaced what the DETECTOR matched, and the detector's patterns
+  carry fixed quantifiers, so a value longer than the canonical shape kept its
+  overshoot — while the output read as fully redacted. This is a remediation
+  defect, not a preview defect: `clean` wrote the residue back into the
+  transcript and reported the redaction complete, `clean-history` did the same
+  to your shell history, and `diff` printed it to stdout under a "REDACTED"
+  label with no length cap. The replacement span is now derived from the
+  credential rather than from the pattern match, and every write and display
+  path routes through the same primitive. Vendors document GitHub, AWS and Slack
+  token lengths as variable, so a fixed quantifier is wrong regardless of
+  today's value. Listed in 0.22.0 as a known issue fixed in 0.23.0; it is fixed
+  here instead.
+
+- **`secretless-mcp` read credentials from the wrong place.** The second
+  published bin carried the same parse idiom and had never been swept:
+  `--vault-dir=` fell back to the default vault and `--backend=` to the
+  configured backend, so the wrapper loaded credentials from somewhere other
+  than where it was told to. An empty `--server` or `--client` now refuses
+  rather than starting an MCP server with none of the credentials the wrapper
+  exists to inject.
+
+- **`verify --alll` answered a narrower question than the one asked.** Any
+  misspelling of `--all` was resolved as the project directory, so every project
+  context file was skipped and the short report was printed as though it were
+  the full one.
+
 ## [0.22.0] - 2026-08-12
 
 Credential disclosure and integrity. Three defects a credential manager should

--- a/README.md
+++ b/README.md
@@ -168,6 +168,20 @@ A scan that could not read everything is not a passing scan. If the walk stops a
 
 Symlinks are followed inside the scan root. A link whose target resolves outside it is not followed -- otherwise a repo containing `link -> $HOME` would pull the whole home directory into the scan -- and each one is listed with the command to scan its target directly, so the boundary is never silent. These do not affect the exit code.
 
+### A flag never widens scope
+
+A command line the tool cannot bind is refused with exit 2 before anything runs, rather than partly ignored. That covers an unrecognised flag on a command that writes, a flag given a value it cannot use, and a value-taking flag given no value at all. `--only=NAME`, `--path=DIR` and every other `--flag=value` spelling binds the same way as the spaced form.
+
+Exit codes: `0` clean, `1` credentials found (or an incomplete scan), `2` the command line was refused and nothing ran. Gate CI on `2` separately -- it means the tool did not answer the question, not that the answer was clean.
+
+```bash
+npx secretless-ai clean --dryrun --path ./transcripts
+#   Unknown option: --dryrun (did you mean --dry-run?)
+#   `clean` was not run. Nothing was changed.
+#   Supported: --dry-run, --help, --json, --last, --path <value>
+#   Run `secretless-ai clean --help` for usage.
+```
+
 ```bash
 npx secretless-ai scan --json | jq '.summary'
 # { "total": 0, "critical": 0, "high": 0, "placeholdersSuppressed": 0,

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npx secretless-ai init
 ```
 
 ```
-  Secretless v0.22.0
+  Secretless v0.22.1
   Keeping secrets out of AI
 
   Configured: Claude Code (1 of 1 detected)

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Exit codes: `0` clean, `1` credentials found (or an incomplete scan), `2` the co
 npx secretless-ai clean --dryrun --path ./transcripts
 #   Unknown option: --dryrun (did you mean --dry-run?)
 #   `clean` was not run. Nothing was changed.
-#   Supported: --dry-run, --help, --json, --last, --path <value>
+#   Supported: --dry-run, --help, --last, --path <value>
 #   Run `secretless-ai clean --help` for usage.
 ```
 

--- a/docs/use-cases/run-broker.md
+++ b/docs/use-cases/run-broker.md
@@ -120,7 +120,23 @@ Supported constraints:
 - `rateLimit.maxPerMinute` — per agent + credential pair
 - `minTrustScore` — AIM-only, see below
 - `requireCapability` — AIM-only, see below
-- `scopeCheck` — deny if credential permissions expanded since last baseline
+
+A rule is refused if it names anything else, including a constraint this build
+cannot apply and a top-level field it does not read. The refusal names the key
+and the legal set. This is deliberate: a constraint that is accepted but not
+applied drops the restrictive half of your rule and keeps the permissive half,
+while every status surface reports the rule loaded.
+
+That includes documentation keys — a `comment` or `description` beside `id` is
+refused today. An `x-` prefixed annotation namespace is planned; until it lands,
+keep notes outside the rule objects.
+
+`scopeCheck` was listed here until 0.22.1 and is no longer accepted. It never
+denied a request: the check compared an empty current-permission list against
+the baseline, so it could not observe an expansion. Enforcing it needs live
+permission discovery in the resolve path, which is tracked separately. A rule
+naming it is refused rather than silently ignored, so that a policy relying on
+it fails visibly instead of appearing enforced.
 
 Reload by restarting the daemon. Or pass `--policy-file <path>` on start to use a non-default location.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "secretless-ai",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "secretless-ai",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/post-quantum": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secretless-ai",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "One command to keep secrets out of AI. Works with Claude Code, Cursor, Copilot, Windsurf, and any AI coding tool.",
   "license": "Apache-2.0",
   "type": "commonjs",

--- a/src/argv.test.ts
+++ b/src/argv.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { prepareArgv, prepareBinArgv, VERBS, MCP_WRAPPER, EXIT_USAGE } from './argv';
+
+/**
+ * The argv layer, unit level.
+ *
+ * These cannot be red-proofed against v0.22.0 — `src/argv.ts` does not exist
+ * there, so every one of them fails on a missing import rather than on its own
+ * assertion, which proves nothing. The red-proof for this fix lives in
+ * `cli.test.ts`, driving the built CLI, where the behaviour existed before and
+ * after. What these add is the per-spelling matrix that a behavioural test
+ * cannot cover cheaply, and the two guards at the bottom, whose oracle is the
+ * SOURCE rather than the table they check.
+ */
+
+describe('prepareArgv: the equals spelling binds', () => {
+  // The positive control for the whole file. `--only NAME` already worked on
+  // 0.22.0; if this row ever fails, the matrix below is measuring the harness
+  // and not the fix.
+  it('CONTROL: the space form binds, as it always did', () => {
+    const p = prepareArgv('run', ['run', '--only', 'DEPLOY_TOKEN', '--', 'npm', 'test']);
+    expect(p.args).toEqual(['run', '--only', 'DEPLOY_TOKEN', '--', 'npm', 'test']);
+    expect(p.errors).toEqual([]);
+  });
+
+  it('`--only=NAME` becomes `--only` `NAME`', () => {
+    const p = prepareArgv('run', ['run', '--only=DEPLOY_TOKEN', '--', 'npm', 'test']);
+    expect(p.args).toEqual(['run', '--only', 'DEPLOY_TOKEN', '--', 'npm', 'test']);
+    expect(p.errors).toEqual([]);
+  });
+
+  // `--only=` is the flag WITH an empty value, not the flag absent. The
+  // difference is the whole defect: absent means "inject every credential in
+  // the store", and #110 established that an empty selector must fail closed.
+  it('`--only=` keeps the empty value rather than dropping the flag', () => {
+    const p = prepareArgv('run', ['run', '--only=', '--', 'npm', 'test']);
+    expect(p.args).toEqual(['run', '--only', '', '--', 'npm', 'test']);
+    expect(p.errors).toEqual([]);
+  });
+
+  it('a value containing `=` survives intact', () => {
+    const p = prepareArgv('clean', ['clean', '--path=/tmp/a=b/c']);
+    expect(p.args).toEqual(['clean', '--path', '/tmp/a=b/c']);
+  });
+
+  it.each([
+    ['clean', '--path', '/tmp/t'],
+    ['scan', '--max-files', '20000'],
+    ['scan', '--min-confidence', '0.8'],
+    ['scan', '--max-file-size', '20mb'],
+    ['env', '--only', 'A,B'],
+    ['warm', '--ttl', '3600'],
+    ['broker', '--port', '9999'],
+    ['migrate', '--from', 'local'],
+    ['protect-mcp', '--backend', 'keychain'],
+  ])('%s %s=%s binds like the space form', (verb, flag, value) => {
+    const equals = prepareArgv(verb, [verb, `${flag}=${value}`]);
+    const spaced = prepareArgv(verb, [verb, flag, value]);
+    expect(equals.args).toEqual(spaced.args);
+    expect(equals.errors).toEqual([]);
+  });
+});
+
+describe('prepareArgv: a flag never widens scope', () => {
+  it('a near-miss safety flag on a destructive verb refuses the run', () => {
+    const p = prepareArgv('clean', ['clean', '--dryrun']);
+    expect(p.errors).toHaveLength(1);
+    expect(p.errors[0]).toContain('--dryrun');
+    expect(p.errors[0]).toContain('--dry-run');
+  });
+
+  it('`clean-history --dryrun` refuses — it has no path flag and targets real history', () => {
+    const p = prepareArgv('clean-history', ['clean-history', '--dryrun']);
+    expect(p.errors).toHaveLength(1);
+  });
+
+  it('an unknown flag with no near miss still refuses on a destructive verb', () => {
+    const p = prepareArgv('clean', ['clean', '--zzzzzz']);
+    expect(p.errors).toHaveLength(1);
+    expect(p.errors[0]).not.toContain('did you mean');
+  });
+
+  it('a value-taking flag given last, with no value, refuses', () => {
+    const p = prepareArgv('clean', ['clean', '--path']);
+    expect(p.errors).toEqual(['--path needs a value, but none was given.']);
+  });
+
+  it('a boolean flag given a value refuses rather than inventing a positional', () => {
+    const p = prepareArgv('clean', ['clean', '--dry-run=true']);
+    expect(p.errors).toHaveLength(1);
+    expect(p.errors[0]).toContain('does not take a value');
+  });
+
+  // An unregistered flag is left WHOLE. If it were split, `bar` would land in
+  // the positional list, and for scan or clean a positional is a path — a
+  // target the user never typed.
+  it('an unregistered `--foo=bar` never becomes a positional', () => {
+    const p = prepareArgv('scan', ['scan', '--foo=bar', './src']);
+    expect(p.positionals).toEqual(['./src']);
+    expect(p.args).toContain('--foo=bar');
+  });
+
+  it('a flag value is never counted as a positional', () => {
+    const p = prepareArgv('scan', ['scan', '--max-files', '20000', './src']);
+    expect(p.positionals).toEqual(['./src']);
+  });
+
+  // The measured 0.22.0 defect: `--max-files` eats the path, leaving no
+  // positional, and the scan silently retargets to the working directory.
+  // Binding is not enough on its own — cli.ts must then refuse the value.
+  it('a flag given the path as its value leaves no positional to scan', () => {
+    const p = prepareArgv('scan', ['scan', '--max-files', './src']);
+    expect(p.positionals).toEqual([]);
+  });
+});
+
+describe('prepareArgv: the child command after `--` is untouched', () => {
+  it('does not rewrite the child\'s own equals flags', () => {
+    const p = prepareArgv('run', ['run', '--only=A', '--', 'npm', 'run', 'x', '--flag=keepme']);
+    expect(p.args).toEqual(['run', '--only', 'A', '--', 'npm', 'run', 'x', '--flag=keepme']);
+  });
+
+  it('does not judge the child\'s flags as unknown', () => {
+    const p = prepareArgv('run', ['run', '--', 'node', '--zzzzzz']);
+    expect(p.errors).toEqual([]);
+    expect(p.warnings).toEqual([]);
+  });
+
+  it('a second `--` belongs to the child', () => {
+    const p = prepareArgv('run', ['run', '--only=A', '--', 'sh', '-c', '--', 'x']);
+    expect(p.args.slice(3)).toEqual(['--', 'sh', '-c', '--', 'x']);
+  });
+
+  it('a non-passthrough verb treats `--` as an ordinary token', () => {
+    const p = prepareArgv('clean', ['clean', '--path=/tmp/t']);
+    expect(p.args).toEqual(['clean', '--path', '/tmp/t']);
+  });
+});
+
+describe('prepareArgv: read-only verbs warn and keep running', () => {
+  // #81 shipped this warning for `scan` and CI consumers read its exit code.
+  // Moving scan to a hard refusal would be a breaking change this release does
+  // not make; the warning moved to the shared layer, the behaviour did not.
+  it('scan warns on an unknown flag and still runs', () => {
+    const p = prepareArgv('scan', ['scan', '--show-placeholder', './src']);
+    expect(p.errors).toEqual([]);
+    expect(p.warnings).toHaveLength(1);
+    expect(p.warnings[0]).toContain('--show-placeholders');
+  });
+
+  it('an unknown verb is left entirely alone for the dispatcher to report', () => {
+    const p = prepareArgv('not-a-command', ['not-a-command', '--only=X']);
+    expect(p.args).toEqual(['not-a-command', '--only=X']);
+    expect(p.errors).toEqual([]);
+  });
+});
+
+/**
+ * The two guards below take their oracle from the SOURCE, not from the table
+ * they are checking, so the table cannot satisfy them by agreeing with itself.
+ *
+ * They exist because the registry has one dangerous failure direction: a flag a
+ * verb really does accept, missing from its row, becomes an "unknown option"
+ * and a command that works today starts exiting 2.
+ */
+describe('the registry is derived from the source, not from itself', () => {
+  const SRC = path.resolve(__dirname);
+
+  function sourceFiles(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) { out.push(...sourceFiles(full)); continue; }
+      if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) out.push(full);
+    }
+    return out;
+  }
+
+  /**
+   * Flag literals that are arguments we pass to ANOTHER program, not flags we
+   * accept. Each is listed with the program it belongs to, because an entry
+   * added here without a reason is how a real flag gets excused from the guard.
+   */
+  const NOT_OURS = new Map<string, string>([
+    ['--version', 'top-level, handled before dispatch (cli.ts:65)'],
+    ['--help', 'global, in GLOBAL_FLAGS'],
+    ['--json', 'global, in GLOBAL_FLAGS'],
+  ]);
+
+  /**
+   * A line that TESTS a flag literal, as opposed to printing it in help text,
+   * naming it in a comment, or passing it to `git`.
+   *
+   * The looser first draft of this predicate matched a comment in
+   * `mcp/rewrite.ts` that happened to quote the flags it builds, and reported
+   * two flags as unregistered that no parser reads. It also matched, correctly,
+   * `ignore`'s real `--pattern` parse site, which the registry was missing —
+   * so the tightening below was checked in both directions before it was
+   * trusted: it must still catch `--pattern`.
+   */
+  const TESTS_A_FLAG = /(===|!==|includes\(|indexOf\(|startsWith\()\s*'(--[a-z][a-z0-9-]*)'/g;
+
+  function parseSites(): { file: string; flag: string }[] {
+    const sites: { file: string; flag: string }[] = [];
+    for (const file of sourceFiles(SRC)) {
+      const text = fs.readFileSync(file, 'utf-8');
+      for (const raw of text.split('\n')) {
+        const line = raw.trim();
+        if (line.startsWith('//') || line.startsWith('*') || line.startsWith('/*')) continue;
+        for (const m of line.matchAll(TESTS_A_FLAG)) {
+          sites.push({ file: path.relative(SRC, file), flag: m[2] });
+        }
+      }
+    }
+    return sites;
+  }
+
+  // A guard that found nothing would pass whether or not the registry is
+  // complete. Pin the predicate on flags known to be parsed, so a regex that
+  // stops matching fails here rather than going quietly green.
+  it('the parse-site predicate still finds the flags it is supposed to find', () => {
+    const found = new Set(parseSites().map((s) => s.flag));
+    for (const flag of ['--dry-run', '--path', '--only', '--pattern', '--check-only', '--yes']) {
+      expect(found.has(flag), `predicate no longer finds ${flag}`).toBe(true);
+    }
+  });
+
+  it('every flag literal compared against argv in src/ is in the registry', () => {
+    const registered = new Set<string>();
+    for (const spec of [...Object.values(VERBS), MCP_WRAPPER]) {
+      for (const flag of Object.keys(spec.flags)) registered.add(flag);
+    }
+
+    const missing = parseSites()
+      .filter((s) => !NOT_OURS.has(s.flag) && !registered.has(s.flag))
+      .map((s) => `${s.file}: ${s.flag}`);
+    expect(missing).toEqual([]);
+  });
+
+  it('every verb the dispatcher accepts has a registry row', () => {
+    const cli = fs.readFileSync(path.join(SRC, 'cli.ts'), 'utf-8');
+    const verbs = [...cli.matchAll(/^\s+case '([a-z][a-z-]*)':/gm)].map((m) => m[1]);
+    // Sanity: if the regex stops matching, an empty list would pass vacuously.
+    expect(verbs.length).toBeGreaterThan(25);
+    const unregistered = verbs.filter((v) => !VERBS[v]);
+    expect(unregistered).toEqual([]);
+  });
+
+  it('every verb that can write refuses unknown flags', () => {
+    // Named rather than derived: this is the release's whole claim, so the list
+    // is the assertion. A new writing verb added with 'warn' must show up here
+    // as a deliberate edit, not slip through a predicate.
+    const writers = [
+      'clean', 'clean-history', 'run', 'env', 'init', 'doctor', 'import', 'setup',
+      'secret', 'watch', 'hook', 'warm', 'install', 'protect-mcp', 'mcp-unprotect',
+      'ignore', 'telemetry', 'rules', 'backend', 'migrate', 'cache', 'scope', 'broker', 'vault',
+    ];
+    for (const verb of writers) {
+      expect(VERBS[verb], `${verb} has no registry row`).toBeDefined();
+      expect(VERBS[verb].unknownFlags, `${verb} must reject unknown flags`).toBe('reject');
+    }
+  });
+});
+
+describe('secretless-mcp, the second bin, gets the same normalisation', () => {
+  // Its argv has no leading verb — the first token is already a flag — so a
+  // layer that assumed args[0] was a verb would silently drop `--server`.
+  it('binds the first token, which is a flag and not a verb', () => {
+    const p = prepareBinArgv(MCP_WRAPPER, ['--server=github', '--client=claude', '--', 'npx', 'server']);
+    expect(p.args).toEqual(['--server', 'github', '--client', 'claude', '--', 'npx', 'server']);
+  });
+
+  it('`--vault-dir=` no longer falls back to the default vault', () => {
+    const p = prepareBinArgv(MCP_WRAPPER, ['--vault-dir=/tmp/v', '--', 'x']);
+    expect(p.args).toEqual(['--vault-dir', '/tmp/v', '--', 'x']);
+  });
+
+  it('leaves the wrapped MCP server\'s own argv alone', () => {
+    const p = prepareBinArgv(MCP_WRAPPER, ['--server=a', '--', 'npx', '-y', 'pkg', '--port=3000']);
+    expect(p.args.slice(2)).toEqual(['--', 'npx', '-y', 'pkg', '--port=3000']);
+  });
+});
+
+/**
+ * `protect-mcp` installs the wrapper by copying `dist/` — and only `dist/` — to
+ * `~/.secretless-ai/bin`, then writes that path into the user's MCP configs. So
+ * any module the wrapper reaches that requires something OUTSIDE dist/ is
+ * missing in the installed layout, and every protected MCP server fails to
+ * start.
+ *
+ * This is not hypothetical: adding `import { CLI_BARE } from './commands/utils'`
+ * to argv.ts did exactly that, because that module does
+ * `require('../../package.json')`. `mcp/e2e.test.ts` caught it, but only after
+ * building a real vault. This asserts the same property in one spawn, so the
+ * next import that breaks it fails here first and says why.
+ */
+describe('the mcp-wrapper require graph is self-contained within dist/', () => {
+  const DIST = path.resolve(__dirname, '..', 'dist');
+  const hasBuild = fs.existsSync(path.join(DIST, 'mcp-wrapper.js'));
+  const itIfBuilt = hasBuild ? it : it.skip;
+
+  itIfBuilt('starts from a standalone copy of dist/, as protect-mcp installs it', () => {
+    const { execFileSync } = require('child_process') as typeof import('child_process');
+    const os = require('os') as typeof import('os');
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-wrapper-standalone-'));
+    try {
+      fs.cpSync(DIST, path.join(tmp, 'bin'), { recursive: true });
+      let stderr = '';
+      let exitCode = 0;
+      try {
+        execFileSync(process.execPath, [path.join(tmp, 'bin', 'mcp-wrapper.js')], {
+          encoding: 'utf-8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+        });
+      } catch (err) {
+        const e = err as { status?: number; stderr?: string };
+        exitCode = e.status ?? -1;
+        stderr = e.stderr ?? '';
+      }
+      // It must reach its own usage message. Reaching ANY of its own output
+      // proves the module graph loaded; a MODULE_NOT_FOUND never gets there.
+      expect(stderr).not.toMatch(/MODULE_NOT_FOUND|Cannot find module/);
+      expect(stderr).toMatch(/secretless-mcp: Usage:/);
+      expect(exitCode).toBe(1);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('EXIT_USAGE matches the code the CLI already uses for a usage error', () => {
+  it('is 2, not the scanner\'s 1', () => {
+    // 1 means "credentials found" for scan; a usage error must not be readable
+    // as a finding by a CI consumer.
+    expect(EXIT_USAGE).toBe(2);
+  });
+});

--- a/src/argv.test.ts
+++ b/src/argv.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
-import { prepareArgv, prepareBinArgv, VERBS, MCP_WRAPPER, EXIT_USAGE } from './argv';
+import { prepareArgv, prepareBinArgv, supportedFlags, VERBS, MCP_WRAPPER, EXIT_USAGE } from './argv';
 
 /**
  * The argv layer, unit level.
@@ -335,5 +335,43 @@ describe('EXIT_USAGE matches the code the CLI already uses for a usage error', (
     // 1 means "credentials found" for scan; a usage error must not be readable
     // as a finding by a CI consumer.
     expect(EXIT_USAGE).toBe(2);
+  });
+});
+
+/**
+ * A refusal message may not advertise a flag the verb does not implement.
+ *
+ * `supportedFlags` unioned GLOBAL_FLAGS into every verb, so refusing a command
+ * line printed `Supported: ..., --json, ...` for all 32 verbs while two honor
+ * it — and `verify --json` prints human text and exits 0. That is a promise of
+ * a machine-readable mode that does not exist, made in the one place a user
+ * reads after hitting an error, and it contradicted this release's own note
+ * that `--json` is unchanged. Accepting the flag is unchanged; naming it is not.
+ */
+describe('supportedFlags names only what the verb honors', () => {
+  it('exactly the verbs implementing --json advertise it', () => {
+    const advertising = Object.entries(VERBS)
+      .filter(([, spec]) => supportedFlags(spec).includes('--json'))
+      .map(([verb]) => verb)
+      .sort();
+    // Oracle is the SOURCE: the verbs whose dispatch actually reads the flag.
+    const cli = fs.readFileSync(path.join(path.resolve(__dirname), 'cli.ts'), 'utf-8');
+    const implementing = cli.split('\n').filter((l) => l.includes("includes('--json')")).length;
+    expect(implementing).toBe(2);
+    expect(advertising).toEqual(['scan', 'status']);
+  });
+
+  it('a destructive verb does not offer --json in its refusal', () => {
+    const p = prepareArgv('clean', ['clean', '--dryrun']);
+    expect(p.errors).toHaveLength(1);
+    expect(supportedFlags(VERBS.clean)).not.toContain('--json');
+  });
+
+  it('CONTROL: the flags a verb DOES honor are still all named', () => {
+    // The filter must remove one flag, not shrink the list generally.
+    const listed = supportedFlags(VERBS.clean);
+    for (const f of ['--dry-run', '--last', '--path <value>', '--help']) {
+      expect(listed).toContain(f);
+    }
   });
 });

--- a/src/argv.ts
+++ b/src/argv.ts
@@ -77,6 +77,17 @@ export interface VerbSpec {
    * the command the user is wrapping.
    */
   passthrough?: boolean;
+  /**
+   * True when this verb actually implements `--json`.
+   *
+   * Acceptance of `--json` is global and unchanged (see GLOBAL_FLAGS); this
+   * governs only whether we NAME it as supported when refusing a command line.
+   * Naming it on the 30 verbs that ignore it would advertise a machine-readable
+   * mode that does not exist, in the text a user reads at the moment they hit
+   * an error — the same false-clean class this release exists to close, and it
+   * would contradict this release's own note that `--json` is unchanged.
+   */
+  honorsJson?: boolean;
 }
 
 /**
@@ -89,6 +100,9 @@ export interface VerbSpec {
  * belongs to its own release, so it is NOT made here. Listing `--json` keeps
  * this release's behaviour byte-identical and leaves the ruling exactly one
  * place to land: delete this entry and give the implementing verbs their own.
+ *
+ * ACCEPTING it globally is not the same as ADVERTISING it globally. Only verbs
+ * marked `honorsJson` name it in a refusal message — see `supportedFlags`.
  */
 const GLOBAL_FLAGS: Readonly<Record<string, boolean>> = {
   '--help': false,
@@ -124,12 +138,13 @@ export const VERBS: Readonly<Record<string, VerbSpec>> = {
       '--max-file-size': true,
     },
     unknownFlags: 'warn',
+    honorsJson: true,
   },
   // `status` already refuses an unknown flag today, via
   // `rejectUnknownFlagAsDirArg` — the flag falls through as its directory
   // argument. Keeping it at `reject` preserves that exit code while replacing a
   // message that called the flag a bad path with one that calls it a bad flag.
-  status: { flags: {}, unknownFlags: 'reject' },
+  status: { flags: {}, unknownFlags: 'reject', honorsJson: true },
   // `verify` is the one read-only verb where a swallowed flag changes the
   // ANSWER rather than wasting the run: `verify --alll` silently returns the
   // short report, and the user reads "36 known env vars not set (use --all to
@@ -272,6 +287,10 @@ export function supportedFlags(spec: VerbSpec): string[] {
   const all = { ...GLOBAL_FLAGS, ...spec.flags };
   return Object.keys(all)
     .filter((f) => f !== '-h')
+    // `--json` is accepted by every verb and implemented by two. Listing it as
+    // "Supported" everywhere promises a machine-readable mode that does not
+    // exist — and promises it in the one place a user reads after a refusal.
+    .filter((f) => f !== '--json' || spec.honorsJson === true)
     .sort()
     .map((f) => usageOf(f, all[f]));
 }

--- a/src/argv.ts
+++ b/src/argv.ts
@@ -1,0 +1,386 @@
+/**
+ * argv normalisation — one derivation, applied once at the entry point.
+ *
+ * WHY THIS FILE EXISTS. Every command used to parse its own argv, and each
+ * parser recognised exactly the spellings its author happened to think of.
+ * `--only=NAME` was not one of them, so `run` dropped the selector and injected
+ * the ENTIRE credential store into the child process. `--dryrun` was not one of
+ * them, so `clean` performed the irreversible in-place redaction it had been
+ * asked to preview. `--path=DIR` was not one of them, so `clean` walked every
+ * transcript on the machine instead of the one directory named — measured at
+ * 9,119 files against the 1 the user asked for.
+ *
+ * Those are not three bugs. They are one: a token the user typed is discarded,
+ * and the command proceeds with a scope WIDER than the one requested, exits 0,
+ * and says nothing. `--only` and `--path` are both scope NARROWING flags, which
+ * is what makes dropping them dangerous rather than merely annoying.
+ *
+ * THE RULE. A flag that is present, in any spelling, never widens scope. It
+ * binds, or the command refuses to run.
+ *
+ * WHY IT IS NOT AN `=` BRANCH PER COMMAND. That was the obvious fix and it is
+ * the wrong one: it adds a parsing surface to every command, and a parsing
+ * surface per command is precisely what produced this class. Normalisation
+ * happens once, here, before dispatch. Every existing downstream consumer —
+ * `args.includes('--dry-run')`, `args.indexOf('--path')` — keeps working
+ * unchanged, because by the time it runs it is looking at the split form.
+ *
+ * SAFETY PROPERTY OF AN INCOMPLETE REGISTRY. Splitting only ever happens for a
+ * flag this file records as taking a value. An unregistered `--foo=bar` is left
+ * whole and falls through to the unknown-flag path exactly as it does today, so
+ * a gap in the table degrades to the OLD behaviour and can never invent a
+ * positional argument the user did not type. The direction of that failure is
+ * deliberate.
+ */
+
+/**
+ * IMPORTS ARE LOAD-BEARING HERE. `mcp-wrapper.ts` imports this module, and
+ * `protect-mcp` installs the wrapper by copying `dist/` — and ONLY `dist/` — to
+ * `~/.secretless-ai/bin`. Anything this module reaches that lives outside
+ * `dist/` is therefore missing in the installed layout. An earlier draft
+ * imported `commands/utils` for its `CLI_BARE` constant, which does
+ * `require('../../package.json')`; in the copied tree that path does not exist,
+ * so every protected MCP server died at startup with MODULE_NOT_FOUND. Caught
+ * by `mcp/e2e.test.ts`, which spawns the wrapper from a real installed copy.
+ *
+ * Keep this module's dependencies to leaf modules with no package-relative
+ * requires. Presentation that needs `CLI_BARE` lives in `cli.ts` instead.
+ */
+import { nearestMatch } from './near-miss';
+
+/**
+ * Exit code for a usage error, matching what the CLI already uses for one:
+ * `scan` refusing multiple paths and `rejectUnknownFlagAsDirArg` both return 2.
+ * Reserved from the scanner's own 0/1, where 1 means "credentials found".
+ */
+export const EXIT_USAGE = 2;
+
+/** How a verb treats a flag it does not recognise. */
+export type UnknownFlagPolicy =
+  /** Refuse to run, exit EXIT_USAGE, before any side effect. */
+  | 'reject'
+  /** Print a warning and continue — the behaviour `scan` has shipped since #81. */
+  | 'warn';
+
+export interface VerbSpec {
+  /** Flag spelling -> whether it consumes the FOLLOWING argv token as its value. */
+  flags: Record<string, boolean>;
+  /**
+   * What to do with a flag not in `flags`. `reject` on every verb that can
+   * write, because a misspelled safety flag there is a destroyed file; `warn`
+   * on read-only verbs, where the cost of a typo is a wasted run.
+   */
+  unknownFlags: UnknownFlagPolicy;
+  /**
+   * True when everything from the first bare `--` is a child command. That tail
+   * is the CHILD's argv, not ours: rewriting `--only=x` inside it would corrupt
+   * the command the user is wrapping.
+   */
+  passthrough?: boolean;
+}
+
+/**
+ * Accepted by every verb.
+ *
+ * `--json` is here because 20 verbs accept and silently ignore it today. The
+ * 2026-08-12 `[CHIEF-CPO]` ruling is that a flag the tool accepts is a flag the
+ * tool honors, and that `--json` on a verb that does not implement it must exit
+ * 2 naming the verbs that do. That is a consumer-visible exit-code change and
+ * belongs to its own release, so it is NOT made here. Listing `--json` keeps
+ * this release's behaviour byte-identical and leaves the ruling exactly one
+ * place to land: delete this entry and give the implementing verbs their own.
+ */
+const GLOBAL_FLAGS: Readonly<Record<string, boolean>> = {
+  '--help': false,
+  '-h': false,
+  '--json': false,
+};
+
+/**
+ * Every verb the dispatcher accepts, with the flags it actually reads.
+ *
+ * `unknownFlags` is keyed on whether the verb can WRITE — mutate a file, the
+ * credential store, or system state — not on how dangerous it feels. `clean`
+ * and `clean-history` are the sharpest cases: both are destructive by default
+ * and `--dry-run` is the only thing that makes either a preview, so a
+ * misspelling of that flag has to stop the run rather than degrade to it.
+ *
+ * A verb whose flag list is incomplete would reject a working command, so
+ * `argv.test.ts` derives the flag literals from the source and asserts this
+ * table covers them. The test reads the source, not this table, so the two
+ * cannot agree by construction.
+ */
+export const VERBS: Readonly<Record<string, VerbSpec>> = {
+  // --- read-only: a typo costs a wasted run, so warn and continue -----------
+  scan: {
+    flags: {
+      '--history': false,
+      '--include-tests': false,
+      '--explain': false,
+      '--no-ignore': false,
+      '--show-placeholders': false,
+      '--min-confidence': true,
+      '--max-files': true,
+      '--max-file-size': true,
+    },
+    unknownFlags: 'warn',
+  },
+  // `status` already refuses an unknown flag today, via
+  // `rejectUnknownFlagAsDirArg` — the flag falls through as its directory
+  // argument. Keeping it at `reject` preserves that exit code while replacing a
+  // message that called the flag a bad path with one that calls it a bad flag.
+  status: { flags: {}, unknownFlags: 'reject' },
+  // `verify` is the one read-only verb where a swallowed flag changes the
+  // ANSWER rather than wasting the run: `verify --alll` silently returns the
+  // short report, and the user reads "36 known env vars not set (use --all to
+  // list)" believing they ran the full listing.
+  verify: { flags: { '--all': false }, unknownFlags: 'reject' },
+  'scan-staged': { flags: { '--no-ignore': false }, unknownFlags: 'warn' },
+  'scan-history': { flags: {}, unknownFlags: 'warn' },
+  'mcp-status': { flags: {}, unknownFlags: 'warn' },
+  feedback: { flags: {}, unknownFlags: 'warn' },
+  // No flags of its own: `diff` reads one positional ref (commands/diff.ts:292).
+  // The `--no-color`, `--verify` and `--show-toplevel` literals in that file are
+  // arguments it passes to `git`, not flags it accepts — the distinction matters
+  // because listing them here would make the tool silently accept three flags it
+  // does not implement.
+  diff: { flags: {}, unknownFlags: 'warn' },
+
+  // --- writing verbs: a swallowed flag is a changed file --------------------
+  clean: {
+    flags: { '--dry-run': false, '--last': false, '--path': true },
+    unknownFlags: 'reject',
+  },
+  'clean-history': {
+    flags: { '--dry-run': false },
+    unknownFlags: 'reject',
+  },
+  run: {
+    flags: { '--only': true },
+    unknownFlags: 'reject',
+    passthrough: true,
+  },
+  env: {
+    flags: { '--only': true },
+    unknownFlags: 'reject',
+  },
+  init: { flags: {}, unknownFlags: 'reject' },
+  doctor: { flags: { '--fix': false }, unknownFlags: 'reject' },
+  import: { flags: { '--detect': false }, unknownFlags: 'reject' },
+  setup: { flags: { '--check': false }, unknownFlags: 'reject' },
+  secret: { flags: { '--force': false }, unknownFlags: 'reject' },
+  watch: { flags: {}, unknownFlags: 'reject' },
+  hook: { flags: { '--check-only': false }, unknownFlags: 'reject' },
+  warm: { flags: { '--ttl': true, '--no-broker': false }, unknownFlags: 'reject' },
+  install: { flags: {}, unknownFlags: 'reject' },
+  'protect-mcp': { flags: { '--backend': true }, unknownFlags: 'reject' },
+  'mcp-unprotect': { flags: {}, unknownFlags: 'reject' },
+  ignore: { flags: { '--pattern': true }, unknownFlags: 'reject' },
+  telemetry: { flags: {}, unknownFlags: 'reject' },
+  rules: { flags: { '--env': false, '--file': false, '--bash': false }, unknownFlags: 'reject' },
+  backend: {
+    flags: { '--yes': false, '--prefix': true, '--from': true, '--to': true },
+    unknownFlags: 'reject',
+  },
+  migrate: { flags: { '--from': true, '--to': true }, unknownFlags: 'reject' },
+  cache: { flags: {}, unknownFlags: 'reject' },
+  scope: { flags: {}, unknownFlags: 'reject' },
+  broker: {
+    flags: {
+      '--aim-url': true,
+      '--aim-token': true,
+      '--port': true,
+      '--policy-file': true,
+    },
+    unknownFlags: 'reject',
+  },
+  vault: {
+    // The union of every subcommand's flags rather than a per-subcommand table:
+    // accepting `--limit` on `vault add` is what the tool does today and is not
+    // what this release is about, while a per-subcommand table would be a
+    // second parsing surface — the thing this file exists to avoid.
+    flags: {
+      '--name': true,
+      '--value': true,
+      '--env': true,
+      '--description': true,
+      '--operations': true,
+      '--url-patterns': true,
+      '--limit': true,
+      '--since': true,
+      '--namespace': true,
+      '--env-name': true,
+      '--env-file': true,
+      '--dry-run': false,
+    },
+    unknownFlags: 'reject',
+    passthrough: true,
+  },
+};
+
+/**
+ * `secretless-mcp`, the second published bin (package.json `bin`).
+ *
+ * It is not a verb of `secretless-ai` and has never been swept, which is the
+ * whole reason it is here: the broker fail-open survived two dedicated sweeps
+ * because both swept per COMMAND SURFACE, and this wrapper is a command surface
+ * nobody was looking at. It carries the identical
+ * `argv[i] === '--server' && argv[i + 1]` idiom, so `--vault-dir=/path` is
+ * dropped and the wrapper silently reads the DEFAULT vault instead of the one
+ * named — the same substitution as `clean --path=`, one bin over.
+ *
+ * `unknownFlags: 'warn'` rather than 'reject': these argv lines are written
+ * into MCP client configs by `protect-mcp` and are edited by hand afterwards,
+ * so refusing an unrecognised token would break a user's MCP server at startup
+ * for a flag that may simply be new. Binding the ones we do know is the fix;
+ * refusing the ones we do not is a separate decision with a different blast
+ * radius.
+ */
+export const MCP_WRAPPER: VerbSpec = {
+  flags: {
+    '--server': true,
+    '--client': true,
+    '--vault-dir': true,
+    '--vault-key': true,
+    '--backend': true,
+  },
+  unknownFlags: 'warn',
+  passthrough: true,
+};
+
+export interface PreparedArgv {
+  /** argv with every registered `--flag=value` split into two tokens. */
+  args: string[];
+  /**
+   * Non-flag tokens after the verb, with flag VALUES excluded — so a path is
+   * never mistaken for a value and a value is never mistaken for a path.
+   */
+  positionals: string[];
+  /** Print to stderr; the command still runs. */
+  warnings: string[];
+  /** Print to stderr and exit EXIT_USAGE; the command must NOT run. */
+  errors: string[];
+}
+
+/** `--path <value>` for a value-taking flag, `--dry-run` otherwise. */
+function usageOf(flag: string, takesValue: boolean): string {
+  return takesValue ? `${flag} <value>` : flag;
+}
+
+/** Every flag a verb accepts, in a stable order, for an error message. */
+export function supportedFlags(spec: VerbSpec): string[] {
+  const all = { ...GLOBAL_FLAGS, ...spec.flags };
+  return Object.keys(all)
+    .filter((f) => f !== '-h')
+    .sort()
+    .map((f) => usageOf(f, all[f]));
+}
+
+/**
+ * Normalise and validate one command line.
+ *
+ * `args` is the FULL argv after the node binary and script — `args[0]` is the
+ * verb — so the caller can keep passing the same array it always did.
+ */
+export function prepareArgv(verb: string | undefined, args: string[]): PreparedArgv {
+  const spec = verb ? VERBS[verb] : undefined;
+  // An unrecognised verb is the dispatcher's error to report, with its own help
+  // output. Rewriting argv for a command that will not run helps nobody.
+  if (!verb || !spec) return { args, positionals: [], warnings: [], errors: [] };
+  // args[0] is the verb; flags start at 1.
+  return prepareWithSpec(spec, args, 1);
+}
+
+/**
+ * The same normalisation for a bin whose argv has no leading verb — the
+ * `secretless-mcp` wrapper, whose first token is already a flag.
+ */
+export function prepareBinArgv(spec: VerbSpec, args: string[]): PreparedArgv {
+  return prepareWithSpec(spec, args, 0);
+}
+
+function prepareWithSpec(spec: VerbSpec, args: string[], firstFlagIndex: number): PreparedArgv {
+  // Split at the first bare `--` BEFORE touching anything, so the child's argv
+  // is preserved byte for byte.
+  const sepIdx = spec.passthrough ? args.indexOf('--') : -1;
+  const head = sepIdx === -1 ? args : args.slice(0, sepIdx);
+  const tail = sepIdx === -1 ? [] : args.slice(sepIdx);
+
+  const known: Record<string, boolean> = { ...GLOBAL_FLAGS, ...spec.flags };
+  const knownNames = Object.keys(known);
+
+  const out: string[] = [];
+  const positionals: string[] = [];
+  const warnings: string[] = [];
+  const errors: string[] = [];
+  const unknown: string[] = [];
+
+  for (let i = 0; i < head.length; i++) {
+    const token = head[i];
+
+    // The verb itself, where there is one.
+    if (i < firstFlagIndex) { out.push(token); continue; }
+
+    if (!token.startsWith('--')) {
+      out.push(token);
+      positionals.push(token);
+      continue;
+    }
+
+    const eq = token.indexOf('=');
+    const name = eq === -1 ? token : token.slice(0, eq);
+    const inline = eq === -1 ? undefined : token.slice(eq + 1);
+    const takesValue = known[name];
+
+    if (takesValue === undefined) {
+      // Left WHOLE on purpose. Splitting an unregistered `--foo=bar` would push
+      // `bar` into the positional list, and for `scan` or `clean` a stray
+      // positional is a path — a token the user never typed becoming a target.
+      unknown.push(token);
+      out.push(token);
+      continue;
+    }
+
+    if (takesValue) {
+      if (inline !== undefined) {
+        // `--only=` (empty) is the flag WITH an empty value, not the flag
+        // absent. That distinction is load-bearing: `--only ''` fails closed
+        // downstream while a missing `--only` injects everything (#110).
+        out.push(name, inline);
+        continue;
+      }
+      if (i + 1 >= head.length) {
+        errors.push(`${name} needs a value, but none was given.`);
+        out.push(token);
+        continue;
+      }
+      out.push(name, head[i + 1]);
+      // Consumed, so the value can never be re-read as a flag or a positional.
+      i++;
+      continue;
+    }
+
+    if (inline !== undefined) {
+      errors.push(`${name} does not take a value, but was given "${inline}".`);
+      out.push(name);
+      continue;
+    }
+    out.push(token);
+  }
+
+  if (unknown.length > 0) {
+    const lines = unknown.map((u) => {
+      const near = nearestMatch(u, knownNames);
+      return near ? `${u} (did you mean ${usageOf(near, known[near])}?)` : u;
+    });
+    const plural = unknown.length > 1 ? 's' : '';
+    if (spec.unknownFlags === 'reject') {
+      errors.push(`Unknown option${plural}: ${lines.join(', ')}`);
+    } else {
+      warnings.push(`Warning: ignoring unknown flag${plural} ${lines.join(', ')}.`);
+    }
+  }
+
+  return { args: out.concat(tail), positionals, warnings, errors };
+}
+

--- a/src/broker/aap-conformance.test.ts
+++ b/src/broker/aap-conformance.test.ts
@@ -202,7 +202,13 @@ describe('AAP v1 conformance: no credential or backend identifier in the agent c
     });
 
     server = new BrokerServer(
-      { socketPath, httpPort: 0, auditLog: auditPath, tokenFile: tokenPath },
+      // policyFile is pinned into the test's own tmpdir. Omitted, PolicyEngine
+      // falls back to ~/.secretless-ai/broker-policies.json, so this suite's
+      // result depended on the machine's real policy file — it passed here
+      // because that file happened to validate, and started failing the moment
+      // policy validation got stricter. A conformance suite must not read
+      // developer state.
+      { socketPath, httpPort: 0, auditLog: auditPath, tokenFile: tokenPath, policyFile: path.join(tmpDir, 'broker-policies.json') },
       { aimClient: null, grantResolver },
     );
     await server.start();

--- a/src/broker/policy.test.ts
+++ b/src/broker/policy.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { PolicyEngine, matchGlob, isWithinTimeWindow } from './policy';
+import { PolicyEngine, matchGlob, isWithinTimeWindow, KNOWN_RULE_KEYS, KNOWN_CONSTRAINT_KEYS, KNOWN_ENVELOPE_KEYS } from './policy';
 import { RateLimiter } from './rate-limiter';
 import type { PolicyRule, AgentIdentity } from './types';
 
@@ -734,5 +734,156 @@ describe('no test constructs BrokerServer against the machine policy file', () =
     // exists. Pin it on there being something to check.
     expect(constructions).toBeGreaterThan(0);
     expect(offenders).toEqual([]);
+  });
+});
+
+/**
+ * The same predicate at every nesting level of operator-authored input.
+ *
+ * This defect has now been found four times, each a level further out or in:
+ * a constraint VALUE we could not type-match; the constraints CONTAINER
+ * misspelled; a sibling of `rules` in the ENVELOPE; and a SUB-KEY inside a
+ * structured constraint. Each fix matched the last instance rather than the
+ * class, which is why there was always another one. The question these assert
+ * is level-independent: is there an input that makes the rule WIDER than the
+ * operator wrote, while every surface reports it loaded?
+ */
+describe('PolicyEngine — no level of policy input silently drops what it cannot read', () => {
+  const tmpDirs: string[] = [];
+
+  function engineFor(doc: unknown): PolicyEngine {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'policy-levels-'));
+    tmpDirs.push(dir);
+    const file = path.join(dir, 'p.json');
+    fs.writeFileSync(file, JSON.stringify(doc));
+    return new PolicyEngine({ policyFile: file });
+  }
+
+  afterEach(() => {
+    for (const d of tmpDirs.splice(0)) {
+      try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  });
+
+  const ALLOW_ALL = { id: 'a1', agentSelector: '*', credentialSelector: '*', effect: 'allow' };
+  const DENY_ALL = { id: 'deny-all', agentSelector: '*', credentialSelector: '*', effect: 'deny' };
+
+  describe('the envelope', () => {
+    it('CONTROL: a deny rule under the real key denies', () => {
+      const engine = engineFor({ version: 1, rules: [DENY_ALL] });
+      expect(engine.loadPolicies()).toBe(1);
+      expect(engine.evaluate('agent-1', 'AWS_KEY').allowed).toBe(false);
+    });
+
+    it('refuses a sibling of `rules` rather than loading only half the policy', () => {
+      // Measured pre-fix: loaded=1, allowed=true, matched the allow rule. The
+      // operator's deny rules were never in the engine and nothing said so.
+      const engine = engineFor({ rules: [ALLOW_ALL], denyRules: [DENY_ALL] });
+      expect(() => engine.loadPolicies()).toThrow(/denyRules/);
+    });
+
+    it('a bare array is still accepted', () => {
+      const engine = engineFor([DENY_ALL]);
+      expect(engine.loadPolicies()).toBe(1);
+    });
+  });
+
+  describe('a constraint sub-key', () => {
+    const base = { id: 'r1', agentSelector: '*', credentialSelector: '*', effect: 'allow' };
+
+    it('CONTROL: the sub-keys we do read still load and still enforce', () => {
+      const engine = engineFor({ rules: [{ ...base, constraints: { timeWindow: { start: '00:00', end: '00:01' } } }] });
+      expect(engine.loadPolicies()).toBe(1);
+      expect(engine.evaluate('agent-1', 'AWS_KEY').allowed).toBe(false);
+    });
+
+    it.each([
+      ['rateLimit.maxPerHour — a cap we would silently drop', { rateLimit: { maxPerMinute: 60, maxPerHour: 1 } }],
+      ['timeWindow.End — a near-miss of end', { timeWindow: { start: '00:00', end: '23:59', End: '00:01' } }],
+      ['timeWindow.days — a restriction we do not implement', { timeWindow: { start: '00:00', end: '23:59', days: ['sun'] } }],
+      ['timeWindow.timezone — the window is server-local', { timeWindow: { start: '00:00', end: '23:59', timezone: 'UTC' } }],
+    ])('refuses %s', (_label, constraints) => {
+      const engine = engineFor({ rules: [{ ...base, constraints }] });
+      expect(() => engine.loadPolicies()).toThrow();
+    });
+  });
+
+  describe('an empty value that deletes the restriction', () => {
+    const base = { id: 'r1', agentSelector: '*', credentialSelector: '*', effect: 'allow' };
+
+    it('CONTROL: a named capability with no identity denies', () => {
+      const engine = engineFor({ rules: [{ ...base, constraints: { requireCapability: 'deploy' } }] });
+      expect(engine.loadPolicies()).toBe(1);
+      expect(engine.evaluate('agent-1', 'AWS_KEY').allowed).toBe(false);
+    });
+
+    it('refuses requireCapability: "" rather than skipping the gate', () => {
+      // Pre-fix the enforcement branch guarded on truthiness, so "" skipped the
+      // whole block INCLUDING its fail-closed no-identity arm: allowed=true.
+      const engine = engineFor({ rules: [{ ...base, constraints: { requireCapability: '' } }] });
+      expect(() => engine.loadPolicies()).toThrow(/must not be empty/);
+    });
+
+    it('refuses an empty selector, which matches nothing and so never denies', () => {
+      const engine = engineFor({ rules: [{ ...DENY_ALL, agentSelector: '' }] });
+      expect(() => engine.loadPolicies()).toThrow(/non-empty/);
+    });
+  });
+});
+
+/**
+ * The pin CISO found claimed but absent.
+ *
+ * `KNOWN_CONSTRAINT_KEYS` carried a comment stating it was "pinned by a test
+ * against PolicyConstraints". No such test existed — the symbol appeared in one
+ * file and no test file. A source comment asserting a test we do not have is
+ * the same class as a scanner reporting clean without looking, and it was
+ * shipped inside the commit fixing an authorization fail-open.
+ *
+ * The oracle is the TYPE DECLARATION, read from source. Deriving it from the
+ * runtime Set would let the two agree by construction and pin nothing.
+ */
+describe('the key allowlists are pinned to the type declarations', () => {
+  const TYPES = fs.readFileSync(path.resolve(__dirname, 'types.ts'), 'utf-8');
+
+  function fieldsOf(interfaceName: string): string[] {
+    const start = TYPES.indexOf(`export interface ${interfaceName} {`);
+    expect(start, `${interfaceName} not found in types.ts`).toBeGreaterThan(-1);
+    const body = TYPES.slice(start, TYPES.indexOf('\n}', start));
+    return [...body.matchAll(/^\s{2}([a-zA-Z][a-zA-Z0-9]*)\??:/gm)].map((m) => m[1]);
+  }
+
+  it('KNOWN_RULE_KEYS is exactly the fields of PolicyRule', () => {
+    const declared = fieldsOf('PolicyRule');
+    // Guard the guard: a regex that stopped matching would make this vacuous.
+    expect(declared.length).toBe(5);
+    expect([...KNOWN_RULE_KEYS].sort()).toEqual(declared.sort());
+  });
+
+  it('KNOWN_CONSTRAINT_KEYS is exactly the fields of PolicyConstraints', () => {
+    const declared = fieldsOf('PolicyConstraints');
+    expect(declared.length).toBeGreaterThan(0);
+    expect([...KNOWN_CONSTRAINT_KEYS].sort()).toEqual(declared.sort());
+  });
+
+  it('a constraint in the promise set has an enforcement branch', () => {
+    // The set's own comment calls it "a promise about what is applied, not a
+    // list of what parses". scopeCheck sat in it for thirteen published
+    // versions while its branch could not deny. This asserts the promise.
+    const impl = fs.readFileSync(path.resolve(__dirname, 'policy.ts'), 'utf-8');
+    const checkConstraints = impl.slice(impl.indexOf('private checkConstraints('), impl.indexOf('export function matchGlob'));
+    for (const key of KNOWN_CONSTRAINT_KEYS) {
+      expect(checkConstraints, `${key} is promised but never read in checkConstraints`).toContain(`constraints.${key}`);
+    }
+  });
+
+  it('KNOWN_ENVELOPE_KEYS covers what the documented example writes', () => {
+    const doc = fs.readFileSync(path.resolve(__dirname, '..', '..', 'docs', 'use-cases', 'run-broker.md'), 'utf-8');
+    // The example a user copies must load. If the docs grow a key, this fails
+    // before an operator's file does.
+    for (const key of ['version', 'rules']) {
+      expect(doc).toContain(`"${key}"`);
+      expect(KNOWN_ENVELOPE_KEYS.has(key)).toBe(true);
+    }
   });
 });

--- a/src/broker/policy.test.ts
+++ b/src/broker/policy.test.ts
@@ -442,3 +442,98 @@ describe('isWithinTimeWindow', () => {
     expect(isWithinTimeWindow('09:00', '17:00')).toBe(true);
   });
 });
+
+/**
+ * A constraint the engine cannot apply must REFUSE the rule, never widen it.
+ *
+ * Measured on 0.22.0 before this landed: each malformed shape below loaded as a
+ * rule with `constraints: {}` and `evaluate()` returned
+ * `{allowed: true, reason: 'Allowed by rule "r1"'}` — the restrictive half of
+ * the operator's rule dropped, the permissive half kept, and `loadPolicies()`
+ * reporting 1 so every status surface showed the policy as loaded.
+ */
+describe('PolicyEngine — an unappliable constraint refuses the rule', () => {
+  const tmpFiles: string[] = [];
+
+  function policyFile(constraints: unknown): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'policy-'));
+    const file = path.join(dir, 'p.json');
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        rules: [
+          {
+            id: 'r1',
+            agentSelector: '*',
+            credentialSelector: '*',
+            effect: 'allow',
+            constraints,
+          },
+        ],
+      }),
+    );
+    tmpFiles.push(file);
+    return file;
+  }
+
+  afterEach(() => {
+    for (const f of tmpFiles.splice(0)) {
+      try {
+        fs.rmSync(path.dirname(f), { recursive: true, force: true });
+      } catch {
+        /* best effort */
+      }
+    }
+  });
+
+  // Each row is a shape a YAML-to-JSON conversion, a templating layer or an
+  // env-var substitution actually produces.
+  const MALFORMED: Array<[string, unknown]> = [
+    ['timeWindow as numbers', { timeWindow: { start: 0, end: 1 } }],
+    ['timeWindow not "HH:MM"', { timeWindow: { start: '0:00', end: 'noon' } }],
+    ['rateLimit as a numeric string', { rateLimit: { maxPerMinute: '1' } }],
+    ['rateLimit zero', { rateLimit: { maxPerMinute: 0 } }],
+    ['minTrustScore as a string', { minTrustScore: '80' }],
+    ['requireCapability as a number', { requireCapability: 7 }],
+    ['scopeCheck as a string', { scopeCheck: 'true' }],
+    ['an unknown constraint key', { maxUses: 5 }],
+    ['constraints as an array', ['timeWindow']],
+  ];
+
+  for (const [label, constraints] of MALFORMED) {
+    it(`refuses to load: ${label}`, () => {
+      const e = new PolicyEngine({ policyFile: policyFile(constraints) });
+      expect(() => e.loadPolicies()).toThrow();
+    });
+
+    /**
+     * The security property, asserted separately from the throw.
+     *
+     * A rule that cannot be applied must never end up granting. Checking the
+     * throw alone would still pass if some later change caught the error and
+     * carried on with a widened rule, which is exactly the shape being fixed.
+     */
+    it(`never grants after: ${label}`, () => {
+      const e = new PolicyEngine({ policyFile: policyFile(constraints) });
+      try {
+        e.loadPolicies();
+      } catch {
+        /* refusing to load is the fix; the assertion below is the invariant */
+      }
+      expect(e.evaluate('agent-x', 'STRIPE_SECRET_KEY').allowed).toBe(false);
+    });
+  }
+
+  it('still loads and still ENFORCES a well-formed constraint', () => {
+    // The negative direction: refusing malformed input must not have been
+    // bought by refusing everything.
+    const e = new PolicyEngine({ policyFile: policyFile({ timeWindow: { start: '00:00', end: '00:01' } }) });
+    expect(e.loadPolicies()).toBe(1);
+    expect(e.getRules()[0].constraints).toEqual({ timeWindow: { start: '00:00', end: '00:01' } });
+  });
+
+  it('accepts a rule with no constraints at all', () => {
+    const e = new PolicyEngine({ policyFile: policyFile(undefined) });
+    expect(e.loadPolicies()).toBe(1);
+  });
+});

--- a/src/broker/policy.test.ts
+++ b/src/broker/policy.test.ts
@@ -887,3 +887,51 @@ describe('the key allowlists are pinned to the type declarations', () => {
     }
   });
 });
+
+/**
+ * A glob DENY rule must not be defeated by a line terminator.
+ *
+ * `.` does not match `\n`, and `pattern === '*'` short-circuits before the
+ * regex, so a wildcard ALLOW matched a newline-bearing value that every glob
+ * DENY missed. Measured: `deny AWS_*` + `allow *` against `"AWS_KEY\n"`
+ * returned allowed=true, matching the allow rule, while the same policy against
+ * `"AWS_KEY"` correctly denied.
+ *
+ * Not exploitable today for a credential — `getSecret` rejects such a name at
+ * SAFE_NAME before the store, the MCP vault or the env fallback is reached, so
+ * nothing resolves. It is the authorization DECISION that was wrong, and this
+ * pins it so it stays right if name validation ever moves.
+ */
+describe('matchGlob is not defeated by a line terminator', () => {
+  it.each([
+    ['newline', '\n'],
+    ['carriage return', '\r'],
+    ['line separator U+2028', ' '],
+    ['paragraph separator U+2029', ' '],
+  ])('a glob matches a value containing a %s, as `*` already did', (_label, ch) => {
+    // The asymmetry IS the defect: these two must agree.
+    expect(matchGlob('*', `AWS_KEY${ch}`)).toBe(true);
+    expect(matchGlob('AWS_*', `AWS_KEY${ch}`)).toBe(true);
+    expect(matchGlob('?', ch)).toBe(true);
+  });
+
+  it('a deny rule fires on a newline-bearing credential name', () => {
+    const engine = new PolicyEngine({ rateLimiter: new RateLimiter() });
+    engine.loadRules([
+      { id: 'deny-aws', agentSelector: '*', credentialSelector: 'AWS_*', constraints: {}, effect: 'deny' },
+      { id: 'allow-all', agentSelector: '*', credentialSelector: '*', constraints: {}, effect: 'allow' },
+    ]);
+    // CONTROL: the ordinary name is denied, so the policy is doing its job.
+    expect(engine.evaluate('agent-1', 'AWS_KEY').matchedRuleId).toBe('deny-aws');
+    // ARM: pre-fix this returned allowed=true, matched by allow-all.
+    expect(engine.evaluate('agent-1', 'AWS_KEY\n').allowed).toBe(false);
+    expect(engine.evaluate('agent-1\n', 'AWS_KEY').allowed).toBe(false);
+  });
+
+  it('CONTROL: a glob still does NOT match a value it should not', () => {
+    // Widening the character class must not widen the match itself.
+    expect(matchGlob('AWS_*', 'GCP_KEY')).toBe(false);
+    expect(matchGlob('a.b', 'aXb')).toBe(false);
+    expect(matchGlob('?', 'ab')).toBe(false);
+  });
+});

--- a/src/broker/policy.test.ts
+++ b/src/broker/policy.test.ts
@@ -537,3 +537,202 @@ describe('PolicyEngine — an unappliable constraint refuses the rule', () => {
     expect(e.loadPolicies()).toBe(1);
   });
 });
+
+/**
+ * A rule field we do not read is refused, not ignored.
+ *
+ * The sibling block above closes the same fail-open one level down: a
+ * constraint whose VALUE we cannot type-match. This closes the container.
+ * Misspelling `constraints` left `r.constraints` undefined, so the whole
+ * constraint block never ran and the rule loaded as an unconstrained ALLOW,
+ * while `loadPolicies()`, `getRules()` and `/health` all reported it loaded —
+ * verbatim the failure mode the constraint-key fix was written for, still
+ * reachable in the build that fixed it.
+ */
+describe('PolicyEngine — a rule field we do not read refuses the rule', () => {
+  const tmpDirs: string[] = [];
+
+  function policyFileFor(rule: Record<string, unknown>): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'policy-toplevel-'));
+    tmpDirs.push(dir);
+    const file = path.join(dir, 'p.json');
+    fs.writeFileSync(file, JSON.stringify({ rules: [rule] }));
+    return file;
+  }
+
+  const BASE = { id: 'r1', agentSelector: '*', credentialSelector: '*', effect: 'allow' };
+  // A window that has already closed, so an HONOURED constraint must deny.
+  // Using a constraint that DENIES is what makes the controls discriminate:
+  // a rule that loads with its constraints intact returns allowed=false, and a
+  // rule that silently lost them returns allowed=true.
+  const CLOSED_WINDOW = { timeWindow: { start: '00:00', end: '00:01' } };
+
+  afterEach(() => {
+    for (const d of tmpDirs.splice(0)) {
+      try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  });
+
+  // POSITIVE CONTROLS. Both pass before and after the fix. Without them a
+  // validator that refused every rule would satisfy the arms below.
+  it('CONTROL: the correctly spelled container still loads and still denies', () => {
+    const engine = new PolicyEngine({ policyFile: policyFileFor({ ...BASE, constraints: CLOSED_WINDOW }) });
+    expect(engine.loadPolicies()).toBe(1);
+    expect(engine.getRules()[0].constraints.timeWindow).toEqual(CLOSED_WINDOW.timeWindow);
+    expect(engine.evaluate('agent-1', 'DEPLOY_TOKEN').allowed).toBe(false);
+  });
+
+  it('CONTROL: a rule with no constraints at all is still legitimate', () => {
+    // "constraints absent" cannot itself be an error — an unconstrained allow
+    // rule is a real thing an operator writes.
+    const engine = new PolicyEngine({ policyFile: policyFileFor({ ...BASE }) });
+    expect(engine.loadPolicies()).toBe(1);
+    expect(engine.evaluate('agent-1', 'DEPLOY_TOKEN').allowed).toBe(true);
+  });
+
+  const UNKNOWN_FIELDS: Array<[string, Record<string, unknown>]> = [
+    ['contraints — the measured typo', { ...BASE, contraints: CLOSED_WINDOW }],
+    ['constraint — singular', { ...BASE, constraint: CLOSED_WINDOW }],
+    ['a documentation annotation', { ...BASE, constraints: CLOSED_WINDOW, description: 'allow deploys' }],
+    ['an invented field', { ...BASE, constraints: CLOSED_WINDOW, priority: 10 }],
+    ['effect misspelled, so the real effect is absent', { ...BASE, efect: 'deny' }],
+  ];
+
+  it.each(UNKNOWN_FIELDS)('refuses a rule carrying %s', (_label, rule) => {
+    const engine = new PolicyEngine({ policyFile: policyFileFor(rule) });
+    expect(() => engine.loadPolicies()).toThrow();
+  });
+
+  it('the refusal names the offending field and the legal set', () => {
+    const engine = new PolicyEngine({ policyFile: policyFileFor({ ...BASE, contraints: CLOSED_WINDOW }) });
+    let message = '';
+    try { engine.loadPolicies(); } catch (err) { message = (err as Error).message; }
+    expect(message).toContain('contraints');
+    expect(message).toContain('did you mean "constraints"');
+    for (const key of ['id', 'agentSelector', 'credentialSelector', 'constraints', 'effect']) {
+      expect(message).toContain(key);
+    }
+  });
+
+  // The property, stated once: no rule that carries an unreadable field may
+  // ever load. Asserting the rule SET rather than an error string, because a
+  // refusal that loaded the rule anyway would still throw somewhere.
+  it('nothing is loaded when a rule is refused', () => {
+    const engine = new PolicyEngine({ policyFile: policyFileFor({ ...BASE, contraints: CLOSED_WINDOW }) });
+    try { engine.loadPolicies(); } catch { /* expected */ }
+    expect(engine.getRules()).toEqual([]);
+    expect(engine.evaluate('agent-1', 'DEPLOY_TOKEN').allowed).toBe(false);
+  });
+});
+
+/**
+ * A constraint we parse but do not enforce is refused, not accepted.
+ *
+ * `scopeCheck` sat in the known-constraint set and was documented as "deny if
+ * credential permissions expanded since last baseline". It could not deny:
+ * `checkConstraints` called `compareToBaseline(credentialName, '', [])`, and
+ * expansion is computed from that empty current-permission list, so it was
+ * false for every baseline. Measured before removal — the same comparison
+ * returns hasExpanded: true when handed real permissions, so the call site was
+ * what disabled it, not the comparison.
+ */
+describe('PolicyEngine — an unenforced constraint refuses the rule', () => {
+  const tmpDirs: string[] = [];
+
+  function engineFor(constraints: unknown): PolicyEngine {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'policy-unenforced-'));
+    tmpDirs.push(dir);
+    const file = path.join(dir, 'p.json');
+    fs.writeFileSync(file, JSON.stringify({
+      rules: [{ id: 'r1', agentSelector: '*', credentialSelector: '*', effect: 'allow', constraints }],
+    }));
+    return new PolicyEngine({ policyFile: file });
+  }
+
+  afterEach(() => {
+    for (const d of tmpDirs.splice(0)) {
+      try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  });
+
+  it.each([
+    ['true', true],
+    ['false', false],
+    ['a string', 'true'],
+  ])('refuses scopeCheck: %s rather than reporting a gate that is not there', (_label, value) => {
+    const engine = engineFor({ scopeCheck: value });
+    expect(() => engine.loadPolicies()).toThrow(/does not enforce scopeCheck/);
+  });
+
+  it('says it is unenforced, not that it is unknown', () => {
+    // The distinction is the whole point: "unknown constraint" would tell an
+    // operator they typed it wrong. They did not — we removed it.
+    const engine = engineFor({ scopeCheck: true });
+    let message = '';
+    try { engine.loadPolicies(); } catch (err) { message = (err as Error).message; }
+    expect(message).toContain('does not enforce');
+    expect(message).not.toContain('unknown constraint');
+  });
+
+  it('CONTROL: the constraints that ARE enforced still load', () => {
+    const engine = engineFor({ timeWindow: { start: '00:00', end: '23:59' }, minTrustScore: 80 });
+    expect(engine.loadPolicies()).toBe(1);
+    expect(engine.getRules()[0].constraints.minTrustScore).toBe(80);
+  });
+});
+
+/**
+ * Gate integrity: no suite may read the developer's real policy file.
+ *
+ * `PolicyEngine` defaults to ~/.secretless-ai/broker-policies.json, so a
+ * `BrokerServer` built without an explicit `policyFile` takes its authorization
+ * rules from whatever is on the machine running the tests. The AAP conformance
+ * suite did exactly that and was green because that file happened to validate —
+ * it started failing the moment policy validation got stricter, which means it
+ * had never been measuring what it claimed. Fixing the one instance leaves the
+ * class open, so this asserts the class.
+ */
+describe('no test constructs BrokerServer against the machine policy file', () => {
+  const SRC = path.resolve(__dirname, '..');
+
+  function testFiles(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) { out.push(...testFiles(full)); continue; }
+      if (entry.name.endsWith('.test.ts')) out.push(full);
+    }
+    return out;
+  }
+
+  it('every `new BrokerServer(` in a test passes an explicit policyFile', () => {
+    const offenders: string[] = [];
+    let constructions = 0;
+
+    for (const file of testFiles(SRC)) {
+      const text = fs.readFileSync(file, 'utf-8');
+      let idx = text.indexOf('new BrokerServer(');
+      while (idx !== -1) {
+        // Skip the literal inside this guard's own source. A real construction
+        // is preceded by whitespace or `=`, never by a quote.
+        if (idx > 0 && `'"\``.includes(text[idx - 1])) {
+          idx = text.indexOf('new BrokerServer(', idx + 1);
+          continue;
+        }
+        constructions++;
+        // The config object is the first argument; scan to the end of the call.
+        const window = text.slice(idx, idx + 600);
+        if (!window.includes('policyFile')) {
+          const line = text.slice(0, idx).split('\n').length;
+          offenders.push(`${path.relative(SRC, file)}:${line}`);
+        }
+        idx = text.indexOf('new BrokerServer(', idx + 1);
+      }
+    }
+
+    // A guard that found no constructions would pass whether or not the class
+    // exists. Pin it on there being something to check.
+    expect(constructions).toBeGreaterThan(0);
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/broker/policy.ts
+++ b/src/broker/policy.ts
@@ -11,7 +11,7 @@ import * as path from 'path';
 import * as os from 'os';
 import type { PolicyRule, PolicyConstraints, AgentIdentity } from './types';
 import { RateLimiter } from './rate-limiter';
-import { compareToBaseline } from '../scope/baselines';
+import { nearestMatch } from '../near-miss';
 
 const DEFAULT_POLICY_FILE = path.join(os.homedir(), '.secretless-ai', 'broker-policies.json');
 
@@ -174,17 +174,13 @@ export class PolicyEngine {
       }
     }
 
-    // Scope check
-    if (constraints.scopeCheck) {
-      const scopeResult = compareToBaseline(credentialName, '', []);
-      // Only enforce if a baseline exists (baselinePermissions > 0 means we have a baseline)
-      if (scopeResult.baselinePermissions.length > 0 && scopeResult.hasExpanded) {
-        return {
-          passed: false,
-          reason: `Credential scope has expanded since baseline (+${scopeResult.added.length} permissions)`,
-        };
-      }
-    }
+    // No scope check. It lived here, and it could not deny: it called
+    // compareToBaseline with an empty current-permission list, and expansion is
+    // computed from that list, so the deny branch was unreachable for every
+    // baseline. The key is now refused at load (UNENFORCED_CONSTRAINT_KEYS)
+    // rather than accepted and not applied, so there is nothing to enforce
+    // here. Real enforcement needs live permission discovery in the resolve
+    // path — latency, egress and error semantics — and is its own unit.
 
     // Capability check
     if (constraints.requireCapability) {
@@ -283,7 +279,59 @@ const KNOWN_CONSTRAINT_KEYS = new Set([
   'rateLimit',
   'minTrustScore',
   'requireCapability',
-  'scopeCheck',
+]);
+
+/**
+ * The five keys a policy rule may carry, mirroring `PolicyRule` in ./types.
+ *
+ * A rule is refused if it carries anything else. Misspelling the CONTAINER
+ * reaches the same place misspelling a constraint did: `contraints: {...}` left
+ * `r.constraints` undefined, so the block below never ran, and the rule loaded
+ * as an unconstrained ALLOW while `loadPolicies()`, `getRules()` and `/health`
+ * all reported it loaded. That is the same fail-open the constraint-key check
+ * closes, one level up, and it was reachable in the build that fixed the inner
+ * one.
+ *
+ * Deliberately NOT tolerating annotation keys (`description`, `comment`): the
+ * shipped example in docs/use-cases/run-broker.md and every fixture use exactly
+ * these five, so tolerance buys no compatibility, and each tolerated key is one
+ * more near-miss neighbour for the typo this exists to catch.
+ *
+ * Deliberately NOT auto-correcting a near miss to the key it resembles. Binding
+ * a key the operator did not write is a guess about intent inside the
+ * authorization path; the error names the likely intent instead.
+ */
+const KNOWN_RULE_KEYS = new Set([
+  'id',
+  'agentSelector',
+  'credentialSelector',
+  'constraints',
+  'effect',
+]);
+
+/**
+ * Constraints this build parses but does not enforce, with the reason.
+ *
+ * A rule naming one is REFUSED, not ignored. `scopeCheck` sat in the known set
+ * and was documented as "deny if credential permissions expanded since last
+ * baseline", while `checkConstraints` called
+ * `compareToBaseline(credentialName, '', [])` — an empty current-permission
+ * list, from which `hasExpanded` is computed, so it was false for every
+ * baseline and the deny branch was unreachable. Measured: the same function
+ * returns `hasExpanded: true` when given real permissions, so the call site was
+ * what disabled it, not the comparison. An operator's scope-drift gate was
+ * inert while every surface reported it enforced.
+ *
+ * Accepting the key with no enforcement is the failure mode this file is about,
+ * so it is refused until the enforcement exists.
+ */
+const UNENFORCED_CONSTRAINT_KEYS = new Map<string, string>([
+  [
+    'scopeCheck',
+    'this build does not enforce scopeCheck — it never denied a request, so accepting it ' +
+    'would report a scope-drift gate that is not there. Remove it from the rule; a rule ' +
+    'without it is enforced exactly as written.',
+  ],
 ]);
 
 /** "HH:MM", 00:00-23:59. */
@@ -298,6 +346,20 @@ function validateRule(raw: unknown): PolicyRule {
 
   if (typeof r.id !== 'string' || !r.id) {
     throw new Error('Policy rule must have a non-empty "id" string');
+  }
+
+  // Top-level keys are checked BEFORE the constraint block, because the defect
+  // this closes is that a misspelled container never reaches that block at all.
+  for (const key of Object.keys(r)) {
+    if (KNOWN_RULE_KEYS.has(key)) continue;
+    const near = nearestMatch(key, [...KNOWN_RULE_KEYS]);
+    throw new Error(
+      `Rule "${r.id}": unknown field "${key}"${near ? ` (did you mean "${near}"?)` : ''}. ` +
+      `A rule may carry: ${[...KNOWN_RULE_KEYS].join(', ')}. ` +
+      `A field this build does not read is refused rather than ignored, because ignoring ` +
+      `"${key}" would drop whatever it was meant to restrict and load the rule as written ` +
+      `without it.`,
+    );
   }
   if (typeof r.agentSelector !== 'string') {
     throw new Error(`Rule "${r.id}": agentSelector must be a string`);
@@ -341,6 +403,10 @@ function validateRule(raw: unknown): PolicyRule {
     const c = r.constraints as Record<string, unknown>;
 
     for (const key of Object.keys(c)) {
+      const unenforced = UNENFORCED_CONSTRAINT_KEYS.get(key);
+      if (unenforced) {
+        throw new Error(`Rule "${r.id}": ${unenforced}`);
+      }
       if (!KNOWN_CONSTRAINT_KEYS.has(key)) {
         throw new Error(
           `Rule "${r.id}": unknown constraint "${key}". ` +
@@ -399,12 +465,6 @@ function validateRule(raw: unknown): PolicyRule {
       constraints.requireCapability = c.requireCapability;
     }
 
-    if (c.scopeCheck !== undefined) {
-      if (typeof c.scopeCheck !== 'boolean') {
-        throw new Error(`Rule "${r.id}": scopeCheck must be a boolean`);
-      }
-      constraints.scopeCheck = c.scopeCheck;
-    }
   }
 
   return {

--- a/src/broker/policy.ts
+++ b/src/broker/policy.ts
@@ -269,6 +269,26 @@ function parseTimeToMinutes(time: string): number {
   return hours * 60 + minutes;
 }
 
+/**
+ * Every constraint this build knows how to ENFORCE.
+ *
+ * Derived by hand and pinned by a test against `PolicyConstraints`, so a new
+ * constraint added to the type without being added here fails the suite rather
+ * than being silently refused at runtime — and one added here without an
+ * enforcement branch in `checkConstraints` fails too. The set is a promise
+ * about what is applied, not a list of what parses.
+ */
+const KNOWN_CONSTRAINT_KEYS = new Set([
+  'timeWindow',
+  'rateLimit',
+  'minTrustScore',
+  'requireCapability',
+  'scopeCheck',
+]);
+
+/** "HH:MM", 00:00-23:59. */
+const TIME_OF_DAY = /^([01][0-9]|2[0-3]):[0-5][0-9]$/;
+
 function validateRule(raw: unknown): PolicyRule {
   if (!raw || typeof raw !== 'object') {
     throw new Error('Policy rule must be an object');
@@ -289,33 +309,100 @@ function validateRule(raw: unknown): PolicyRule {
     throw new Error(`Rule "${r.id}": effect must be "allow" or "deny"`);
   }
 
+  /**
+   * Constraint parsing REFUSES what it cannot apply.
+   *
+   * This block used to accept a rule and silently drop any constraint it could
+   * not type-match, which is the worst possible reading of an unrecognised
+   * policy: the RESTRICTIVE half of the operator's rule evaporated and the
+   * PERMISSIVE half survived. Measured on 0.22.0 — a `timeWindow` written with
+   * numeric hours instead of "HH:MM" strings, or `rateLimit.maxPerMinute` as
+   * the string "1", produced `constraints: {}` and `evaluate()` returned
+   * `allowed: true, reason: 'Allowed by rule "r1"'`, while `loadPolicies()`
+   * returned 1 and `getRules()` showed the rule present. Every surface the
+   * operator could check reported the policy as loaded.
+   *
+   * A numeric string is not a hypothetical: it is what a YAML-to-JSON
+   * conversion, a templating layer or an env-var substitution produces. The
+   * sharpest case is `minTrustScore: "80"` — the trust floor vanishes and any
+   * agent matching the selector is served.
+   *
+   * The surrounding function already throws on a malformed `id`,
+   * `agentSelector`, `credentialSelector` or `effect`. This block is now
+   * consistent with the rest of its own function rather than the exception
+   * inside it, and `checkConstraints` — which is correctly fail-closed — is no
+   * longer defeated by its own input layer.
+   */
   const constraints: PolicyConstraints = {};
-  if (r.constraints && typeof r.constraints === 'object') {
+  if (r.constraints !== undefined && r.constraints !== null) {
+    if (typeof r.constraints !== 'object' || Array.isArray(r.constraints)) {
+      throw new Error(`Rule "${r.id}": constraints must be an object`);
+    }
     const c = r.constraints as Record<string, unknown>;
 
-    if (c.timeWindow && typeof c.timeWindow === 'object') {
-      const tw = c.timeWindow as Record<string, unknown>;
-      if (typeof tw.start === 'string' && typeof tw.end === 'string') {
-        constraints.timeWindow = { start: tw.start, end: tw.end };
+    for (const key of Object.keys(c)) {
+      if (!KNOWN_CONSTRAINT_KEYS.has(key)) {
+        throw new Error(
+          `Rule "${r.id}": unknown constraint "${key}". ` +
+          `Known constraints: ${[...KNOWN_CONSTRAINT_KEYS].join(', ')}. ` +
+          `A constraint this build cannot apply is refused rather than ignored, ` +
+          `because ignoring it would widen the rule.`,
+        );
       }
     }
 
-    if (c.rateLimit && typeof c.rateLimit === 'object') {
-      const rl = c.rateLimit as Record<string, unknown>;
-      if (typeof rl.maxPerMinute === 'number' && rl.maxPerMinute > 0) {
-        constraints.rateLimit = { maxPerMinute: rl.maxPerMinute };
+    if (c.timeWindow !== undefined) {
+      const tw = c.timeWindow;
+      if (typeof tw !== 'object' || tw === null || Array.isArray(tw)) {
+        throw new Error(`Rule "${r.id}": timeWindow must be an object with "start" and "end"`);
       }
+      const { start, end } = tw as Record<string, unknown>;
+      if (typeof start !== 'string' || typeof end !== 'string') {
+        throw new Error(
+          `Rule "${r.id}": timeWindow.start and timeWindow.end must be "HH:MM" strings ` +
+          `(got ${typeof start} and ${typeof end})`,
+        );
+      }
+      if (!TIME_OF_DAY.test(start) || !TIME_OF_DAY.test(end)) {
+        throw new Error(`Rule "${r.id}": timeWindow.start and timeWindow.end must be "HH:MM", 00:00-23:59`);
+      }
+      constraints.timeWindow = { start, end };
     }
 
-    if (typeof c.minTrustScore === 'number') {
+    if (c.rateLimit !== undefined) {
+      const rl = c.rateLimit;
+      if (typeof rl !== 'object' || rl === null || Array.isArray(rl)) {
+        throw new Error(`Rule "${r.id}": rateLimit must be an object with "maxPerMinute"`);
+      }
+      const { maxPerMinute } = rl as Record<string, unknown>;
+      if (typeof maxPerMinute !== 'number' || !Number.isFinite(maxPerMinute) || maxPerMinute <= 0) {
+        throw new Error(
+          `Rule "${r.id}": rateLimit.maxPerMinute must be a positive number (got ${JSON.stringify(maxPerMinute)})`,
+        );
+      }
+      constraints.rateLimit = { maxPerMinute };
+    }
+
+    if (c.minTrustScore !== undefined) {
+      if (typeof c.minTrustScore !== 'number' || !Number.isFinite(c.minTrustScore)) {
+        throw new Error(
+          `Rule "${r.id}": minTrustScore must be a number (got ${JSON.stringify(c.minTrustScore)})`,
+        );
+      }
       constraints.minTrustScore = c.minTrustScore;
     }
 
-    if (typeof c.requireCapability === 'string') {
+    if (c.requireCapability !== undefined) {
+      if (typeof c.requireCapability !== 'string') {
+        throw new Error(`Rule "${r.id}": requireCapability must be a string`);
+      }
       constraints.requireCapability = c.requireCapability;
     }
 
-    if (typeof c.scopeCheck === 'boolean') {
+    if (c.scopeCheck !== undefined) {
+      if (typeof c.scopeCheck !== 'boolean') {
+        throw new Error(`Rule "${r.id}": scopeCheck must be a boolean`);
+      }
       constraints.scopeCheck = c.scopeCheck;
     }
   }

--- a/src/broker/policy.ts
+++ b/src/broker/policy.ts
@@ -54,6 +54,25 @@ export class PolicyEngine {
         throw new Error('Policy file must contain a "rules" array or be a JSON array');
       }
 
+      // The ENVELOPE gets the same treatment as a rule. Measured: a file with
+      // `{"rules": [allow], "denyRules": [deny-all]}` loaded the allow set,
+      // ignored the deny set, and served the credential — the operator's deny
+      // rules were never in the engine and nothing said so. This defect has now
+      // been found at four nesting levels, so the check goes at every level
+      // rather than at the one where the last instance turned up.
+      if (!Array.isArray(parsed)) {
+        for (const key of Object.keys(parsed)) {
+          if (KNOWN_ENVELOPE_KEYS.has(key)) continue;
+          const near = nearestMatch(key, [...KNOWN_ENVELOPE_KEYS]);
+          throw new Error(
+            `Policy file has an unknown top-level key "${key}"${near ? ` (did you mean "${near}"?)` : ''}. ` +
+            `A policy file may carry: ${[...KNOWN_ENVELOPE_KEYS].join(', ')}. ` +
+            `Rules under a key this build does not read would never be loaded, and nothing ` +
+            `downstream could tell that from a file that declared no such rules.`,
+          );
+        }
+      }
+
       this.rules = rules.map((r: unknown) => validateRule(r));
       return this.rules.length;
     } catch (err) {
@@ -182,8 +201,9 @@ export class PolicyEngine {
     // here. Real enforcement needs live permission discovery in the resolve
     // path — latency, egress and error semantics — and is its own unit.
 
-    // Capability check
-    if (constraints.requireCapability) {
+    // Capability check. `!== undefined`, not truthiness — see the load-time
+    // check: an empty string is falsy and used to skip this whole block.
+    if (constraints.requireCapability !== undefined) {
       if (!agentIdentity) {
         return {
           passed: false,
@@ -274,7 +294,7 @@ function parseTimeToMinutes(time: string): number {
  * enforcement branch in `checkConstraints` fails too. The set is a promise
  * about what is applied, not a list of what parses.
  */
-const KNOWN_CONSTRAINT_KEYS = new Set([
+export const KNOWN_CONSTRAINT_KEYS = new Set([
   'timeWindow',
   'rateLimit',
   'minTrustScore',
@@ -301,13 +321,47 @@ const KNOWN_CONSTRAINT_KEYS = new Set([
  * a key the operator did not write is a guess about intent inside the
  * authorization path; the error names the likely intent instead.
  */
-const KNOWN_RULE_KEYS = new Set([
+export const KNOWN_RULE_KEYS = new Set([
   'id',
   'agentSelector',
   'credentialSelector',
   'constraints',
   'effect',
 ]);
+
+/** Top-level keys of the policy FILE. `version` is in the documented example. */
+export const KNOWN_ENVELOPE_KEYS = new Set(['version', 'rules']);
+
+/**
+ * Sub-keys of each structured constraint.
+ *
+ * The destructuring below reads `{start, end}` and `{maxPerMinute}` and drops
+ * everything else, so `rateLimit: {maxPerMinute: 60, maxPerHour: 1}` silently
+ * discarded the hourly cap and permitted 3600/hour, and `timeWindow` with a
+ * mistyped `End` kept the open window the operator meant to close. Same defect
+ * as the container, one level further in.
+ */
+const KNOWN_CONSTRAINT_SUBKEYS = new Map<string, Set<string>>([
+  ['timeWindow', new Set(['start', 'end'])],
+  ['rateLimit', new Set(['maxPerMinute'])],
+]);
+
+/** Refuse a structured constraint carrying a sub-key we would silently drop. */
+function checkSubKeys(ruleId: string, constraint: string, value: object): void {
+  const known = KNOWN_CONSTRAINT_SUBKEYS.get(constraint);
+  if (!known) return;
+  for (const key of Object.keys(value)) {
+    if (known.has(key)) continue;
+    const near = nearestMatch(key, [...known]);
+    throw new Error(
+      `Rule "${ruleId}": ${constraint} has an unknown field "${key}"` +
+      `${near ? ` (did you mean "${near}"?)` : ''}. ` +
+      `${constraint} takes: ${[...known].join(', ')}. ` +
+      `A field this build does not read is refused rather than dropped, because dropping ` +
+      `it would loosen the limit the operator wrote.`,
+    );
+  }
+}
 
 /**
  * Constraints this build parses but does not enforce, with the reason.
@@ -361,11 +415,20 @@ function validateRule(raw: unknown): PolicyRule {
       `without it.`,
     );
   }
-  if (typeof r.agentSelector !== 'string') {
-    throw new Error(`Rule "${r.id}": agentSelector must be a string`);
+  // Non-empty, and the DENY direction is why: an empty selector matches nothing,
+  // so a deny rule written with one never fires while a sibling `allow: *`
+  // does — the restriction disappears and the permission survives. Measured.
+  if (typeof r.agentSelector !== 'string' || r.agentSelector === '') {
+    throw new Error(
+      `Rule "${r.id}": agentSelector must be a non-empty string. An empty selector matches ` +
+      `no agent, so a deny rule carrying one silently never fires. Use "*" to match every agent.`,
+    );
   }
-  if (typeof r.credentialSelector !== 'string') {
-    throw new Error(`Rule "${r.id}": credentialSelector must be a string`);
+  if (typeof r.credentialSelector !== 'string' || r.credentialSelector === '') {
+    throw new Error(
+      `Rule "${r.id}": credentialSelector must be a non-empty string. An empty selector matches ` +
+      `no credential, so a deny rule carrying one silently never fires. Use "*" to match every one.`,
+    );
   }
   if (r.effect !== 'allow' && r.effect !== 'deny') {
     throw new Error(`Rule "${r.id}": effect must be "allow" or "deny"`);
@@ -432,6 +495,7 @@ function validateRule(raw: unknown): PolicyRule {
       if (!TIME_OF_DAY.test(start) || !TIME_OF_DAY.test(end)) {
         throw new Error(`Rule "${r.id}": timeWindow.start and timeWindow.end must be "HH:MM", 00:00-23:59`);
       }
+      checkSubKeys(r.id, 'timeWindow', tw);
       constraints.timeWindow = { start, end };
     }
 
@@ -446,6 +510,7 @@ function validateRule(raw: unknown): PolicyRule {
           `Rule "${r.id}": rateLimit.maxPerMinute must be a positive number (got ${JSON.stringify(maxPerMinute)})`,
         );
       }
+      checkSubKeys(r.id, 'rateLimit', rl);
       constraints.rateLimit = { maxPerMinute };
     }
 
@@ -461,6 +526,20 @@ function validateRule(raw: unknown): PolicyRule {
     if (c.requireCapability !== undefined) {
       if (typeof c.requireCapability !== 'string') {
         throw new Error(`Rule "${r.id}": requireCapability must be a string`);
+      }
+      // Non-empty, because the enforcement branch guards on TRUTHINESS: an
+      // empty string skipped the whole capability check, including its
+      // fail-closed "no agent identity" arm, so the gate vanished while
+      // getRules() still showed `requireCapability: ""`. Measured: "deploy"
+      // with no identity denies, "" with no identity allows. `${VAR}` with the
+      // variable unset is exactly how a templating layer produces it — the same
+      // substitution story as the numeric strings this function already refuses.
+      if (c.requireCapability === '') {
+        throw new Error(
+          `Rule "${r.id}": requireCapability must not be empty. An empty capability is not ` +
+          `a capability that everything satisfies — it removes the check. Name the capability, ` +
+          `or omit requireCapability entirely.`,
+        );
       }
       constraints.requireCapability = c.requireCapability;
     }

--- a/src/broker/policy.ts
+++ b/src/broker/policy.ts
@@ -243,10 +243,21 @@ export function matchGlob(pattern: string, value: string): boolean {
   if (pattern === value) return true;
 
   // Convert glob to regex: escape special chars, then convert * and ?
+  //
+  // `[\s\S]` and `[^]`-style classes rather than `.`, because `.` does not match
+  // a line terminator: `matchGlob('AWS_*', 'AWS_KEY\n')` was FALSE while
+  // `matchGlob('*', 'AWS_KEY\n')` was true (the `*` fast path above skips the
+  // regex entirely). A glob DENY rule therefore missed any value carrying \n,
+  // \r, U+2028 or U+2029 while a wildcard ALLOW matched it — the deny rule the
+  // operator wrote silently did not fire. Measured; also measured that such a
+  // name does not currently resolve to a credential, because `getSecret`
+  // rejects it at `SAFE_NAME` before any lookup. So this is the policy decision
+  // being wrong rather than a credential being served, and it is fixed here so
+  // that it stays that way if name validation ever moves.
   const escaped = pattern
     .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-    .replace(/\*/g, '.*')
-    .replace(/\?/g, '.');
+    .replace(/\*/g, '[\\s\\S]*')
+    .replace(/\?/g, '[\\s\\S]');
 
   const regex = new RegExp(`^${escaped}$`);
   return regex.test(value);

--- a/src/broker/server.ts
+++ b/src/broker/server.ts
@@ -86,12 +86,23 @@ export class BrokerServer {
    * Start the broker server on both Unix socket and HTTP port.
    */
   async start(): Promise<void> {
-    // Load policies
-    try {
-      this.policy.loadPolicies();
-    } catch {
-      // No policies is fine — default deny applies
-    }
+    // A policy file that EXISTS and cannot be loaded is a hard startup failure.
+    //
+    // This used to be swallowed, under a comment reading "No policies is fine —
+    // default deny applies". That premise is false: `loadPolicies()` returns 0
+    // WITHOUT throwing when the file is absent, so the catch was reachable only
+    // in the one case it claimed to be handling safely — a policy file the
+    // operator wrote that failed to parse or validate. The broker then started
+    // serving credentials with zero rules.
+    //
+    // Refusing to start is deliberate and is the other half of the constraint
+    // validation in policy.ts. With that validation throwing and this catch
+    // still in place, a malformed constraint would turn a silent fail-OPEN into
+    // a silent deny-everything with no diagnosis, and the operator's rational
+    // next move is to delete the policy file — which is a fail-open again, by
+    // hand. A daemon that cannot apply the policy it was given must say so and
+    // stop, not pick a direction quietly.
+    this.policy.loadPolicies();
 
     // Generate and persist bearer token for caller authentication
     const tokenFile = this.config.tokenFile ?? TOKEN_FILE;

--- a/src/broker/types.ts
+++ b/src/broker/types.ts
@@ -67,8 +67,13 @@ export interface PolicyConstraints {
   minTrustScore?: number;
   /** AIM capability the agent must possess. */
   requireCapability?: string;
-  /** Block if credential scope has expanded beyond baseline. */
-  scopeCheck?: boolean;
+  // No `scopeCheck`. It was documented as "block if credential scope has
+  // expanded beyond baseline" and could not block: the enforcement path
+  // compared an empty current-permission list against the baseline, so
+  // expansion was false for every baseline. The key is refused at policy load
+  // rather than accepted and not applied — see UNENFORCED_CONSTRAINT_KEYS in
+  // ./policy. Reinstating it means implementing live permission discovery
+  // first, and the type should stay silent about it until then.
 }
 
 /** Audit log entry for credential access attempts. */

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -378,3 +378,148 @@ describe('scan rejects more than one path', () => {
     expect(res.stdout).toContain('credential');
   });
 });
+
+/**
+ * The argv layer (0.22.1).
+ *
+ * Every block below is an A/B on ONE variable: how a flag is spelled. The
+ * CONTROL row passes on v0.22.0 and after, which is what proves the arm beside
+ * it is measuring the fix rather than the harness. Each arm fails on v0.22.0 on
+ * its OWN assertion — not on a missing import, and not on a timeout.
+ *
+ * These are the red-proofable half of the fix. `argv.test.ts` covers the
+ * per-spelling matrix but cannot be red-proofed, because `src/argv.ts` does not
+ * exist on v0.22.0 and every test there would fail on the import instead.
+ */
+describe('a flag never widens scope (0.22.1 argv layer)', () => {
+  const hasBuild = fs.existsSync(CLI_PATH);
+  const itIfBuilt = hasBuild ? it : it.skip;
+
+  // Split so this file is not itself a credential-bearing file.
+  const PAT = ['ghp_', 'R1T2Y3U4I5O6P7A8S9D0F1G2H3J4K5L6Z7X8'].join('');
+
+  function transcriptFixture(): { dir: string; file: string; before: string } {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-argv-clean-'));
+    const file = path.join(dir, 'session.jsonl');
+    fs.writeFileSync(file, JSON.stringify({ role: 'user', content: `token ${PAT}` }) + '\n');
+    return { dir, file, before: fs.readFileSync(file, 'utf-8') };
+  }
+
+  function scanFixture(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-argv-scan-'));
+    fs.writeFileSync(path.join(dir, 'leak.js'), `const k = "${PAT}";\n`);
+    return dir;
+  }
+
+  function cli(args: string[], cwd?: string) {
+    return spawnSync(process.execPath, [CLI_PATH, ...args], {
+      encoding: 'utf-8', cwd, stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  }
+
+  // --- clean: the destructive verb, where the safety flag is the only thing
+  // standing between a preview and an irreversible in-place rewrite ----------
+
+  itIfBuilt('CONTROL: `clean --dry-run` previews and changes nothing', () => {
+    const { dir, file, before } = transcriptFixture();
+    try {
+      const res = cli(['clean', '--dry-run', '--path', dir]);
+      expect(res.status).toBe(0);
+      expect(res.stdout).toContain('dry-run');
+      expect(fs.readFileSync(file, 'utf-8')).toBe(before);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  itIfBuilt('`clean --dryrun` is refused, and the file is not rewritten', () => {
+    const { dir, file, before } = transcriptFixture();
+    try {
+      const res = cli(['clean', '--dryrun', '--path', dir]);
+      // On v0.22.0 this exits 0 having performed the redaction the user asked
+      // to preview: `runClean` computes `args.includes('--dry-run')`, which is
+      // false, and validates nothing else.
+      expect(res.status).toBe(2);
+      expect(fs.readFileSync(file, 'utf-8')).toBe(before);
+      expect(res.stderr).toContain('--dry-run');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // The pre-fix arm of this one walks the machine's whole transcript corpus,
+  // which is the defect. Read-only (--dry-run) but slow, so the timeout is
+  // raised: a red-proof that fails on the clock has not proved anything.
+  itIfBuilt('`clean --path=DIR` scopes to DIR instead of the whole corpus', () => {
+    const { dir } = transcriptFixture();
+    try {
+      const res = cli(['clean', `--path=${dir}`, '--dry-run']);
+      expect(res.stdout).toContain(`Scanning transcripts at ${dir}`);
+      expect(res.stdout).toContain('Scanned:  1 files');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }, 60_000);
+
+  // --- scan: a flag's value silently eating the path ------------------------
+
+  itIfBuilt('CONTROL: `--max-files 20000 <dir>` honours the path', () => {
+    const dir = scanFixture();
+    try {
+      const res = cli(['scan', '--max-files', '20000', dir]);
+      expect(res.status).toBe(1);
+      expect(res.stdout).toContain('credential');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  itIfBuilt('`--max-files <dir>` refuses rather than silently scanning the cwd', () => {
+    const dir = scanFixture();
+    const emptyCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-argv-cwd-'));
+    try {
+      const res = cli(['scan', '--max-files', dir], emptyCwd);
+      // On v0.22.0: exit 0 and "No hardcoded credentials found." — over a
+      // directory the tool never opened, because the path was consumed as the
+      // flag's value and the scan retargeted to the working directory.
+      expect(res.status).toBe(2);
+      expect(res.stdout).not.toContain('No hardcoded credentials found');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(emptyCwd, { recursive: true, force: true });
+    }
+  });
+
+  itIfBuilt('`--max-files=N` binds the cap instead of being dropped as unknown', () => {
+    const dir = scanFixture();
+    try {
+      const res = cli(['scan', dir, '--max-files=20000', '--json']);
+      const summary = JSON.parse(res.stdout).summary;
+      // On v0.22.0 this is 5000: the equals form was warned about as an unknown
+      // flag and the scan silently ran at the default cap.
+      expect(summary.maxFiles).toBe(20000);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // --- run: the selector whose absence means "inject everything" ------------
+
+  const ABSENT = 'SECRETLESS_ARGV_NO_SUCH_SECRET';
+
+  itIfBuilt('CONTROL: `run --only NAME` fails closed on a name the store lacks', () => {
+    const res = cli(['run', '--only', ABSENT, '--', process.execPath, '-e', 'process.exit(7)']);
+    expect(res.status).not.toBe(7);
+    expect(res.stderr).toContain(ABSENT);
+  });
+
+  itIfBuilt('`run --only=NAME` binds the selector rather than injecting the whole store', () => {
+    const res = cli(['run', `--only=${ABSENT}`, '--', process.execPath, '-e', 'process.exit(7)']);
+    // On v0.22.0 `--only=NAME` is unparsed, so `only` stays undefined, undefined
+    // means "inject every credential in the store", and the child RUNS —
+    // exiting 7. The selector naming a nonexistent secret is what makes this
+    // observable without printing anything: bound, it must refuse and name it.
+    expect(res.status).not.toBe(7);
+    expect(res.stderr).toContain(ABSENT);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,33 @@ import { runFeedback } from './commands/feedback';
 import { runIgnore } from './commands/ignore';
 import { runDiff } from './commands/diff';
 import { printHelp, OWN_HELP } from './commands/help';
+import { prepareArgv, supportedFlags, VERBS, EXIT_USAGE, type PreparedArgv } from './argv';
+
+/**
+ * The stderr block for a refused command.
+ *
+ * States that nothing ran, because the failure mode being closed here is a
+ * command that did something OTHER than what was asked: after a refusal the
+ * user has to know the difference between "not run" and "run wrongly".
+ *
+ * Lives here rather than in `argv.ts` because it needs `CLI_BARE`, and
+ * `argv.ts` is in the `mcp-wrapper` require graph, which is copied to a
+ * standalone directory where `commands/utils`' `require('../../package.json')`
+ * does not resolve. See the import note at the top of `argv.ts`.
+ */
+function formatArgvErrors(verb: string, errors: string[]): string[] {
+  const spec = VERBS[verb];
+  const lines = errors.map((e) => `  ${e}`);
+  lines.push(`  \`${verb}\` was not run. Nothing was changed.`);
+  if (spec) {
+    lines.push(`  Supported: ${supportedFlags(spec).join(', ')}`);
+  }
+  // CLI_BARE, not a literal: an embedding host sets SECRETLESS_CLI_PREFIX and
+  // every citation we print has to rebrand with it (#191). A hardcoded name
+  // here tells that host's users to run a command that does not exist.
+  lines.push(`  Run \`${CLI_BARE} ${verb} --help\` for usage.`);
+  return lines;
+}
 
 const TOOL = 'secretless-ai';
 // Subcommands we don't track: pure-help / pure-config calls don't represent
@@ -35,8 +62,16 @@ const NON_TRACKED = new Set<string>(['telemetry', '--version', '-v', '--help', '
 
 
 async function main(): Promise<number> {
-  const args = process.argv.slice(2);
-  const command = args[0];
+  const rawArgs = process.argv.slice(2);
+  const command = rawArgs[0];
+
+  // Normalise argv ONCE, here, before anything reads it. Every command below
+  // still does its own `args.includes('--dry-run')` / `args.indexOf('--path')`
+  // and none of them had to change, because by this point they are looking at
+  // the split form: `--path=DIR` has already become `--path` `DIR`. See
+  // src/argv.ts for why this is not an `=` branch inside each parser.
+  const prepared = prepareArgv(command, rawArgs);
+  const args = prepared.args;
 
   // Tier-1 anonymous usage telemetry — default ON; opt-out via OPENA2A_TELEMETRY=off
   // or `secretless-ai telemetry off`. See README §Telemetry. Disclosure surfaces:
@@ -67,6 +102,17 @@ async function main(): Promise<number> {
     return 0;
   }
 
+  // Refuse a command line we could not bind, BEFORE any side effect: before
+  // telemetry is recorded, before dispatch, and so before the first byte is
+  // written by a destructive verb. `clean --dryrun` reaching runClean at all is
+  // the defect — by then the only signal is a missing "Mode: dry-run" line,
+  // printed after the file has already been rewritten.
+  if (prepared.errors.length > 0 && command) {
+    for (const line of formatArgvErrors(command, prepared.errors)) console.error(line);
+    return EXIT_USAGE;
+  }
+  for (const warning of prepared.warnings) console.error(`  ${warning}`);
+
   // telemetry subcommand
   if (command === 'telemetry') {
     console.log(runTelemetryCommand(args[1] as TelemetryAction, {
@@ -80,7 +126,7 @@ async function main(): Promise<number> {
   const startedAt = Date.now();
   let exitCode = 0;
   try {
-    exitCode = await dispatch(args, command);
+    exitCode = await dispatch(args, command, prepared);
   } catch (err) {
     exitCode = 1;
     if (command) tele.error(command, (err as { code?: string; name?: string })?.code || (err as { name?: string })?.name || 'UNKNOWN');
@@ -114,7 +160,24 @@ function rejectUnknownFlagAsDirArg(command: string, dirArg: string | undefined):
   return true;
 }
 
-async function dispatch(args: string[], command: string | undefined): Promise<number> {
+/**
+ * Refuse a flag whose VALUE we could not use, instead of falling back to the
+ * default and answering a different question than the one asked.
+ *
+ * The fallback was a silent scope change, not merely a wasted flag: `scan
+ * --max-files ./src` consumes `./src` as the cap's value, so no positional
+ * remains, so the scan retargets to the current directory and prints "No
+ * hardcoded credentials found." over a tree it never opened. Measured on
+ * 0.22.0: exit 0, one warning naming the VALUE, and nothing anywhere saying a
+ * different directory was scanned.
+ */
+function refuseFlagValue(verb: string, flag: string, raw: string, expected: string): number {
+  const detail = `${flag} needs ${expected}, but was given "${raw}".`;
+  for (const line of formatArgvErrors(verb, [detail])) console.error(line);
+  return EXIT_USAGE;
+}
+
+async function dispatch(args: string[], command: string | undefined, prepared: PreparedArgv): Promise<number> {
   switch (command) {
     case 'init': {
       const dirArg = args[1];
@@ -133,17 +196,16 @@ async function dispatch(args: string[], command: string | undefined): Promise<nu
       const showPlaceholders = args.includes('--show-placeholders');
       // --min-confidence <n>  (n in [0, 1]). Drops findings whose composite
       // confidence score is below the threshold. Useful on noisy repos to
-      // surface only high-confidence credentials. Invalid values fall back to
-      // 0 (no filtering) and the runner prints a warning.
+      // surface only high-confidence credentials.
       let minConfidence = 0;
       const mcIdx = args.indexOf('--min-confidence');
-      if (mcIdx !== -1 && mcIdx + 1 < args.length) {
+      if (mcIdx !== -1) {
         const raw = args[mcIdx + 1];
         const parsed = Number.parseFloat(raw);
         if (Number.isFinite(parsed) && parsed >= 0 && parsed <= 1) {
           minConfidence = parsed;
         } else {
-          console.error(`  Warning: ignoring invalid --min-confidence value "${raw}" (must be in [0, 1]).`);
+          return refuseFlagValue('scan', '--min-confidence', raw, 'a number in [0, 1], e.g. --min-confidence 0.8');
         }
       }
       // --max-files <n>  Raise the per-walk file cap (default 5000). Without
@@ -151,7 +213,7 @@ async function dispatch(args: string[], command: string | undefined): Promise<nu
       // but the user has no way to finish it short of scanning subtrees by hand.
       let maxFiles: number | undefined;
       const mfIdx = args.indexOf('--max-files');
-      if (mfIdx !== -1 && mfIdx + 1 < args.length) {
+      if (mfIdx !== -1) {
         const raw = args[mfIdx + 1];
         // Must be ALL digits. `parseInt` stops at the first non-digit and
         // returns what it got, so `--max-files 20abc` silently became a cap of
@@ -161,7 +223,7 @@ async function dispatch(args: string[], command: string | undefined): Promise<nu
         if (Number.isSafeInteger(parsed) && parsed > 0) {
           maxFiles = parsed;
         } else {
-          console.error(`  Warning: ignoring invalid --max-files value "${raw}" (must be a positive whole number, e.g. --max-files 20000).`);
+          return refuseFlagValue('scan', '--max-files', raw, 'a positive whole number, e.g. --max-files 20000');
         }
       }
       // --max-file-size <size>  Raise the per-file size cap (10MB config, 1MB
@@ -169,34 +231,21 @@ async function dispatch(args: string[], command: string | undefined): Promise<nu
       // way hitting the file cap was before --max-files existed.
       let maxFileSizeBytes: number | undefined;
       const fsIdx = args.indexOf('--max-file-size');
-      if (fsIdx !== -1 && fsIdx + 1 < args.length) {
+      if (fsIdx !== -1) {
         const raw = args[fsIdx + 1];
         const parsed = parseFileSize(raw);
         if (parsed !== null) {
           maxFileSizeBytes = parsed;
         } else {
-          console.error(`  Warning: ignoring invalid --max-file-size value "${raw}" (e.g. --max-file-size 20mb, 500kb, or a byte count).`);
+          return refuseFlagValue('scan', '--max-file-size', raw, 'a size, e.g. --max-file-size 20mb, 500kb, or a byte count');
         }
       }
-      const flagFlag = new Set(['--include-tests', '--explain', '--no-ignore', '--json', '--show-placeholders', '--min-confidence', '--max-files', '--max-file-size']);
-      const positionalArgs: string[] = [];
-      const unknownFlags: string[] = [];
-      for (let k = 1; k < args.length; k++) {
-        const a = args[k];
-        if (flagFlag.has(a)) {
-          if (a === '--min-confidence' || a === '--max-files' || a === '--max-file-size') k++;
-          continue;
-        }
-        // Warn (don't fail) on an unrecognized flag so a typo like `--show-placeholder`
-        // for `--show-placeholders` doesn't silently no-op (#81). Matches the warn-not-
-        // crash behavior already used for an invalid `--min-confidence` value.
-        if (a.startsWith('--')) { unknownFlags.push(a); continue; }
-        positionalArgs.push(a);
-      }
-      if (unknownFlags.length > 0) {
-        console.error(`  Warning: ignoring unknown flag${unknownFlags.length > 1 ? 's' : ''} ${unknownFlags.join(', ')}.`);
-        console.error(`  Run \`${CLI_BARE} scan\` for supported flags (--json, --show-placeholders, --min-confidence, --max-files, --max-file-size, --no-ignore, --include-tests, --explain).`);
-      }
+      // Positionals come from the shared argv layer, which knows which tokens
+      // were consumed as flag values. The local loop this replaces had its own
+      // copy of the flag list, and a flag missing from that copy became a
+      // positional — a second place for the two to disagree about what the user
+      // typed. The unknown-flag warning #81 added moved there with it.
+      const positionalArgs = prepared.positionals;
       // Refuse extra paths rather than silently scanning only the first. A
       // second path used to be dropped with no warning, and since the first
       // path's findings still set exit 1, the run LOOKED complete while a whole

--- a/src/history.test.ts
+++ b/src/history.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs/promises';
 import * as os from 'os';
 import { scanHistory, cleanHistory } from './history';
+import { leaksAny } from './redact';
 
 vi.mock('fs/promises');
 vi.mock('os');
@@ -256,4 +257,37 @@ describe('cleanHistory', () => {
     expect(result.linesRedacted).toBe(0);
     expect(mockWriteFile).not.toHaveBeenCalled();
   });
+});
+
+/**
+ * The write path, pinned at the consumer rather than at the helper.
+ *
+ * `clean-history` is the remedy `scan-history` tells the user to run, so a
+ * partial redaction here is reported to the user as a completed one. Measured
+ * on 0.22.0: a `ghp_` value longer than the pattern's fixed 36-char quantifier
+ * left its tail in the rewritten file while the command printed
+ * `History cleaned.` and exit 0.
+ *
+ * Asserted with `leaksAny` — the module's own residue detector — rather than
+ * with `not.toContain(value)`, because whole-value containment is exactly the
+ * check that returns false over a message showing most of a credential.
+ */
+describe('cleanHistory — no residue for an over-length credential', () => {
+  const CANONICAL = 'ghp_' + 'aB3xQ9zK7mR2tY5wL8pN4vC6hJ1sD0gF1234'.slice(0, 36);
+  const OVERSHOOT = CANONICAL + 'TAILMARKER99';
+
+  for (const [label, value] of [['canonical length', CANONICAL], ['over length', OVERSHOOT]] as const) {
+    it(`writes no run of the credential back to disk — ${label}`, async () => {
+      mockHistoryFiles({ '.bash_history': `export B=${value}` });
+      mockWriteFile.mockResolvedValue(undefined);
+
+      await cleanHistory(false);
+
+      const written = mockWriteFile.mock.calls.find(c => c[0] === '/home/testuser/.bash_history');
+      expect(written, 'the history file was never rewritten').toBeDefined();
+      const content = written![1] as string;
+      expect(content).toContain('[REDACTED:github-pat]');
+      expect(leaksAny(content, [value])).toBe(false);
+    });
+  }
 });

--- a/src/history.ts
+++ b/src/history.ts
@@ -10,6 +10,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
 import { CREDENTIAL_PATTERNS, type CredentialPattern } from './patterns';
+import { redactMatches } from './redact';
 
 export interface HistoryFinding {
   /** Display path with ~ for home directory */
@@ -207,8 +208,12 @@ export async function cleanHistory(dryRun = false): Promise<HistoryCleanResult> 
         modified = true;
 
         if (!dryRun) {
-          // Replace the credential value with a redaction marker
-          lines[i] = rawLine.replace(match.regex, `[REDACTED:${match.id}]`);
+          // Replace the credential value with a redaction marker.
+          // redactMatches, not String.replace: the pattern's quantifier is not
+          // the credential's length, so replacing exactly the match left the
+          // tail of an over-length value in the file this function REWRITES,
+          // under a line that says it was redacted.
+          lines[i] = redactMatches(rawLine, match.regex, `[REDACTED:${match.id}]`);
         }
       }
     }

--- a/src/mcp-wrapper.ts
+++ b/src/mcp-wrapper.ts
@@ -17,6 +17,7 @@ import * as os from 'os';
 
 import { McpVault } from './mcp/vault';
 import { resolveBackendType } from './backends/config';
+import { prepareBinArgv, MCP_WRAPPER } from './argv';
 
 function parseArgs(argv: string[]): {
   server: string;
@@ -34,13 +35,25 @@ function parseArgs(argv: string[]): {
   let backend = '';
   let separatorIdx = -1;
 
+  // Normalise before parsing, so `--server=NAME` binds here exactly as it does
+  // in the CLI. Without it every flag below is dropped on the equals spelling:
+  // `--vault-dir=/path` silently falls back to the DEFAULT vault and
+  // `--backend=1password` silently falls back to the configured backend, so the
+  // wrapper reads credentials from somewhere other than where it was told to.
+  // The child command after `--` is left untouched.
+  argv = prepareBinArgv(MCP_WRAPPER, argv).args;
+
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === '--') { separatorIdx = i; break; }
-    if (argv[i] === '--server' && argv[i + 1]) { server = argv[++i]; continue; }
-    if (argv[i] === '--client' && argv[i + 1]) { client = argv[++i]; continue; }
-    if (argv[i] === '--vault-dir' && argv[i + 1]) { vaultDir = argv[++i]; continue; }
-    if (argv[i] === '--vault-key' && argv[i + 1]) { vaultKey = argv[++i]; continue; }
-    if (argv[i] === '--backend' && argv[i + 1]) {
+    // `!== undefined`, not truthiness: `--server ''` is the flag WITH an empty
+    // value. Read as "flag absent" it produced an empty server name, and an
+    // empty name looks up no secrets — so the wrapper spawned the MCP server
+    // with none of its credentials and said nothing. Same shape as #110.
+    if (argv[i] === '--server' && argv[i + 1] !== undefined) { server = argv[++i]; continue; }
+    if (argv[i] === '--client' && argv[i + 1] !== undefined) { client = argv[++i]; continue; }
+    if (argv[i] === '--vault-dir' && argv[i + 1] !== undefined) { vaultDir = argv[++i]; continue; }
+    if (argv[i] === '--vault-key' && argv[i + 1] !== undefined) { vaultKey = argv[++i]; continue; }
+    if (argv[i] === '--backend' && argv[i + 1] !== undefined) {
       const val = argv[++i];
       if (val !== 'local' && val !== 'keychain' && val !== '1password' && val !== 'vault' && val !== 'gcp-sm') {
         process.stderr.write(`secretless-mcp: Unknown backend: ${val}. Use 'local', 'keychain', '1password', 'vault', or 'gcp-sm'.\n`);
@@ -72,6 +85,19 @@ async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
 
   if (!args) {
+    process.stderr.write('secretless-mcp: Usage: secretless-mcp --server <name> --client <client> -- <command> [args...]\n');
+    process.exit(1);
+  }
+
+  // Refuse rather than spawn an unprotected child. An empty server or client
+  // name matches no vault entry, so the wrapper would hand the MCP server an
+  // environment with none of the credentials it was installed to inject — and
+  // the server would start anyway, looking installed and doing nothing. The
+  // whole point of this bin is that the child gets its secrets; if we cannot
+  // say which secrets those are, not starting is the safe answer.
+  if (!args.server || !args.client) {
+    const missing = [!args.server && '--server', !args.client && '--client'].filter(Boolean).join(' and ');
+    process.stderr.write(`secretless-mcp: ${missing} must be given a non-empty value. The server was not started.\n`);
     process.stderr.write('secretless-mcp: Usage: secretless-mcp --server <name> --client <client> -- <command> [args...]\n');
     process.exit(1);
   }

--- a/src/near-miss.ts
+++ b/src/near-miss.ts
@@ -1,0 +1,91 @@
+/**
+ * Near-miss suggestion — "did you mean X?" for a token the user typed that we
+ * do not recognise.
+ *
+ * A leaf module with no imports, because both callers need it and neither
+ * should have to depend on the other: `secret-store` suggests a stored secret
+ * name for an unmatched `--only` entry, and `argv` suggests a real flag for a
+ * misspelled one. A second copy of an edit distance is how two callers drift
+ * to two different definitions of "close enough".
+ */
+
+/**
+ * How far apart two names may be and still be offered as a suggestion.
+ * At 2, `--dryrun` reaches `--dry-run` (one insertion) and `AWS_KEY` reaches
+ * `AWS_KEYS`, while unrelated names stay unsuggested.
+ */
+export const NEAR_MISS_MAX = 2;
+
+/** Anything above the threshold; all such values are equivalent to the caller. */
+export const OVER = NEAR_MISS_MAX + 1;
+
+/**
+ * Case-insensitive edit distance, only ever used to suggest a typo fix.
+ * Any result above NEAR_MISS_MAX is returned as OVER, not computed exactly.
+ *
+ * BANDED. Only cells within NEAR_MISS_MAX of the diagonal are evaluated, so a
+ * comparison costs O(n * k) rather than O(n^2) — bounded whether the two names
+ * are similar or not.
+ *
+ * A row-minimum cutoff alone is not enough, and the measurement that suggested
+ * it was misleading: it used maximally DIFFERENT names, which exit on the first
+ * row. For names sharing a long prefix and differing only near the end — the
+ * realistic shape, since stored names look alike — the band around the diagonal
+ * stays under the threshold and the full table gets computed. Measured at 5000
+ * stored names sharing a 60-char prefix, against 100 unmatched: 7814ms
+ * unbounded, 840ms with the cutoff alone, 378ms banded. (The same shape with
+ * maximally different names is 33ms — which is why benchmarking that shape hid
+ * the problem.)
+ */
+export function editDistance(a: string, b: string): number {
+  const s = a.toUpperCase();
+  const t = b.toUpperCase();
+  // Names have no length limit; keep the table small regardless.
+  if (s.length > 64 || t.length > 64) return OVER;
+  if (Math.abs(s.length - t.length) > NEAR_MISS_MAX) return OVER;
+
+  let prev: number[] = new Array(t.length + 1).fill(OVER);
+  for (let j = 0; j <= Math.min(t.length, NEAR_MISS_MAX); j++) prev[j] = j;
+
+  for (let i = 1; i <= s.length; i++) {
+    const cur: number[] = new Array(t.length + 1).fill(OVER);
+    cur[0] = i <= NEAR_MISS_MAX ? i : OVER;
+    const lo = Math.max(1, i - NEAR_MISS_MAX);
+    const hi = Math.min(t.length, i + NEAR_MISS_MAX);
+    let rowMin = cur[0];
+    for (let j = lo; j <= hi; j++) {
+      const v = Math.min(
+        prev[j] + 1,
+        cur[j - 1] + 1,
+        prev[j - 1] + (s[i - 1] === t[j - 1] ? 0 : 1),
+      );
+      cur[j] = v > OVER ? OVER : v;
+      if (cur[j] < rowMin) rowMin = cur[j];
+    }
+    // Every reachable cell already exceeds the threshold, so the final distance
+    // cannot come back under it.
+    if (rowMin > NEAR_MISS_MAX) return OVER;
+    prev = cur;
+  }
+  return prev[t.length];
+}
+
+/**
+ * The closest candidate to `miss` within NEAR_MISS_MAX, or undefined.
+ *
+ * Ties resolve to the first candidate in the order given, so callers control
+ * determinism by controlling their candidate order rather than relying on a
+ * sort that a future edit could make unstable.
+ */
+export function nearestMatch(miss: string, candidates: readonly string[]): string | undefined {
+  let best: string | undefined;
+  let bestDistance = OVER;
+  for (const candidate of candidates) {
+    const d = editDistance(miss, candidate);
+    if (d < bestDistance) {
+      bestDistance = d;
+      best = candidate;
+    }
+  }
+  return bestDistance <= NEAR_MISS_MAX ? best : undefined;
+}

--- a/src/redact.test.ts
+++ b/src/redact.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import { leaksAny, redactValues, scrubOrDrop, redactMatches } from './redact';
+import { CREDENTIAL_PATTERNS } from './patterns';
+import { maskLine } from './scan';
+
+/**
+ * The residue oracle.
+ *
+ * Deliberately NOT string equality against an expected output. An assertion
+ * copied from the tool's own output encodes whatever the tool currently does,
+ * including the defect — the whole point of #133 is that the output LOOKED
+ * redacted (`[GitHub Token REDACTED]iJ4k`) while carrying the credential. So
+ * these tests ask the independent question `leaksAny` was written to answer:
+ * does any run of the secret's own characters survive anywhere in the text?
+ *
+ * `leaksAny` is the module's existing detector and takes a different form from
+ * the replacement code under test, so it cannot fail in the same direction.
+ */
+function assertNoResidue(output: string, value: string) {
+  expect(leaksAny(output, [value])).toBe(false);
+}
+
+/**
+ * Prefix-anchored patterns whose quantifier is FIXED, with the shortest value
+ * each one accepts. These are the patterns where a real credential one
+ * character longer than the quantifier left the overshoot in the output.
+ *
+ * Values are synthetic and generated from a fixed alphabet — never a real
+ * credential, and deliberately free of the literal `FAKE`, which the scanner
+ * suppresses as a placeholder (that suppression is what made an earlier
+ * walkthrough measure the suppressor instead of the redactor).
+ */
+const BODY = 'aB3xQ9zK7mR2tY5wL8pN4vC6hJ1sD0gF';
+function body(n: number): string {
+  let s = '';
+  while (s.length < n) s += BODY;
+  return s.slice(0, n);
+}
+
+const FIXED_LENGTH_PATTERNS: Array<{ id: string; make: (extra: number) => string }> = [
+  { id: 'github-pat', make: (x) => 'ghp_' + body(36 + x) },
+  { id: 'github-oauth', make: (x) => 'gho_' + body(36 + x) },
+  { id: 'github-app', make: (x) => 'ghs_' + body(36 + x) },
+  { id: 'npm', make: (x) => 'npm_' + body(36 + x) },
+  { id: 'google', make: (x) => 'AIza' + body(35 + x) },
+  { id: 'aws-access', make: (x) => 'AKIA' + 'ABCDEFGHIJKLMNOP'.slice(0, 16) + 'Q'.repeat(x) },
+  { id: 'aws-sts', make: (x) => 'ASIA' + 'ABCDEFGHIJKLMNOP'.slice(0, 16) + 'Q'.repeat(x) },
+  { id: 'twilio', make: (x) => 'SK' + '0123456789abcdef0123456789abcdef'.slice(0, 32) + 'a'.repeat(x) },
+];
+
+describe('redactMatches — the redactor is not bounded by the detector (#133)', () => {
+  /**
+   * The matrix #133 asked for: minimum length, one over, and well over. A suite
+   * pinned to one length is what hid this — a correctly-shaped value redacts
+   * cleanly at every length the pattern was written for.
+   */
+  for (const { id, make } of FIXED_LENGTH_PATTERNS) {
+    const pattern = CREDENTIAL_PATTERNS.find((p) => p.id === id);
+    it(`leaves no residue for ${id} at min, +1 and +8`, () => {
+      expect(pattern, `pattern ${id} not found — the table is stale`).toBeDefined();
+      for (const extra of [0, 1, 8]) {
+        const value = make(extra);
+        const line = `TOKEN="${value}"`;
+        // Guard the guard: if the pattern stopped matching the value entirely
+        // the assertion below would pass vacuously.
+        expect(
+          new RegExp(pattern!.regex.source).test(line),
+          `${id} at +${extra} no longer matches its own pattern`,
+        ).toBe(true);
+        assertNoResidue(redactMatches(line, pattern!.regex, '[X]'), value);
+      }
+    });
+  }
+
+  it('masks the whole credential through maskLine, the shared display path', () => {
+    const pattern = CREDENTIAL_PATTERNS.find((p) => p.id === 'github-pat')!;
+    const value = 'ghp_' + body(44);
+    assertNoResidue(maskLine(`token: ${value}`, pattern), value);
+  });
+
+  /**
+   * The other direction, which matters because two callers REWRITE THE USER'S
+   * FILE. A redactor that extends too far deletes content the user wrote.
+   */
+  it('does not consume the path segment after a token inside a URL', () => {
+    const pattern = CREDENTIAL_PATTERNS.find((p) => p.id === 'github-pat')!;
+    const value = 'ghp_' + body(36);
+    const out = redactMatches(`git clone https://x@example.com/p/${value}/repo.git`, pattern.regex, '[X]');
+    assertNoResidue(out, value);
+    expect(out).toContain('/repo.git');
+    expect(out).toContain('https://x@example.com/p/');
+  });
+
+  it('redacts every occurrence on a line, not just the first', () => {
+    const pattern = CREDENTIAL_PATTERNS.find((p) => p.id === 'github-pat')!;
+    const a = 'ghp_' + body(40);
+    const b = 'ghp_' + body(37);
+    const out = redactMatches(`${a} and ${b}`, pattern.regex, '[X]');
+    assertNoResidue(out, a);
+    assertNoResidue(out, b);
+  });
+
+  it('keeps the gating variable name for capture-group patterns', () => {
+    const pattern = CREDENTIAL_PATTERNS.find((p) => p.id === 'aws-secret');
+    if (!pattern) return;
+    const value = body(40);
+    const line = `aws_secret_access_key = "${value}"`;
+    const out = redactMatches(line, pattern.regex, '[X]', { preferCaptureGroup: true });
+    assertNoResidue(out, value);
+    // The name is the useful half of the finding; erasing it rendered the line
+    // as a bare quote.
+    expect(out).toContain('aws_secret_access_key');
+  });
+
+  it('leaves text with no credential untouched', () => {
+    const pattern = CREDENTIAL_PATTERNS.find((p) => p.id === 'github-pat')!;
+    const line = 'nothing to see here';
+    expect(redactMatches(line, pattern.regex, '[X]')).toBe(line);
+  });
+});
+
+describe('redact — existing primitives still hold', () => {
+  it('leaksAny detects a truncated value by run', () => {
+    const v = 'sk-live-' + body(40);
+    expect(leaksAny(`Received '${v.slice(0, 20)}...'`, [v])).toBe(true);
+  });
+
+  it('redactValues replaces longest-first', () => {
+    expect(redactValues('abcdef abc', ['abc', 'abcdef'])).toBe('[REDACTED] [REDACTED]');
+  });
+
+  it('scrubOrDrop returns empty when residue survives', () => {
+    const v = body(40);
+    expect(scrubOrDrop(`prefix ${v.slice(0, 10)} suffix`, [v])).toBe('');
+  });
+});

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -82,3 +82,90 @@ export function scrubOrDrop(text: string, values: readonly string[]): string {
   const scrubbed = redactValues(text, values);
   return leaksAny(scrubbed, values) ? '' : scrubbed;
 }
+
+/**
+ * Characters that may continue a credential past the end of its pattern match.
+ *
+ * Deliberately NARROWER than the alphabet real credentials can use: `+`, `/` and
+ * `=` are excluded even though base64 secrets contain them. Two of the three
+ * callers here REWRITE THE USER'S FILE (`clean` a transcript, `clean-history`
+ * a shell history), so over-extending is not a harmless wider mask — it deletes
+ * the user's own content. `/` is the dangerous one: a token appearing inside a
+ * URL or path would swallow the rest of the path.
+ *
+ * The residual limit is recorded rather than hidden: a base64 value whose
+ * overshoot begins with `+`, `/` or `=` still keeps that character. Closing that
+ * needs the pattern's quantifier opened, which is a DETECTION change and is
+ * scoped separately.
+ */
+const CREDENTIAL_TAIL = /[A-Za-z0-9_-]/;
+
+/**
+ * Replace every match of `regex` in `text` with `label`, extending the
+ * replacement across any credential-shaped characters that FOLLOW the match.
+ *
+ * Why this exists: a redactor that replaces exactly what the detector matched is
+ * only as wide as the detector, and much of `patterns.ts` uses FIXED quantifiers
+ * (`ghp_[a-zA-Z0-9]{36}`, `AKIA[0-9A-Z]{16}`, `AIza[...]{35}`). A value one
+ * character longer than the pattern's fixed length matched a PREFIX, and the
+ * unmatched tail survived into whatever the caller did next. Measured on 0.22.0:
+ * `clean-history` reported `History cleaned.` while leaving 11 four-character
+ * runs of a `ghp_` token in `~/.bash_history`, and `diff` printed most of an
+ * over-length credential to stdout under a `[... REDACTED]` label.
+ *
+ * This is the same lesson as `leaksAny` above, applied to the replacement side:
+ * the detector's reach is not the credential's length, so the redactor must not
+ * take the match as the boundary. It is a REDACTION change only — no pattern is
+ * altered, so nothing new is detected and no scan result changes.
+ *
+ * `preferCaptureGroup` keeps the existing name-gated behaviour: patterns like
+ * `AWS_SECRET_ACCESS_KEY = "..."` match ACROSS the variable name, so replacing
+ * the whole match erased the name and left a bare quote. When the pattern
+ * captures the value in group 1, only from that group onward is replaced.
+ */
+export function redactMatches(
+  text: string,
+  regex: RegExp,
+  label: string,
+  opts?: { preferCaptureGroup?: boolean },
+): string {
+  const flags = regex.flags.includes('g') ? regex.flags : regex.flags + 'g';
+  const scanner = new RegExp(regex.source, flags);
+  let out = '';
+  let cursor = 0;
+  let m: RegExpExecArray | null;
+
+  while ((m = scanner.exec(text)) !== null) {
+    // A zero-length match would leave lastIndex where it is and spin forever.
+    if (m[0].length === 0) {
+      scanner.lastIndex++;
+      continue;
+    }
+
+    const matchStart = m.index;
+    let cutFrom = matchStart;
+
+    if (opts?.preferCaptureGroup) {
+      const group = typeof m[1] === 'string' ? m[1] : undefined;
+      // indexOf, not a group index: the goal is to keep the gating prefix the
+      // user needs to see (the variable name), and the value's offset inside
+      // the match is what identifies where that prefix ends.
+      if (group && group.length > 0) {
+        const rel = m[0].indexOf(group);
+        if (rel > 0) cutFrom = matchStart + rel;
+      }
+    }
+
+    // Extend past the match across anything that could still be the credential.
+    let cutTo = matchStart + m[0].length;
+    while (cutTo < text.length && CREDENTIAL_TAIL.test(text[cutTo])) cutTo++;
+
+    out += text.slice(cursor, cutFrom) + label;
+    cursor = cutTo;
+    // The tail is consumed, so continue scanning after it rather than from the
+    // match end — otherwise the same characters are re-examined.
+    scanner.lastIndex = cutTo;
+  }
+
+  return cursor === 0 ? text : out + text.slice(cursor);
+}

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -6,6 +6,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { CREDENTIAL_PATTERNS, CONFIG_FILES, CREDENTIAL_PREFIX_QUICK_CHECK, SOURCE_FILE_EXTENSIONS, SOURCE_SKIP_DIRS, KNOWN_EXAMPLE_KEYS, PLACEHOLDER_INDICATORS, type CredentialPattern } from './patterns';
+import { redactMatches } from './redact';
 import { loadSecretlessIgnore, buildMatcher, DEFAULT_IGNORE_PATTERNS, type IgnoreMatcher } from './secretlessignore';
 import { scoreFinding, type ConfidenceTier } from './confidence';
 
@@ -85,19 +86,12 @@ export function fixFor(pattern: Pick<CredentialPattern, 'id' | 'name' | 'envPref
  * whole-match redaction.
  */
 export function maskLine(line: string, pattern: Pick<CredentialPattern, 'name' | 'regex'>): string {
-  const flags = pattern.regex.flags.includes('g') ? pattern.regex.flags : pattern.regex.flags + 'g';
-  const globalRegex = new RegExp(pattern.regex.source, flags);
-  const label = `[${pattern.name} REDACTED]`;
-  return line.replace(globalRegex, (full: string, ...rest: unknown[]) => {
-    // A replacer's trailing args are (offset, wholeString[, groups]); a string
-    // in slot 0 means the pattern has at least one capture group.
-    const value = typeof rest[0] === 'string' ? rest[0] : undefined;
-    if (!value) return label;
-    if (!full.includes(value)) return label;
-    // EVERY occurrence, not just the first or last: a match that spans the
-    // value twice would otherwise leave a copy of the secret in the preview.
-    // No pattern does that today; redacting all of them means none can.
-    return full.split(value).join(label);
+  // Shared with the transcript and shell-history redactors, so the preview and
+  // the file rewrite cannot drift: all three used to replace exactly the regex
+  // match, which left the tail of any value longer than the pattern's fixed
+  // quantifier (#133 — `ghp_` + 37 chars printed the 37th verbatim).
+  return redactMatches(line, pattern.regex, `[${pattern.name} REDACTED]`, {
+    preferCaptureGroup: true,
   });
 }
 

--- a/src/secret-store.ts
+++ b/src/secret-store.ts
@@ -11,6 +11,7 @@ import { resolveBackendType } from './backends/config';
 import type { WritableSecretBackend } from './backends/types';
 import type { SelectableBackendType } from './backends/config';
 import { findSecretValueProblem, unstorableSecretError } from './secret-value';
+import { editDistance, NEAR_MISS_MAX } from './near-miss';
 
 const SECRET_PREFIX = 'secret';
 
@@ -144,65 +145,9 @@ export class SecretStore {
   }
 }
 
-/** Largest edit distance still shown as a "did you mean". */
-const NEAR_MISS_MAX = 2;
-
 /** Most unmatched names we compute a near-miss hint for. */
 const MAX_HINTED = 10;
 
-/** Anything above the threshold; all such values are equivalent to the caller. */
-const OVER = NEAR_MISS_MAX + 1;
-
-/**
- * Case-insensitive edit distance, only ever used to suggest a typo fix.
- * Any result above NEAR_MISS_MAX is returned as OVER, not computed exactly.
- *
- * BANDED. Only cells within NEAR_MISS_MAX of the diagonal are evaluated, so a
- * comparison costs O(n * k) rather than O(n^2) — bounded whether the two names
- * are similar or not.
- *
- * A row-minimum cutoff alone is not enough, and the measurement that suggested
- * it was misleading: it used maximally DIFFERENT names, which exit on the first
- * row. For names sharing a long prefix and differing only near the end — the
- * realistic shape, since stored names look alike — the band around the diagonal
- * stays under the threshold and the full table gets computed. Measured at 5000
- * stored names sharing a 60-char prefix, against 100 unmatched: 7814ms
- * unbounded, 840ms with the cutoff alone, 378ms banded. (The same shape with
- * maximally different names is 33ms — which is why benchmarking that shape hid
- * the problem.)
- */
-function editDistance(a: string, b: string): number {
-  const s = a.toUpperCase();
-  const t = b.toUpperCase();
-  // Names have no length limit; keep the table small regardless.
-  if (s.length > 64 || t.length > 64) return OVER;
-  if (Math.abs(s.length - t.length) > NEAR_MISS_MAX) return OVER;
-
-  let prev: number[] = new Array(t.length + 1).fill(OVER);
-  for (let j = 0; j <= Math.min(t.length, NEAR_MISS_MAX); j++) prev[j] = j;
-
-  for (let i = 1; i <= s.length; i++) {
-    const cur: number[] = new Array(t.length + 1).fill(OVER);
-    cur[0] = i <= NEAR_MISS_MAX ? i : OVER;
-    const lo = Math.max(1, i - NEAR_MISS_MAX);
-    const hi = Math.min(t.length, i + NEAR_MISS_MAX);
-    let rowMin = cur[0];
-    for (let j = lo; j <= hi; j++) {
-      const v = Math.min(
-        prev[j] + 1,
-        cur[j - 1] + 1,
-        prev[j - 1] + (s[i - 1] === t[j - 1] ? 0 : 1),
-      );
-      cur[j] = v > OVER ? OVER : v;
-      if (cur[j] < rowMin) rowMin = cur[j];
-    }
-    // Every reachable cell already exceeds the threshold, so the final distance
-    // cannot come back under it.
-    if (rowMin > NEAR_MISS_MAX) return OVER;
-    prev = cur;
-  }
-  return prev[t.length];
-}
 
 /**
  * Error for `--only` names that matched nothing.

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import * as os from 'os';
 import * as crypto from 'crypto';
 import { CREDENTIAL_PATTERNS } from './patterns';
+import { redactMatches } from './redact';
 
 export interface TranscriptFinding {
   file: string;
@@ -152,10 +153,12 @@ function scanString(
   let result = value;
   for (const pattern of CREDENTIAL_PATTERNS) {
     if (pattern.regex.test(result)) {
-      // Use global regex to replace ALL occurrences, not just the first
-      const flags = pattern.regex.flags.includes('g') ? pattern.regex.flags : pattern.regex.flags + 'g';
-      const globalRegex = new RegExp(pattern.regex.source, flags);
-      const preview = result.replace(globalRegex, `[REDACTED:${pattern.id}]`).substring(0, 80);
+      // redactMatches replaces ALL occurrences AND extends across the tail of a
+      // value longer than the pattern's fixed quantifier. Plain String.replace
+      // wrote the tail of an over-length credential back into the user's
+      // transcript while reporting the line as redacted.
+      const redacted = redactMatches(result, pattern.regex, `[REDACTED:${pattern.id}]`);
+      const preview = redacted.substring(0, 80);
       findings.push({
         file: fileInfo.file,
         line: fileInfo.line,
@@ -164,7 +167,7 @@ function scanString(
         patternName: pattern.name,
         preview,
       });
-      result = result.replace(globalRegex, `[REDACTED:${pattern.id}]`);
+      result = redacted;
     }
   }
 


### PR DESCRIPTION
A security patch. Three defects where the tool did something other than what it was asked and reported success, plus the argv layer that closes the class they share.

Cut ahead of the rest of gate B per the 2026-08-12 `[CHIEF-CISO]` ruling, and sized by the 2026-08-12 `[CHIEF-CPO]` readiness ruling. A GHSA + CVE follows this release; it names 0.22.1 as the fixed version, which is why the content is what it is.

## The broker authorized more than the policy said

The policy engine silently dropped constraints it could not apply, so the restrictive half of an operator's rule evaporated and the permissive half survived, while `loadPolicies()`, `getRules()` and `/health` all reported the rule loaded. `minTrustScore: "80"` as a string — what a YAML-to-JSON conversion or an env-var substitution produces — made the trust floor disappear.

**It turned out to be four nesting levels, not one.** Each fix matched the instance it was shown, which is why there was always another:

| level | input | before |
|---|---|---|
| constraint value | `minTrustScore: "80"` | dropped |
| constraints container | `contraints: {...}` | whole block dropped, rule loads as unconstrained ALLOW |
| file envelope | `{"rules":[allow],"denyRules":[deny-all]}` | deny set never loaded |
| constraint sub-key | `rateLimit: {maxPerMinute: 60, maxPerHour: 1}` | hourly cap dropped, 3600/hour permitted |

Plus `requireCapability: ""`, which skipped the capability check entirely including its fail-closed no-identity branch, because that branch tested truthiness while its sibling tests `!== undefined`.

All refuse now. Every matrix carries a positive control that must DENY (a time window of `00:00–00:01` has closed), so a validator that refused everything could not pass.

`scopeCheck` is **removed**: it was documented as "deny if credential permissions expanded since last baseline" and was arithmetically incapable of denying — the enforcement path compared an empty current-permission list against the baseline. Measured with a control: the same comparison reports an expansion when handed real permissions, so the call site was what disabled it. A rule naming it is now refused rather than accepted-and-unapplied.

## A flag never widens scope

Each command parsed its own argv and recognised only the spellings its author thought of:

- `run --only=NAME` dropped the selector, and no selector means **inject the entire credential store** into the child.
- `clean --dryrun` performed the irreversible in-place redaction it was asked to preview — with no backup on that path.
- `clean --path=DIR` walked every transcript on the machine. Measured: 1 file named, **9,119 walked, 205 that would have been rewritten**.
- `scan --max-files <path>` consumed the path as the flag's value and scanned the working directory instead, printing `No hardcoded credentials found.` over a tree it never opened.

Normalised **once at the entry point** rather than adding an `=` branch per command — a parsing surface per command is what produced the class. Splitting only ever fires for a flag the registry records as value-taking, so a gap in the table degrades to the old behaviour and can never invent a positional the user did not type.

`secretless-mcp`, the second published bin, carried the identical idiom and had never been swept: `--vault-dir=` and `--backend=` were dropped, so it read credentials from somewhere other than where it was told to.

## Redaction

The replacement span is now derived from the credential rather than from the pattern match. `clean` wrote the un-redacted tail back into transcripts and reported the redaction complete; `clean-history` did the same to shell history; `diff` printed it with no length cap. `redact.ts` went from 2 consumers to 5 and no raw `replace(regex, label)` redactor remains.

## Behaviour changes worth reading before merging

- **A command line the tool cannot bind now exits 2 before running.** Unknown flags on the twelve verbs that WRITE, a flag given a value it cannot use, and a value-taking flag given none. Read-only `scan` still warns and continues, as it has since #81.
- **A broker policy file with an unrecognised top-level key refuses to load and the daemon will not start.** Including documentation keys — a `comment` beside `id` is refused. That is not hypothetical; it is what one hand-annotated policy file carried, and it is how this was found. An `x-` annotation namespace is a tracked follow-up, deliberately not designed inside a security patch.
- `--json` is deliberately **unchanged**.

## Verification

- Suite **1439 → 1560**.
- Every regression test red-proofed on a `git archive` copy of the pre-fix tree, each failing on its **own** assertion, with positive controls passing in both trees so the arms discriminate on the one variable.
- Guards take their oracle from the **source**, not the table they check. Three of them caught a real defect on first run: `ignore --pattern` missing from the argv registry, a conformance suite silently reading the developer's real policy file, and `--json` advertised as supported on 32 verbs while 2 implement it.
- Release walkthrough run against the **installed tarball**, not `dist/` — an earlier draft of this branch broke every protected MCP server in exactly the way only the installed layout exposes.
- 55 documented commands re-run against the tightened parser; no shipped doc breaks.

## Known issues

Two P1s carried under the provenance rule, both reproducing identically on published 0.22.0, both first carries: #136 (`scan` has three ignore layers, one unreachable by any flag, and two widening flags combine to narrow) → 0.24.0, and #137 (a typo in a coverage flag yields a confident clean) → 0.23.0. Both are in the release notes.

Also corrects two 0.22.0 release-note claims that were wider than the code.
