### PR TITLE
The tool does what it says: argv contract, duplicate policy keys, and coverage disclosure (0.23.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,26 @@ engine holding zero rules, which is default-deny.
 
   This statement is scoped to duplicated member names and to nothing else.
 
+- **`status` no longer reports zero deny patterns for a settings file whose keys
+  collide.** `.claude/settings.json` is read by Claude Code, and Claude Code keeps
+  the last copy of a repeated key. A file whose `permissions` block appears twice
+  therefore has every deny pattern in the first copy dropped -- in the editor, not
+  here -- for as long as the duplicate has existed. `status` reported that as
+  `denyRuleCount: 0` with nothing else set, byte-identical to a project that
+  configured none, and printed a green check beside it. It now names the repeated
+  key and says the patterns cannot be read as configured.
+
+  **Contract change:** `denyRuleCount` is now `number | null`. It is `null`
+  whenever the count was not measured -- a settings file that would not parse, and
+  one whose keys collide. A number implies a measurement, and `0` over a file we
+  could not read is a parse artifact. A consumer testing `denyRuleCount > 0` is
+  unaffected; one testing `=== 0` is not. The two unknown states are
+  distinguishable in the JSON: `settingsUnreadable` and `settingsAmbiguous`.
+
+  Scanned on the raw text with the same check the broker policy loader uses, so a
+  collision spelled as a JSON escape or a case variant is caught too. Measured
+  against 36 real-world config files with no false positives.
+
 - **A `/grant` request no longer reports a broker-side fault as your mistake.**
   One `catch` covered both the load of the duplicate-member scanner and the scan
   itself, while its comment named only the parse — so a scanner that failed to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,18 @@ this package as a library rather than a CLI. `const n = engine.loadPolicies()`
 becomes `const n = await engine.loadPolicies()`. An un-awaited call leaves the
 engine holding zero rules, which is default-deny.
 
+**In the same area:** `PolicyEngine.loadRules()` now validates what it is handed,
+the same way rules read from the policy file are validated. It used to validate
+nothing, so a caller that parsed its own rules skipped every check the file
+loader performs. It now throws on an unknown or misspelled constraint key
+(`timeWindoww`), on a constraint this build does not enforce (`scopeCheck`), and
+on a rule carrying any key outside the five a rule may hold — annotation keys
+such as `description` are deliberately not tolerated, for the same reason they
+are refused in a policy file. It also no longer keeps a reference to the object
+you passed: mutating your own rule after the call used to change the engine's
+decision. Narrowing what a shipped method accepts is a breaking change; on 0.x
+it rides this minor.
+
 ### Security
 
 - **A duplicated key in a broker policy file no longer decides the rule.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.23.0] - 2026-08-13
+## [0.23.0] - 2026-08-19
 
 The tool does what it says. Every change here is a case where a command accepted
 something, did something narrower or different, and reported success.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,105 @@
 # Changelog
 
+## [0.23.0] - 2026-08-13
+
+The tool does what it says. Every change here is a case where a command accepted
+something, did something narrower or different, and reported success.
+
+**Read these three before you upgrade.**
+
+**1. `--json` on a command that does not implement it now exits 2.** It is
+implemented by `scan` and `status`. The other 30 commands accepted it and
+ignored it: 15 did nothing with it, 11 mistook it for a subcommand, and 4
+mistook it for a path. The last group is why this is not a tidy-up — `verify
+--json` resolved `--json` as the project directory and printed `AI context:
+clean (no credentials found)` for a directory whose `CLAUDE.md` held a live key.
+If you pass `--json` to anything other than `scan` or `status`, that call now
+fails instead of returning human text at exit 0.
+
+**2. `scan`, `scan-staged` and `scan-history` now refuse an unrecognised flag
+instead of warning and continuing.** `scan --nosuchflag` on a clean tree changes
+from exit 0 to exit 2; on a tree with findings, from 1 to 2. `scan` is the most
+used command in this tool and this is a CI-visible change to it. The reason is
+that warn-and-continue produced `No hardcoded credentials found.` — the
+strongest clean claim the tool makes — over a scan whose scope you asked to
+change and did not get. `scan-staged` is the pre-commit gate and had no
+machine-readable channel at all, so an exit code was the only signal it had.
+`feedback` and `diff` still warn, since they report no verdict.
+
+**3. `PolicyEngine.loadPolicies()` is now `async`.** Only relevant if you use
+this package as a library rather than a CLI. `const n = engine.loadPolicies()`
+becomes `const n = await engine.loadPolicies()`. An un-awaited call leaves the
+engine holding zero rules, which is default-deny.
+
+### Security
+
+- **A duplicated key in a broker policy file no longer decides the rule.**
+  `JSON.parse` keeps the last of a repeated member name and resolves it before
+  the loader is given anything to inspect, so a rule whose text read
+  `"effect": "deny"` then `"effect": "allow"` loaded as an allow — and the rule
+  count, `getRules()` and `/health` all reported the operator's rule as loaded.
+  The restrictive half was gone and nothing said so. The same shape applied one
+  level out: a file carrying two `rules` arrays loaded only the second, so
+  appending a deny block below an existing one produced a policy containing
+  neither the deny rules nor any indication they had been dropped.
+
+  Duplicating a key that the loader *does* know also defeated the checks added
+  in 0.22.1, because the instance that would have been refused is the instance
+  that disappears: a duplicated `constraints` hid an unknown-constraint
+  refusal, a duplicated `rateLimit` hid the sub-key refusal, a duplicated
+  `requireCapability` hid the empty-capability refusal, and a duplicated
+  `effect` hid effect validation.
+
+  A duplicated member is now refused at every level of the file, on the raw text
+  before parsing. Names are compared after JSON escape decoding and case
+  folding, so a colliding member spelled as an escape sequence or a case variant
+  is caught too — worth knowing, because such a spelling survives a `grep` and
+  a diff review while `JSON.parse` still collapses it. Tracked as #140; the
+  limitation was disclosed in GHSA-4x65-2hwf-fwpm and is now closed.
+
+  This statement is scoped to duplicated member names and to nothing else.
+
+- **A `/grant` request no longer reports a broker-side fault as your mistake.**
+  One `catch` covered both the load of the duplicate-member scanner and the scan
+  itself, while its comment named only the parse — so a scanner that failed to
+  load returned `400 Invalid JSON` to every caller, blaming each request for a
+  security module that was silently absent. The two are now separate, and a
+  scanner that will not load is reported as a broker fault, logged, with grant
+  requests refused rather than answered.
+
+### Fixed
+
+- **`cache` and `backend` refuse a subcommand they do not recognise** instead of
+  printing their status page at exit 0. `backend purg` — a near miss of the
+  destructive `purge` — exited 0 with a normal-looking report, and nothing in
+  the output or the exit code separated "purged" from "never ran". `telemetry`
+  had the same shape with a message: it printed `Unknown action` to stdout and
+  returned 0. Running any of these with no subcommand is still an exploration
+  and still exits 0.
+- **`secret list` refuses an argument** rather than accepting a filter token and
+  listing every stored name anyway, byte-identically to the unfiltered run.
+- **A near miss of `--json` is no longer suggested by a command that does not
+  implement it.** The refusal hid `--json` from its own "Supported:" line while
+  suggesting it two lines earlier, and taking the suggestion produced the
+  silent mistarget above.
+
+### Added
+
+- **`scan` reports what it did not look at.** Two new non-gating fields in the
+  `--json` summary, each with a sample carrying the reason:
+  `skippedUnsupported` (files enumerated but not opened) and `notEntered`
+  (directories not descended into). Neither changes the exit code — a boundary
+  the scanner declared is not a claim it broke, and every repository contains at
+  least one, so gating on them would fail every build.
+
+  The case that made this necessary: source files inside dot-directories are not
+  scanned, while config and key files inside them are. So a scan could report a
+  finding inside `.claude/` while a byte-identical credential in
+  `.claude/agent.ts` went unreported, with every coverage counter reading 0 —
+  the summary did not merely omit the gap, it corroborated the conclusion that
+  there wasn't one. Tracked as #144. This release discloses the gap; changing
+  what is scanned is separate work.
+
 ## [0.22.1] - 2026-08-12
 
 A security patch. Three defects where the tool did something other than what it

--- a/README.md
+++ b/README.md
@@ -166,11 +166,19 @@ npx secretless-ai status --json                # protection state for CI (gate o
 
 A scan that could not read everything is not a passing scan. If the walk stops at the file cap, or a path cannot be opened, `scan` prints what it missed, exits 1, and says `No credentials found in the files scanned` rather than `No hardcoded credentials found`. In `--json`, `summary.truncated` and `summary.unreadable` carry the same signal, so CI can tell "clean" from "unfinished".
 
+**Two kinds of gap, and only one of them gates.** A gap against a claim the scanner made -- it said it would read something and did not -- sets exit 1: `truncated`, `unreadable`, `oversize`. A boundary the scanner declared and never claimed to cross does not: `outOfRoot`, `skippedUnsupported` (files enumerated but not opened, such as a `.png` or a `.md`), and `notEntered` (directories not descended into, such as `node_modules/` or any dot-directory). The second group is reported, sampled and given the command that scans it, but it does not fail your build -- every repository contains at least one of them, so gating on it would fail every build. If you want a declared boundary to gate, test it yourself: `jq -e '.summary.notEntered == 0'`.
+
+Dot-directories are among the `notEntered` group, and that includes `.claude/`. Config files and key files inside them are still scanned; source files inside them are not. See issue #144.
+
 Symlinks are followed inside the scan root. A link whose target resolves outside it is not followed -- otherwise a repo containing `link -> $HOME` would pull the whole home directory into the scan -- and each one is listed with the command to scan its target directly, so the boundary is never silent. These do not affect the exit code.
 
 ### A flag never widens scope
 
-A command line the tool cannot bind is refused with exit 2 before anything runs, rather than partly ignored. That covers an unrecognised flag on a command that writes, a flag given a value it cannot use, and a value-taking flag given no value at all. `--only=NAME`, `--path=DIR` and every other `--flag=value` spelling binds the same way as the spaced form.
+A command line the tool cannot bind is refused with exit 2 before anything runs, rather than partly ignored. That covers an unrecognised flag, a flag given a value it cannot use, and a value-taking flag given no value at all. `--only=NAME`, `--path=DIR` and every other `--flag=value` spelling binds the same way as the spaced form.
+
+`scan`, `scan-staged` and `scan-history` refuse an unrecognised flag rather than warning and continuing, because their output is the answer: a typo in a coverage flag used to produce `No hardcoded credentials found.` at exit 0 over a narrower scan than the one you asked for. `feedback` and `diff` still warn, since they report no verdict.
+
+`--json` is implemented by `scan` and `status`. Passing it to any other command exits 2 and names those two, rather than printing human text and exiting 0 -- the caller of `--json` is a machine, and a machine reading exit 0 beside prose cannot tell it was ignored.
 
 Exit codes: `0` clean, `1` credentials found (or an incomplete scan), `2` the command line was refused and nothing ran. Gate CI on `2` separately -- it means the tool did not answer the question, not that the answer was clean.
 
@@ -185,7 +193,8 @@ npx secretless-ai clean --dryrun --path ./transcripts
 ```bash
 npx secretless-ai scan --json | jq '.summary'
 # { "total": 0, "critical": 0, "high": 0, "placeholdersSuppressed": 0,
-#   "truncated": false, "maxFiles": 5000, "unreadable": 0, "outOfRoot": 0 }
+#   "truncated": false, "maxFiles": 5000, "unreadable": 0, "outOfRoot": 0,
+#   "oversize": 0, "skippedUnsupported": 0, "notEntered": 0 }
 ```
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npx secretless-ai init
 ```
 
 ```
-  Secretless v0.22.1
+  Secretless v0.23.0
   Keeping secrets out of AI
 
   Configured: Claude Code (1 of 1 detected)

--- a/docs/testing/release-smoke.md
+++ b/docs/testing/release-smoke.md
@@ -98,6 +98,7 @@ $SL status --json . | python3 -c "import sys,json; d=json.load(sys.stdin); \
   summary}`. Exit 1 when findings exist (CI gating), 0 when clean.
 - `status --json`: single JSON document — `{tool, version, isProtected,
   hookInstalled, denyRuleCount, configuredTools, secretsFound,
+  settingsUnreadable, settingsAmbiguous,
   transcriptProtection, backend, session, broker, summary}`. Exit 0; CI
   consumers gate on `summary.verdict`.
 - Neither may print the human banner or any ANSI color in JSON mode.
@@ -143,6 +144,27 @@ this checklist uses the leading form and the README uses the trailing one.
 The one that matters: pre-fix, `verify --json` resolved `--json` as the project
 directory and printed `AI context: clean (no credentials found)` for a directory
 whose `CLAUDE.md` held a live key.
+
+---
+
+### 2d. status tells three states apart (settings key collisions)
+
+```bash
+# A settings file whose permissions key appears TWICE loses every deny pattern in
+# the first copy -- in Claude Code, which is what enforces them.
+$SL status /path/with/duplicated-key --json | jq ".denyRuleCount, .settingsAmbiguous"
+#   null
+#   { "path": ".claude/settings.json", "reason": "repeats ..." }
+$SL status /path/with/duplicated-key      # NO green check on that file
+```
+
+`denyRuleCount` is `number | null`: null in BOTH unknown states (would not parse, or
+keys collide), a number only when it was actually measured. Check the three states are
+distinguishable from the JSON alone -- measured / settingsUnreadable / settingsAmbiguous
+-- and that no row renders green over a file in either unknown state. Do NOT verify a
+collision with `grep` or `node -e JSON.parse`: both exit 0 on a duplicate and print
+nothing. Also run it against a REAL settings file from a dev tree, not only fixtures --
+a false positive here is a warning on the tool own status page.
 
 ---
 

--- a/docs/testing/release-smoke.md
+++ b/docs/testing/release-smoke.md
@@ -4,11 +4,22 @@
 
 Every item came from a real bug or regression. Don't skip without writing down why.
 
-Run every command from the local build (`node dist/cli.js`), not the global
-install. Several commands operate on **machine-global state** (the secret
-store, `~/.zshenv`, shell history, MCP configs) — the steps below flag each
-one and use throwaway names or isolated `$HOME` so a smoke run never damages
-the operator's real setup.
+Run every command from the local build, not the global install. Several commands
+operate on **machine-global state** (the secret store, `~/.zshenv`, shell
+history, MCP configs) — the steps below flag each one and use throwaway names or
+isolated `$HOME` so a smoke run never damages the operator's real setup.
+
+**The binary is `dist/cli.js`.** Take it from `package.json` `bin`, never from
+habit: `dist/index.js` is this package's LIBRARY entry, it registers no commands,
+and it prints nothing and exits 0 for every invocation including `--version`.
+A walkthrough scripted against it produces a full sheet of exit-0 rows with no
+output, which is indistinguishable from a clean pass. Two people hit this in one
+day. Before trusting any sheet, confirm at least one row produced real output.
+
+**Build from a clean checkout of the commit you intend to tag**, not from the
+incrementally-built working tree. An incremental `dist/` is not the build
+artifact of any particular commit, and the walkthrough certifies whatever
+happens to be on disk.
 
 ---
 
@@ -91,18 +102,47 @@ $SL status --json . | python3 -c "import sys,json; d=json.load(sys.stdin); \
   consumers gate on `summary.verdict`.
 - Neither may print the human banner or any ANSI color in JSON mode.
 
-### 2b. Unknown-flag rejection (issues #62 / #74 / #81 / #83)
+### 2b. Unknown-flag rejection (issues #62 / #74 / #81 / #83 / #126 / #137)
+
+**Run every flag row on BOTH a clean tree and a tree with a finding.** A tree
+that contains a credential exits 1 for that reason, so it cannot tell you
+whether a flag changed anything — this exact confound put "`scan --nosuchflag`
+-> exit 1, warns and continues" on the record as evidence that warn-and-continue
+was safe. On a clean tree the same command exited 0 and said `No hardcoded
+credentials found.` The 1 was never the flag.
 
 ```bash
-$SL init --dry-run; echo "exit=$?"    # "Unknown option: --dry-run", exit 2, NO --dry-run/ dir created
-$SL status --bogus; echo "exit=$?"    # rejected, exit 2
-$SL scan --show-placeholder .         # WARNS about the unknown flag (typo of --show-placeholders), still scans
-$SL bogus-command; echo "exit=$?"     # "Unknown command", help block, exit 1
+mkdir -p /tmp/sl-clean && : > /tmp/sl-clean/app.ts       # clean tree
+$SL init --dry-run; echo "exit=$?"        # "Unknown option: --dry-run", exit 2, NO --dry-run/ dir created
+$SL status --bogus; echo "exit=$?"        # rejected, exit 2
+$SL scan /tmp/sl-clean --show-placeholder; echo "exit=$?"   # REFUSED, exit 2, names --show-placeholders
+$SL scan /tmp/sl-clean; echo "exit=$?"                      # CONTROL: exit 0, "No hardcoded credentials found."
+$SL scan-staged --no-ignoree; echo "exit=$?"                # REFUSED, exit 2 (the pre-commit gate)
+$SL bogus-command; echo "exit=$?"         # "Unknown command", help block, exit 1
 ```
 
-`init`/`status` reject unknown flags (filesystem footgun — pre-fix, `init
---ci` created a literal `--ci/` directory). `scan` warns-but-runs so a typo'd
-flag never hides scan results.
+`scan`, `scan-staged` and `scan-history` refuse an unrecognised flag: their
+output is the answer, so a dropped flag is a wrong verdict rather than a wasted
+run. `feedback` and `diff` still warn — they report no verdict. The
+`secretless-mcp` wrapper still warns, because its argv lines live in hand-edited
+client configs where a refusal is a server that will not start.
+
+### 2c. `--json` is honored or refused (issue #126)
+
+```bash
+$SL scan /tmp/sl-clean --json | head -c 40; echo " exit=$?"   # JSON, exit 0
+$SL status /tmp/sl-clean --json | head -c 40                  # JSON
+$SL verify --json; echo "exit=$?"      # REFUSED, exit 2, names scan and status
+$SL cache --json; echo "exit=$?"       # REFUSED, exit 2 (pre-fix: status page, exit 0)
+$SL doctor --json; echo "exit=$?"      # REFUSED, exit 2
+```
+
+Check both argv positions — `scan --json <dir>` and `scan <dir> --json` — since
+this checklist uses the leading form and the README uses the trailing one.
+
+The one that matters: pre-fix, `verify --json` resolved `--json` as the project
+directory and printed `AI context: clean (no credentials found)` for a directory
+whose `CLAUDE.md` held a live key.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "secretless-ai",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "secretless-ai",
-      "version": "0.22.1",
+      "version": "0.23.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/post-quantum": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secretless-ai",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "description": "One command to keep secrets out of AI. Works with Claude Code, Cursor, Copilot, Windsurf, and any AI coding tool.",
   "license": "Apache-2.0",
   "type": "commonjs",

--- a/src/argv.test.ts
+++ b/src/argv.test.ts
@@ -186,7 +186,10 @@ describe('the registry is derived from the source, not from itself', () => {
   const NOT_OURS = new Map<string, string>([
     ['--version', 'top-level, handled before dispatch (cli.ts:65)'],
     ['--help', 'global, in GLOBAL_FLAGS'],
-    ['--json', 'global, in GLOBAL_FLAGS'],
+    // `--json` is deliberately NOT excused here any more. As of 0.23.0 it is
+    // declared by the verbs that implement it, so it must be found in the
+    // registry like any other flag — which is what makes the guard below able
+    // to catch a verb that starts reading `--json` without declaring it.
   ]);
 
   /**

--- a/src/argv.test.ts
+++ b/src/argv.test.ts
@@ -139,15 +139,46 @@ describe('prepareArgv: the child command after `--` is untouched', () => {
   });
 });
 
-describe('prepareArgv: read-only verbs warn and keep running', () => {
-  // #81 shipped this warning for `scan` and CI consumers read its exit code.
-  // Moving scan to a hard refusal would be a breaking change this release does
-  // not make; the warning moved to the shared layer, the behaviour did not.
-  it('scan warns on an unknown flag and still runs', () => {
+describe('prepareArgv: a verb whose output is the answer refuses a flag it cannot bind', () => {
+  /**
+   * #81's intent survives and is strengthened. It complained that `scan`
+   * silently swallowed a typo'd flag and asked for the typo to be surfaced;
+   * it settled for a warning because it was scoped as polish, on a build with
+   * no exit-2 contract to reach for. It even cited `init`'s refusal as the
+   * consistent behaviour.
+   *
+   * What retired the warning was measuring what it does on a CLEAN tree:
+   * exit 0 and `No hardcoded credentials found.` over a scan whose scope the
+   * user asked to change and did not get. The earlier evidence that this was
+   * safe recorded exit 1 — but that 1 was the FINDING, from a tree that
+   * happened to contain a credential, not the flag.
+   */
+  it('scan refuses a typo\'d flag rather than answering with a narrowed scope', () => {
     const p = prepareArgv('scan', ['scan', '--show-placeholder', './src']);
+    expect(p.warnings).toEqual([]);
+    expect(p.errors).toHaveLength(1);
+    // #81's actual ask: the typo is surfaced and the intended flag is named.
+    expect(p.errors[0]).toContain('--show-placeholder');
+    expect(p.errors[0]).toContain('--show-placeholders');
+  });
+
+  it('the pre-commit gate refuses too — it has no JSON channel and stderr is swallowed', () => {
+    const p = prepareArgv('scan-staged', ['scan-staged', '--no-ignoree']);
+    expect(p.warnings).toEqual([]);
+    expect(p.errors).toHaveLength(1);
+    expect(p.errors[0]).toContain('--no-ignore');
+  });
+
+  it('CONTROL: a verb that reports no verdict still warns and runs', () => {
+    const p = prepareArgv('diff', ['diff', '--nosuchflag']);
     expect(p.errors).toEqual([]);
     expect(p.warnings).toHaveLength(1);
-    expect(p.warnings[0]).toContain('--show-placeholders');
+  });
+
+  it('CONTROL: a flag the verb DOES accept produces neither', () => {
+    const p = prepareArgv('scan', ['scan', '--show-placeholders', './src']);
+    expect(p.errors).toEqual([]);
+    expect(p.warnings).toEqual([]);
   });
 
   it('an unknown verb is left entirely alone for the dispatcher to report', () => {
@@ -264,6 +295,40 @@ describe('the registry is derived from the source, not from itself', () => {
       expect(VERBS[verb], `${verb} has no registry row`).toBeDefined();
       expect(VERBS[verb].unknownFlags, `${verb} must reject unknown flags`).toBe('reject');
     }
+  });
+
+  /**
+   * The policy, pinned in BOTH directions.
+   *
+   * A test that only asserts the refusing verbs passes when the whole table is
+   * flipped to `reject`, which would break every hand-edited MCP client config
+   * — so the exceptions are asserted as exceptions. A test that only asserts
+   * the exceptions passes when a verdict verb is demoted. Both lists are named
+   * rather than derived, because this is the release's claim and a predicate
+   * that drifts with the table cannot check it.
+   */
+  it('the unknown-flag policy is pinned per verb, presence AND absence', () => {
+    // Verdict-emitting: their output is the answer, so a dropped flag is a
+    // wrong verdict rather than a wasted run.
+    for (const verb of ['scan', 'scan-staged', 'scan-history', 'status', 'verify']) {
+      expect(VERBS[verb], `${verb} has no registry row`).toBeDefined();
+      expect(VERBS[verb].unknownFlags, `${verb} must refuse an unknown flag`).toBe('reject');
+    }
+    // The ONLY verbs that may warn, each for a recorded reason. `mcp-status` is
+    // a deliberately temporary entry, carried with its sibling defect.
+    const mayWarn = ['mcp-status', 'feedback', 'diff'];
+    for (const verb of mayWarn) {
+      expect(VERBS[verb].unknownFlags, `${verb} is a documented warn exception`).toBe('warn');
+    }
+    // Nothing else warns. Derived, so a NEW verb added with 'warn' fails here
+    // rather than joining the exception list silently.
+    const warning = Object.keys(VERBS).filter((v) => VERBS[v].unknownFlags === 'warn');
+    expect(warning.sort()).toEqual([...mayWarn].sort());
+
+    // The second bin keeps `warn` on purpose: its argv lines live in
+    // hand-edited MCP client configs, where a refusal is a server that will not
+    // start. Flipping the table wholesale must fail here.
+    expect(MCP_WRAPPER.unknownFlags).toBe('warn');
   });
 });
 

--- a/src/argv.ts
+++ b/src/argv.ts
@@ -59,16 +59,37 @@ export const EXIT_USAGE = 2;
 export type UnknownFlagPolicy =
   /** Refuse to run, exit EXIT_USAGE, before any side effect. */
   | 'reject'
-  /** Print a warning and continue — the behaviour `scan` has shipped since #81. */
+  /** Print a warning and continue. */
   | 'warn';
 
 export interface VerbSpec {
   /** Flag spelling -> whether it consumes the FOLLOWING argv token as its value. */
   flags: Record<string, boolean>;
   /**
-   * What to do with a flag not in `flags`. `reject` on every verb that can
-   * write, because a misspelled safety flag there is a destroyed file; `warn`
-   * on read-only verbs, where the cost of a typo is a wasted run.
+   * What to do with a flag not in `flags`.
+   *
+   * THE AXIS IS WHETHER THE VERB EMITS A VERDICT, not whether it can write.
+   * The write-based axis was inherited from the harm model of a file-mutation
+   * tool, and it is wrong for a scanner: the cost of a dropped flag here is not
+   * a wasted run, it is a wrong answer the user acts on.
+   *
+   * Measured — the same dropped flag, two trees, and the exit code that made
+   * this look safe came from somewhere else entirely:
+   *
+   *   scan <tree WITH a credential>   --nosuchflag  -> exit 1, "1 credential found"
+   *   scan <tree WITHOUT a credential> --nosuchflag -> exit 0, "No hardcoded credentials found."
+   *
+   * The 1 was the finding. On a clean tree, warn-and-continue emits the
+   * strongest clean claim the tool can make over a scan whose scope the user
+   * asked to change and did not get. `scan-staged --no-ignoree` is the same
+   * shape on the PRE-COMMIT GATE: exit 0, empty stdout, a warning on the one
+   * stream a git hook reliably swallows.
+   *
+   * So `reject` on the verdict-emitting verbs, and `warn` only where a refusal
+   * would be worse than a wrong answer — `feedback` and `diff`, which report no
+   * verdict, and the `secretless-mcp` wrapper, whose argv lines live in
+   * hand-edited client configs where a refusal is a server that will not start.
+   * That failure is loud, and loud is not the class this guards against.
    */
   unknownFlags: UnknownFlagPolicy;
   /**
@@ -123,19 +144,26 @@ const GLOBAL_FLAGS: Readonly<Record<string, boolean>> = {
 /**
  * Every verb the dispatcher accepts, with the flags it actually reads.
  *
- * `unknownFlags` is keyed on whether the verb can WRITE — mutate a file, the
- * credential store, or system state — not on how dangerous it feels. `clean`
- * and `clean-history` are the sharpest cases: both are destructive by default
- * and `--dry-run` is the only thing that makes either a preview, so a
- * misspelling of that flag has to stop the run rather than degrade to it.
+ * `unknownFlags` is `reject` by default and `warn` only by exception. The
+ * exceptions are listed with their reason, because an unexplained `warn` is how
+ * a verdict-emitting verb quietly rejoins the warn-and-continue class.
+ *
+ * It used to be keyed on whether the verb can WRITE. That axis came from the
+ * harm model of a file-mutation tool and was wrong here — see `UnknownFlagPolicy`
+ * for the measurement that retired it. Writing verbs still reject, but they
+ * reject because a dropped flag is a wrong action, not because writing is the
+ * test. `clean` and `clean-history` remain the sharpest of those: destructive by
+ * default, with `--dry-run` the only thing that makes either a preview.
  *
  * A verb whose flag list is incomplete would reject a working command, so
  * `argv.test.ts` derives the flag literals from the source and asserts this
  * table covers them. The test reads the source, not this table, so the two
- * cannot agree by construction.
+ * cannot agree by construction. A second test pins the POLICY per verb, in both
+ * directions, so neither flipping the table wholesale nor demoting one verb can
+ * pass quietly.
  */
 export const VERBS: Readonly<Record<string, VerbSpec>> = {
-  // --- read-only: a typo costs a wasted run, so warn and continue -----------
+  // --- verbs whose output IS the answer: a dropped flag is a wrong verdict ---
   scan: {
     flags: {
       '--history': false,
@@ -148,7 +176,7 @@ export const VERBS: Readonly<Record<string, VerbSpec>> = {
       '--max-file-size': true,
       '--json': false,
     },
-    unknownFlags: 'warn',
+    unknownFlags: 'reject',
     honorsJson: true,
   },
   // `status` already refuses an unknown flag today, via
@@ -161,9 +189,20 @@ export const VERBS: Readonly<Record<string, VerbSpec>> = {
   // short report, and the user reads "36 known env vars not set (use --all to
   // list)" believing they ran the full listing.
   verify: { flags: { '--all': false }, unknownFlags: 'reject' },
-  'scan-staged': { flags: { '--no-ignore': false }, unknownFlags: 'warn' },
-  'scan-history': { flags: {}, unknownFlags: 'warn' },
+  // The pre-commit gate, and the reason the whole axis changed. Measured with a
+  // CLEAN staged set: `scan-staged --no-ignoree` exited 0 with EMPTY stdout and
+  // the warning on stderr — the one stream a git hook reliably swallows. It has
+  // no `--json` channel, so an exit code is the only signal that path has.
+  // (Our own installed hook body passes no flags — `git-hook.ts:19` — so this
+  // cannot refuse an existing installation under version skew.)
+  'scan-staged': { flags: { '--no-ignore': false }, unknownFlags: 'reject' },
+  'scan-history': { flags: {}, unknownFlags: 'reject' },
+  // EXCEPTION, and a deliberately temporary one. By the verdict test this
+  // belongs on `reject`, but its sibling defect (clean-over-unparsed) is
+  // assigned to the next release and reclassifying it here would widen this one.
+  // It is swept with that fix, and the unit names it so it is not lost.
   'mcp-status': { flags: {}, unknownFlags: 'warn' },
+  // EXCEPTION: reports no verdict. A typo costs a wasted run, nothing more.
   feedback: { flags: {}, unknownFlags: 'warn' },
   // No flags of its own: `diff` reads one positional ref (commands/diff.ts:292).
   // The `--no-color`, `--verify` and `--show-toplevel` literals in that file are

--- a/src/argv.ts
+++ b/src/argv.ts
@@ -80,12 +80,15 @@ export interface VerbSpec {
   /**
    * True when this verb actually implements `--json`.
    *
-   * Acceptance of `--json` is global and unchanged (see GLOBAL_FLAGS); this
-   * governs only whether we NAME it as supported when refusing a command line.
-   * Naming it on the 30 verbs that ignore it would advertise a machine-readable
-   * mode that does not exist, in the text a user reads at the moment they hit
-   * an error — the same false-clean class this release exists to close, and it
-   * would contradict this release's own note that `--json` is unchanged.
+   * It is now the single source of truth for that, in both directions: the verb
+   * declares `--json` in its own `flags` AND sets this, and `jsonVerbs()` reads
+   * it to name the honoring verbs in the refusal every other verb produces. A
+   * test pins it against the `--json` read sites in `cli.ts`, so a verb that
+   * starts or stops implementing JSON cannot leave this behind.
+   *
+   * Before 0.23.0 this governed only whether a refusal message NAMED `--json`
+   * as supported, because acceptance was global. That half-measure is gone: the
+   * flag is either implemented or not a flag.
    */
   honorsJson?: boolean;
 }
@@ -93,21 +96,28 @@ export interface VerbSpec {
 /**
  * Accepted by every verb.
  *
- * `--json` is here because 20 verbs accept and silently ignore it today. The
- * 2026-08-12 `[CHIEF-CPO]` ruling is that a flag the tool accepts is a flag the
- * tool honors, and that `--json` on a verb that does not implement it must exit
- * 2 naming the verbs that do. That is a consumer-visible exit-code change and
- * belongs to its own release, so it is NOT made here. Listing `--json` keeps
- * this release's behaviour byte-identical and leaves the ruling exactly one
- * place to land: delete this entry and give the implementing verbs their own.
+ * `--json` USED TO BE HERE, and that is what 0.23.0 changes. It is now declared
+ * by the two verbs that implement it, so on every other verb it is simply not a
+ * flag — which is the honest description of what it was all along.
  *
- * ACCEPTING it globally is not the same as ADVERTISING it globally. Only verbs
- * marked `honorsJson` name it in a refusal message — see `supportedFlags`.
+ * The 2026-08-12 `[CHIEF-CPO]` ruling: a flag the tool accepts is a flag the
+ * tool honors. `--json` on a verb that does not implement it exits 2 naming the
+ * verbs that do, rather than warning, because a machine consumer reading exit 0
+ * plus human text is the same false-clean class the rest of this file closes.
+ *
+ * Measured on 0.22.1 across all 32 verbs: 2 honor it, and of the other 30, 15
+ * truly ignored it, 11 mistook it for a SUBCOMMAND (`cache` and `backend`
+ * silently falling through to a normal-looking status page at exit 0), and 4
+ * mistook it for a POSITIONAL. The last group is why this is not cosmetic:
+ * `verify --json` resolved `--json` as the project directory, so the AI-context
+ * scan ran against a path that does not exist and printed `AI context: clean
+ * (no credentials found)` for a directory whose `CLAUDE.md` held a live
+ * Anthropic key. That is not accept-and-ignore; it is answering a different
+ * question and reporting it as clean.
  */
 const GLOBAL_FLAGS: Readonly<Record<string, boolean>> = {
   '--help': false,
   '-h': false,
-  '--json': false,
 };
 
 /**
@@ -136,6 +146,7 @@ export const VERBS: Readonly<Record<string, VerbSpec>> = {
       '--min-confidence': true,
       '--max-files': true,
       '--max-file-size': true,
+      '--json': false,
     },
     unknownFlags: 'warn',
     honorsJson: true,
@@ -144,7 +155,7 @@ export const VERBS: Readonly<Record<string, VerbSpec>> = {
   // `rejectUnknownFlagAsDirArg` — the flag falls through as its directory
   // argument. Keeping it at `reject` preserves that exit code while replacing a
   // message that called the flag a bad path with one that calls it a bad flag.
-  status: { flags: {}, unknownFlags: 'reject', honorsJson: true },
+  status: { flags: { '--json': false }, unknownFlags: 'reject', honorsJson: true },
   // `verify` is the one read-only verb where a swallowed flag changes the
   // ANSWER rather than wasting the run: `verify --alll` silently returns the
   // short report, and the user reads "36 known env vars not set (use --all to
@@ -287,12 +298,21 @@ export function supportedFlags(spec: VerbSpec): string[] {
   const all = { ...GLOBAL_FLAGS, ...spec.flags };
   return Object.keys(all)
     .filter((f) => f !== '-h')
-    // `--json` is accepted by every verb and implemented by two. Listing it as
-    // "Supported" everywhere promises a machine-readable mode that does not
-    // exist — and promises it in the one place a user reads after a refusal.
-    .filter((f) => f !== '--json' || spec.honorsJson === true)
     .sort()
     .map((f) => usageOf(f, all[f]));
+}
+
+/**
+ * The verbs that implement `--json`, derived from the registry rather than
+ * written out, so the refusal message cannot name a verb that stopped
+ * implementing it — or omit one that started.
+ *
+ * Computed on call, not at module load: `VERBS` is initialised below this
+ * point and a module-level constant here would read it in its temporal dead
+ * zone.
+ */
+export function jsonVerbs(): string[] {
+  return Object.keys(VERBS).filter((v) => VERBS[v].honorsJson === true).sort();
 }
 
 /**
@@ -307,7 +327,7 @@ export function prepareArgv(verb: string | undefined, args: string[]): PreparedA
   // output. Rewriting argv for a command that will not run helps nobody.
   if (!verb || !spec) return { args, positionals: [], warnings: [], errors: [] };
   // args[0] is the verb; flags start at 1.
-  return prepareWithSpec(spec, args, 1);
+  return prepareWithSpec(spec, args, 1, true);
 }
 
 /**
@@ -315,10 +335,20 @@ export function prepareArgv(verb: string | undefined, args: string[]): PreparedA
  * `secretless-mcp` wrapper, whose first token is already a flag.
  */
 export function prepareBinArgv(spec: VerbSpec, args: string[]): PreparedArgv {
-  return prepareWithSpec(spec, args, 0);
+  // `isVerb: false`. The `--json` refusal is a statement about THIS CLI's verb
+  // contract; `secretless-mcp` has no such contract, its argv lines are written
+  // into MCP client configs and hand-edited afterwards, and its `warn` policy
+  // is a deliberate decision with a different blast radius. An unrecognised
+  // `--json` there takes the ordinary unknown-flag path.
+  return prepareWithSpec(spec, args, 0, false);
 }
 
-function prepareWithSpec(spec: VerbSpec, args: string[], firstFlagIndex: number): PreparedArgv {
+function prepareWithSpec(
+  spec: VerbSpec,
+  args: string[],
+  firstFlagIndex: number,
+  isVerb: boolean,
+): PreparedArgv {
   // Split at the first bare `--` BEFORE touching anything, so the child's argv
   // is preserved byte for byte.
   const sepIdx = spec.passthrough ? args.indexOf('--') : -1;
@@ -352,6 +382,28 @@ function prepareWithSpec(spec: VerbSpec, args: string[], firstFlagIndex: number)
     const takesValue = known[name];
 
     if (takesValue === undefined) {
+      // `--json` is refused rather than warned about, on EVERY verb that does
+      // not implement it, whatever that verb's unknown-flag policy says.
+      //
+      // This deliberately overrides `unknownFlags: 'warn'`. Routing `--json`
+      // through the ordinary unknown-flag path would refuse it on the twelve
+      // verbs that reject and merely WARN on the six read-only ones — and a
+      // warning on stderr beside exit 0 and human text on stdout is precisely
+      // the false-clean shape a machine consumer cannot see. `--json` is the
+      // one flag whose entire audience is a machine, so it is the one flag
+      // where warn-and-continue is not available as an answer.
+      if (isVerb && name === '--json') {
+        const honoring = jsonVerbs().map((v) => `\`${v}\``);
+        const list = honoring.length > 1
+          ? `${honoring.slice(0, -1).join(', ')} and ${honoring[honoring.length - 1]}`
+          : honoring.join('');
+        errors.push(
+          `--json is not implemented by this command, so it would have printed human text ` +
+          `and exited as though it had answered. Only ${list} produce JSON.`,
+        );
+        out.push(name);
+        continue;
+      }
       // Left WHOLE on purpose. Splitting an unregistered `--foo=bar` would push
       // `bar` into the positional list, and for `scan` or `clean` a stray
       // positional is a path — a token the user never typed becoming a target.

--- a/src/broker/policy-duplicate-members.test.ts
+++ b/src/broker/policy-duplicate-members.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { PolicyEngine } from './policy';
+
+/**
+ * A duplicated member name in the policy file (#140).
+ *
+ * `JSON.parse` resolves a repeated name before the loader is given anything to
+ * inspect: the surviving object holds ONE entry, and it is the LAST one written.
+ * So a rule whose text reads `"effect": "deny"` then `"effect": "allow"` reaches
+ * `validateRule` as a well-formed allow, and every surface — the rule count,
+ * `getRules()`, `/health` — reports the operator's rule loaded. The restrictive
+ * half is gone and nothing says so.
+ *
+ * WHY THE FILED DIRECTION DOES NOT WORK. Issue #140 proposed a
+ * duplicate-key-detecting reviver. Measured on `{"a":1,"a":2,"b":{"a":3}}`: the
+ * reviver is invoked four times, and NO call ever carries `value: 1`. The first
+ * member does not produce a call at all, because the reviver walks the
+ * already-collapsed result. A reviver cannot see a duplicate; a control built on
+ * one would never fire. The scan therefore has to run on the RAW TEXT, before
+ * `JSON.parse`, which is what `firstDuplicateMember` does.
+ *
+ * WHY IT IS WORSE THAN "A DENY BECOMES AN ALLOW". Duplicating a KNOWN name also
+ * defeats the 0.22.1 refusals, because the instance that would have been refused
+ * is the instance that disappears. Measured on published 0.22.1: a duplicated
+ * `constraints` hides an unknown-constraint refusal, a duplicated `rateLimit`
+ * hides the sub-key refusal, a duplicated `requireCapability` hides the
+ * empty-capability refusal, and a duplicated `effect` hides effect validation.
+ * Those are covered below, because closing only the deny-becomes-allow shape
+ * would leave every one of them live.
+ */
+
+function policyFile(text: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'policy-dup-'));
+  const file = path.join(dir, 'broker-policies.json');
+  fs.writeFileSync(file, text);
+  return file;
+}
+
+/** Always an explicit policyFile — never the developer's real one. */
+function engineFor(text: string): PolicyEngine {
+  return new PolicyEngine({ policyFile: policyFile(text) });
+}
+
+const RULE = '"id":"r1","agentSelector":"*","credentialSelector":"*"';
+
+describe('a duplicated member is refused, at every level of the file', () => {
+  /**
+   * The controls come first and they must come out DIFFERENT from every row
+   * below. A matrix whose refusals all pass would look identical if the loader
+   * simply refused everything, so an honest file that LOADS is what makes the
+   * refusals mean something.
+   */
+  it('CONTROL: an honest file loads, and its deny rule denies', async () => {
+    const engine = engineFor(`{"version":1,"rules":[{${RULE},"effect":"deny"}]}`);
+    expect(await engine.loadPolicies()).toBe(1);
+    expect(engine.getRules()[0].effect).toBe('deny');
+    expect(engine.evaluate('any-agent', 'PROD_DB_PASSWORD').allowed).toBe(false);
+  });
+
+  it('CONTROL: an honest file whose rule ALLOWS still allows', async () => {
+    const engine = engineFor(`{"rules":[{${RULE},"effect":"allow"}]}`);
+    expect(await engine.loadPolicies()).toBe(1);
+    expect(engine.evaluate('any-agent', 'ANY_CRED').allowed).toBe(true);
+  });
+
+  it.each([
+    [
+      'the envelope — two `rules` arrays, so the deny set is never in the engine',
+      `{"rules":[{"id":"deny-all","agentSelector":"*","credentialSelector":"*","effect":"deny"}],` +
+      `"rules":[{"id":"allow-all","agentSelector":"*","credentialSelector":"*","effect":"allow"}]}`,
+      'rules',
+    ],
+    [
+      'the rule — `effect` twice, deny then allow',
+      `{"rules":[{${RULE},"effect":"deny","effect":"allow"}]}`,
+      'effect',
+    ],
+    [
+      'the rule — `agentSelector` twice, `*` then a narrower one',
+      `{"rules":[{"id":"r1","agentSelector":"*","agentSelector":"other","credentialSelector":"*","effect":"deny"}]}`,
+      'agentSelector',
+    ],
+    [
+      'the constraints container — `timeWindow` twice, closed then open',
+      `{"rules":[{${RULE},"effect":"allow","constraints":{"timeWindow":{"start":"00:00","end":"00:01"},` +
+      `"timeWindow":{"start":"00:00","end":"23:59"}}}]}`,
+      'timeWindow',
+    ],
+    [
+      'the constraint sub-object — `end` twice, the deepest level in the schema',
+      `{"rules":[{${RULE},"effect":"allow","constraints":{"timeWindow":{"start":"00:00","end":"00:01","end":"23:59"}}}]}`,
+      'end',
+    ],
+    [
+      'the constraint sub-object — `maxPerMinute` twice, 1 then 3600',
+      `{"rules":[{${RULE},"effect":"allow","constraints":{"rateLimit":{"maxPerMinute":1,"maxPerMinute":3600}}}]}`,
+      'maxPerMinute',
+    ],
+    [
+      'the bare-array file form, which has no envelope to check',
+      `[{${RULE},"effect":"deny","effect":"allow"}]`,
+      'effect',
+    ],
+  ])('refuses %s', async (_label, text, member) => {
+    const engine = engineFor(text);
+    await expect(engine.loadPolicies()).rejects.toThrow(new RegExp(`duplicate member "${member}"`));
+  });
+
+  /**
+   * The property, asserted on the rule SET rather than on a message: a refusal
+   * that threw but left rules loaded would still satisfy `.rejects.toThrow()`.
+   */
+  it('nothing is loaded when a duplicate is refused', async () => {
+    const engine = engineFor(`{"rules":[{${RULE},"effect":"deny","effect":"allow"}]}`);
+    await expect(engine.loadPolicies()).rejects.toThrow();
+    expect(engine.getRules()).toEqual([]);
+    expect(engine.ruleCount).toBe(0);
+    expect(engine.evaluate('any-agent', 'ANY_CRED').allowed).toBe(false);
+  });
+});
+
+/**
+ * Duplicating a KNOWN name defeats the refusals 0.22.1 added, because the
+ * instance that would have been refused is the instance `JSON.parse` drops.
+ * Each row below LOADS on 0.22.1 with `allowed: true`.
+ */
+describe('a duplicate cannot be used to smuggle a rule past a 0.22.1 refusal', () => {
+  it.each([
+    [
+      'an unknown constraint, hidden behind a duplicated `constraints`',
+      `{"rules":[{${RULE},"effect":"allow","constraints":{"maxPerHour":1},"constraints":{}}]}`,
+    ],
+    [
+      'the refused `scopeCheck` key, hidden behind a duplicated `constraints`',
+      `{"rules":[{${RULE},"effect":"allow","constraints":{"scopeCheck":true},"constraints":{}}]}`,
+    ],
+    [
+      'an empty requireCapability, hidden by a second spelling that is valid',
+      `{"rules":[{${RULE},"effect":"allow","constraints":{"requireCapability":"","requireCapability":"read"}}]}`,
+    ],
+    [
+      'an invalid effect, hidden by a second spelling that is valid',
+      `{"rules":[{${RULE},"effect":"DENY","effect":"allow"}]}`,
+    ],
+    [
+      'an empty agentSelector, which matches nothing, hidden by a valid second',
+      `{"rules":[{"id":"r1","agentSelector":"","agentSelector":"*","credentialSelector":"*","effect":"allow"}]}`,
+    ],
+  ])('refuses %s', async (_label, text) => {
+    const engine = engineFor(text);
+    await expect(engine.loadPolicies()).rejects.toThrow(/duplicate member/);
+    expect(engine.getRules()).toEqual([]);
+  });
+});
+
+/**
+ * The collision is judged after JSON escape decoding and after case folding, so
+ * the colliding member can be spelled differently in the file than it reads in
+ * the error. A byte-comparing scanner would return clean on the first case and
+ * ship the bypass in the same direction as the defect.
+ */
+describe('a collision the file does not spell literally', () => {
+  it('refuses an escaped spelling of a name already present', async () => {
+    // `effect` is `effect`. JSON.parse collapses the pair and keeps "allow".
+    const engine = engineFor(`{"rules":[{${RULE},"effect":"deny","\\u0065ffect":"allow"}]}`);
+    await expect(engine.loadPolicies()).rejects.toThrow(/duplicate member "effect"/);
+    expect(engine.getRules()).toEqual([]);
+  });
+
+  it('the refusal says the spelling may differ, so nobody hunts for a literal', async () => {
+    const engine = engineFor(`{"rules":[{${RULE},"effect":"deny","\\u0065ffect":"allow"}]}`);
+    let message = '';
+    try { await engine.loadPolicies(); } catch (err) { message = (err as Error).message; }
+    expect(message).toMatch(/escape decoding/);
+    expect(message).toMatch(/case folding/);
+  });
+
+  /**
+   * A case variant is ALREADY refused by the key allowlists, as an unknown
+   * field. It is here to pin that the outcome does not regress to a load — the
+   * message changes owner, the verdict does not.
+   */
+  it('CONTROL: a case variant is refused either way, never loaded', async () => {
+    const engine = engineFor(`{"rules":[{${RULE},"effect":"deny","EFFECT":"allow"}]}`);
+    await expect(engine.loadPolicies()).rejects.toThrow();
+    expect(engine.getRules()).toEqual([]);
+  });
+});
+
+/**
+ * R1 — the check must not be bypassable by its own failure.
+ *
+ * The likeliest way this fix is broken later is a copy of the `/grant` path's
+ * `try { import; scan } catch { ... }` shape with a catch that CONTINUES. That
+ * would load a policy file with the check silently absent, on any machine where
+ * the module does not resolve — the defect reintroduced by its own fix, and a
+ * green suite would not see it. This test is the thing that sees it.
+ */
+describe('the duplicate-member check cannot be bypassed by failing to load', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock('@opena2a/atx-verify');
+  });
+
+  it('refuses to load anything when the scanner module will not resolve', async () => {
+    vi.resetModules();
+    vi.doMock('@opena2a/atx-verify', () => {
+      throw new Error("Cannot find module '@opena2a/atx-verify'");
+    });
+    const { PolicyEngine: FreshEngine } = await import('./policy');
+
+    // An HONEST file: there is nothing wrong with it. The refusal must come
+    // from the check being unavailable, not from the file's content — which is
+    // what makes this a withhold rather than a refusal.
+    const engine = new FreshEngine({ policyFile: policyFile(`{"rules":[{${RULE},"effect":"deny"}]}`) });
+
+    await expect(engine.loadPolicies()).rejects.toThrow(/could not be loaded/);
+    expect(engine.getRules()).toEqual([]);
+    expect(engine.ruleCount).toBe(0);
+    expect(engine.evaluate('any-agent', 'ANY_CRED').allowed).toBe(false);
+  });
+
+  it('says it is an installation fault, and does not tell the operator to edit the policy', async () => {
+    vi.resetModules();
+    vi.doMock('@opena2a/atx-verify', () => {
+      throw new Error("Cannot find module '@opena2a/atx-verify'");
+    });
+    const { PolicyEngine: FreshEngine } = await import('./policy');
+    const engine = new FreshEngine({ policyFile: policyFile(`{"rules":[{${RULE},"effect":"deny"}]}`) });
+
+    let message = '';
+    try { await engine.loadPolicies(); } catch (err) { message = (err as Error).message; }
+
+    expect(message).toMatch(/installation fault/);
+    expect(message).toMatch(/no credential will be served/);
+    // A remedy that says "delete the policy file" is a fail-open by hand.
+    expect(message).not.toMatch(/delete .*polic/i);
+  });
+});
+
+/**
+ * The scanner is strict about structure where `JSON.parse` is not. Refusing
+ * here keeps the accept-set of the FILE and the accept-set of the CHECK
+ * identical — a file the check cannot vouch for must not be loaded by a parser
+ * that would have accepted it.
+ */
+describe('text the scanner cannot vouch for is refused, not parsed anyway', () => {
+  it('refuses trailing content after the closing brace', async () => {
+    const engine = engineFor(`{"rules":[{${RULE},"effect":"deny"}]} trailing`);
+    await expect(engine.loadPolicies()).rejects.toThrow(/well-formed JSON value/);
+    expect(engine.getRules()).toEqual([]);
+  });
+
+  it('CONTROL: a trailing newline is not trailing content', async () => {
+    const engine = engineFor(`{"rules":[{${RULE},"effect":"deny"}]}\n`);
+    expect(await engine.loadPolicies()).toBe(1);
+  });
+});

--- a/src/broker/policy.test.ts
+++ b/src/broker/policy.test.ts
@@ -277,7 +277,7 @@ describe('PolicyEngine', () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     });
 
-    it('loads policies from a JSON file', () => {
+    it('loads policies from a JSON file', async () => {
       const policies = {
         rules: [{
           id: 'test-rule',
@@ -290,24 +290,24 @@ describe('PolicyEngine', () => {
       fs.writeFileSync(policyFile, JSON.stringify(policies));
 
       const fileEngine = new PolicyEngine({ policyFile });
-      const count = fileEngine.loadPolicies();
+      const count = await fileEngine.loadPolicies();
       expect(count).toBe(1);
       expect(fileEngine.evaluate('agent', 'CRED').allowed).toBe(true);
     });
 
-    it('returns zero when policy file does not exist', () => {
+    it('returns zero when policy file does not exist', async () => {
       const fileEngine = new PolicyEngine({ policyFile: path.join(tmpDir, 'nonexistent.json') });
-      const count = fileEngine.loadPolicies();
+      const count = await fileEngine.loadPolicies();
       expect(count).toBe(0);
     });
 
-    it('throws on invalid policy file', () => {
+    it('throws on invalid policy file', async () => {
       fs.writeFileSync(policyFile, 'not json');
       const fileEngine = new PolicyEngine({ policyFile });
-      expect(() => fileEngine.loadPolicies()).toThrow('Failed to load policies');
+      await expect(fileEngine.loadPolicies()).rejects.toThrow('Failed to load policies');
     });
 
-    it('loads policies from a bare JSON array', () => {
+    it('loads policies from a bare JSON array', async () => {
       const policies = [{
         id: 'bare-rule',
         agentSelector: 'scanner-*',
@@ -318,22 +318,22 @@ describe('PolicyEngine', () => {
       fs.writeFileSync(policyFile, JSON.stringify(policies));
 
       const fileEngine = new PolicyEngine({ policyFile });
-      const count = fileEngine.loadPolicies();
+      const count = await fileEngine.loadPolicies();
       expect(count).toBe(1);
       expect(fileEngine.evaluate('scanner-01', 'GITHUB_TOKEN').allowed).toBe(true);
       expect(fileEngine.evaluate('deploy-agent', 'GITHUB_TOKEN').allowed).toBe(false);
     });
 
-    it('throws on missing rules array', () => {
+    it('throws on missing rules array', async () => {
       fs.writeFileSync(policyFile, JSON.stringify({ notRules: [] }));
       const fileEngine = new PolicyEngine({ policyFile });
-      expect(() => fileEngine.loadPolicies()).toThrow('must contain a "rules" array');
+      await expect(fileEngine.loadPolicies()).rejects.toThrow('must contain a "rules" array');
     });
 
-    it('validates rule structure', () => {
+    it('validates rule structure', async () => {
       fs.writeFileSync(policyFile, JSON.stringify({ rules: [{ invalid: true }] }));
       const fileEngine = new PolicyEngine({ policyFile });
-      expect(() => fileEngine.loadPolicies()).toThrow('non-empty "id"');
+      await expect(fileEngine.loadPolicies()).rejects.toThrow('non-empty "id"');
     });
   });
 
@@ -501,9 +501,9 @@ describe('PolicyEngine — an unappliable constraint refuses the rule', () => {
   ];
 
   for (const [label, constraints] of MALFORMED) {
-    it(`refuses to load: ${label}`, () => {
+    it(`refuses to load: ${label}`, async () => {
       const e = new PolicyEngine({ policyFile: policyFile(constraints) });
-      expect(() => e.loadPolicies()).toThrow();
+      await expect(e.loadPolicies()).rejects.toThrow();
     });
 
     /**
@@ -513,10 +513,10 @@ describe('PolicyEngine — an unappliable constraint refuses the rule', () => {
      * throw alone would still pass if some later change caught the error and
      * carried on with a widened rule, which is exactly the shape being fixed.
      */
-    it(`never grants after: ${label}`, () => {
+    it(`never grants after: ${label}`, async () => {
       const e = new PolicyEngine({ policyFile: policyFile(constraints) });
       try {
-        e.loadPolicies();
+        await e.loadPolicies();
       } catch {
         /* refusing to load is the fix; the assertion below is the invariant */
       }
@@ -524,17 +524,17 @@ describe('PolicyEngine — an unappliable constraint refuses the rule', () => {
     });
   }
 
-  it('still loads and still ENFORCES a well-formed constraint', () => {
+  it('still loads and still ENFORCES a well-formed constraint', async () => {
     // The negative direction: refusing malformed input must not have been
     // bought by refusing everything.
     const e = new PolicyEngine({ policyFile: policyFile({ timeWindow: { start: '00:00', end: '00:01' } }) });
-    expect(e.loadPolicies()).toBe(1);
+    expect(await e.loadPolicies()).toBe(1);
     expect(e.getRules()[0].constraints).toEqual({ timeWindow: { start: '00:00', end: '00:01' } });
   });
 
-  it('accepts a rule with no constraints at all', () => {
+  it('accepts a rule with no constraints at all', async () => {
     const e = new PolicyEngine({ policyFile: policyFile(undefined) });
-    expect(e.loadPolicies()).toBe(1);
+    expect(await e.loadPolicies()).toBe(1);
   });
 });
 
@@ -575,18 +575,18 @@ describe('PolicyEngine — a rule field we do not read refuses the rule', () => 
 
   // POSITIVE CONTROLS. Both pass before and after the fix. Without them a
   // validator that refused every rule would satisfy the arms below.
-  it('CONTROL: the correctly spelled container still loads and still denies', () => {
+  it('CONTROL: the correctly spelled container still loads and still denies', async () => {
     const engine = new PolicyEngine({ policyFile: policyFileFor({ ...BASE, constraints: CLOSED_WINDOW }) });
-    expect(engine.loadPolicies()).toBe(1);
+    expect(await engine.loadPolicies()).toBe(1);
     expect(engine.getRules()[0].constraints.timeWindow).toEqual(CLOSED_WINDOW.timeWindow);
     expect(engine.evaluate('agent-1', 'DEPLOY_TOKEN').allowed).toBe(false);
   });
 
-  it('CONTROL: a rule with no constraints at all is still legitimate', () => {
+  it('CONTROL: a rule with no constraints at all is still legitimate', async () => {
     // "constraints absent" cannot itself be an error — an unconstrained allow
     // rule is a real thing an operator writes.
     const engine = new PolicyEngine({ policyFile: policyFileFor({ ...BASE }) });
-    expect(engine.loadPolicies()).toBe(1);
+    expect(await engine.loadPolicies()).toBe(1);
     expect(engine.evaluate('agent-1', 'DEPLOY_TOKEN').allowed).toBe(true);
   });
 
@@ -598,15 +598,15 @@ describe('PolicyEngine — a rule field we do not read refuses the rule', () => 
     ['effect misspelled, so the real effect is absent', { ...BASE, efect: 'deny' }],
   ];
 
-  it.each(UNKNOWN_FIELDS)('refuses a rule carrying %s', (_label, rule) => {
+  it.each(UNKNOWN_FIELDS)('refuses a rule carrying %s', async (_label, rule) => {
     const engine = new PolicyEngine({ policyFile: policyFileFor(rule) });
-    expect(() => engine.loadPolicies()).toThrow();
+    await expect(engine.loadPolicies()).rejects.toThrow();
   });
 
-  it('the refusal names the offending field and the legal set', () => {
+  it('the refusal names the offending field and the legal set', async () => {
     const engine = new PolicyEngine({ policyFile: policyFileFor({ ...BASE, contraints: CLOSED_WINDOW }) });
     let message = '';
-    try { engine.loadPolicies(); } catch (err) { message = (err as Error).message; }
+    try { await engine.loadPolicies(); } catch (err) { message = (err as Error).message; }
     expect(message).toContain('contraints');
     expect(message).toContain('did you mean "constraints"');
     for (const key of ['id', 'agentSelector', 'credentialSelector', 'constraints', 'effect']) {
@@ -617,9 +617,9 @@ describe('PolicyEngine — a rule field we do not read refuses the rule', () => 
   // The property, stated once: no rule that carries an unreadable field may
   // ever load. Asserting the rule SET rather than an error string, because a
   // refusal that loaded the rule anyway would still throw somewhere.
-  it('nothing is loaded when a rule is refused', () => {
+  it('nothing is loaded when a rule is refused', async () => {
     const engine = new PolicyEngine({ policyFile: policyFileFor({ ...BASE, contraints: CLOSED_WINDOW }) });
-    try { engine.loadPolicies(); } catch { /* expected */ }
+    try { await engine.loadPolicies(); } catch { /* expected */ }
     expect(engine.getRules()).toEqual([]);
     expect(engine.evaluate('agent-1', 'DEPLOY_TOKEN').allowed).toBe(false);
   });
@@ -659,24 +659,24 @@ describe('PolicyEngine — an unenforced constraint refuses the rule', () => {
     ['true', true],
     ['false', false],
     ['a string', 'true'],
-  ])('refuses scopeCheck: %s rather than reporting a gate that is not there', (_label, value) => {
+  ])('refuses scopeCheck: %s rather than reporting a gate that is not there', async (_label, value) => {
     const engine = engineFor({ scopeCheck: value });
-    expect(() => engine.loadPolicies()).toThrow(/does not enforce scopeCheck/);
+    await expect(engine.loadPolicies()).rejects.toThrow(/does not enforce scopeCheck/);
   });
 
-  it('says it is unenforced, not that it is unknown', () => {
+  it('says it is unenforced, not that it is unknown', async () => {
     // The distinction is the whole point: "unknown constraint" would tell an
     // operator they typed it wrong. They did not — we removed it.
     const engine = engineFor({ scopeCheck: true });
     let message = '';
-    try { engine.loadPolicies(); } catch (err) { message = (err as Error).message; }
+    try { await engine.loadPolicies(); } catch (err) { message = (err as Error).message; }
     expect(message).toContain('does not enforce');
     expect(message).not.toContain('unknown constraint');
   });
 
-  it('CONTROL: the constraints that ARE enforced still load', () => {
+  it('CONTROL: the constraints that ARE enforced still load', async () => {
     const engine = engineFor({ timeWindow: { start: '00:00', end: '23:59' }, minTrustScore: 80 });
-    expect(engine.loadPolicies()).toBe(1);
+    expect(await engine.loadPolicies()).toBe(1);
     expect(engine.getRules()[0].constraints.minTrustScore).toBe(80);
   });
 });
@@ -769,31 +769,31 @@ describe('PolicyEngine — no level of policy input silently drops what it canno
   const DENY_ALL = { id: 'deny-all', agentSelector: '*', credentialSelector: '*', effect: 'deny' };
 
   describe('the envelope', () => {
-    it('CONTROL: a deny rule under the real key denies', () => {
+    it('CONTROL: a deny rule under the real key denies', async () => {
       const engine = engineFor({ version: 1, rules: [DENY_ALL] });
-      expect(engine.loadPolicies()).toBe(1);
+      expect(await engine.loadPolicies()).toBe(1);
       expect(engine.evaluate('agent-1', 'AWS_KEY').allowed).toBe(false);
     });
 
-    it('refuses a sibling of `rules` rather than loading only half the policy', () => {
+    it('refuses a sibling of `rules` rather than loading only half the policy', async () => {
       // Measured pre-fix: loaded=1, allowed=true, matched the allow rule. The
       // operator's deny rules were never in the engine and nothing said so.
       const engine = engineFor({ rules: [ALLOW_ALL], denyRules: [DENY_ALL] });
-      expect(() => engine.loadPolicies()).toThrow(/denyRules/);
+      await expect(engine.loadPolicies()).rejects.toThrow(/denyRules/);
     });
 
-    it('a bare array is still accepted', () => {
+    it('a bare array is still accepted', async () => {
       const engine = engineFor([DENY_ALL]);
-      expect(engine.loadPolicies()).toBe(1);
+      expect(await engine.loadPolicies()).toBe(1);
     });
   });
 
   describe('a constraint sub-key', () => {
     const base = { id: 'r1', agentSelector: '*', credentialSelector: '*', effect: 'allow' };
 
-    it('CONTROL: the sub-keys we do read still load and still enforce', () => {
+    it('CONTROL: the sub-keys we do read still load and still enforce', async () => {
       const engine = engineFor({ rules: [{ ...base, constraints: { timeWindow: { start: '00:00', end: '00:01' } } }] });
-      expect(engine.loadPolicies()).toBe(1);
+      expect(await engine.loadPolicies()).toBe(1);
       expect(engine.evaluate('agent-1', 'AWS_KEY').allowed).toBe(false);
     });
 
@@ -802,31 +802,31 @@ describe('PolicyEngine — no level of policy input silently drops what it canno
       ['timeWindow.End — a near-miss of end', { timeWindow: { start: '00:00', end: '23:59', End: '00:01' } }],
       ['timeWindow.days — a restriction we do not implement', { timeWindow: { start: '00:00', end: '23:59', days: ['sun'] } }],
       ['timeWindow.timezone — the window is server-local', { timeWindow: { start: '00:00', end: '23:59', timezone: 'UTC' } }],
-    ])('refuses %s', (_label, constraints) => {
+    ])('refuses %s', async (_label, constraints) => {
       const engine = engineFor({ rules: [{ ...base, constraints }] });
-      expect(() => engine.loadPolicies()).toThrow();
+      await expect(engine.loadPolicies()).rejects.toThrow();
     });
   });
 
   describe('an empty value that deletes the restriction', () => {
     const base = { id: 'r1', agentSelector: '*', credentialSelector: '*', effect: 'allow' };
 
-    it('CONTROL: a named capability with no identity denies', () => {
+    it('CONTROL: a named capability with no identity denies', async () => {
       const engine = engineFor({ rules: [{ ...base, constraints: { requireCapability: 'deploy' } }] });
-      expect(engine.loadPolicies()).toBe(1);
+      expect(await engine.loadPolicies()).toBe(1);
       expect(engine.evaluate('agent-1', 'AWS_KEY').allowed).toBe(false);
     });
 
-    it('refuses requireCapability: "" rather than skipping the gate', () => {
+    it('refuses requireCapability: "" rather than skipping the gate', async () => {
       // Pre-fix the enforcement branch guarded on truthiness, so "" skipped the
       // whole block INCLUDING its fail-closed no-identity arm: allowed=true.
       const engine = engineFor({ rules: [{ ...base, constraints: { requireCapability: '' } }] });
-      expect(() => engine.loadPolicies()).toThrow(/must not be empty/);
+      await expect(engine.loadPolicies()).rejects.toThrow(/must not be empty/);
     });
 
-    it('refuses an empty selector, which matches nothing and so never denies', () => {
+    it('refuses an empty selector, which matches nothing and so never denies', async () => {
       const engine = engineFor({ rules: [{ ...DENY_ALL, agentSelector: '' }] });
-      expect(() => engine.loadPolicies()).toThrow(/non-empty/);
+      await expect(engine.loadPolicies()).rejects.toThrow(/non-empty/);
     });
   });
 });
@@ -908,7 +908,7 @@ describe('matchGlob is not defeated by a line terminator', () => {
     ['carriage return', '\r'],
     ['line separator U+2028', ' '],
     ['paragraph separator U+2029', ' '],
-  ])('a glob matches a value containing a %s, as `*` already did', (_label, ch) => {
+  ])('a glob matches a value containing a %s, as `*` already did', async (_label, ch) => {
     // The asymmetry IS the defect: these two must agree.
     expect(matchGlob('*', `AWS_KEY${ch}`)).toBe(true);
     expect(matchGlob('AWS_*', `AWS_KEY${ch}`)).toBe(true);

--- a/src/broker/policy.test.ts
+++ b/src/broker/policy.test.ts
@@ -935,3 +935,87 @@ describe('matchGlob is not defeated by a line terminator', () => {
     expect(matchGlob('?', 'ab')).toBe(false);
   });
 });
+
+/**
+ * `loadRules` accepts what the file loader accepts, and nothing else.
+ *
+ * It used to validate nothing at all — three lines, a shallow copy — so every
+ * check `loadPolicies()` performs was skipped by a caller that had parsed its
+ * own rules. That is the 0.22.1 fail-open reached through a second public
+ * entry point, in this file.
+ *
+ * The suite could not see it: 206 broker tests passed identically before and
+ * after the fix. Each assertion below is therefore pinned RED against the
+ * pre-fix commit, not merely green after it.
+ */
+describe('loadRules validates what it loads', () => {
+  const BASE = { id: 'r1', agentSelector: '*', credentialSelector: '*', effect: 'allow' as const };
+  const CLOSED = { start: '00:00', end: '00:01' };
+  // Never the default policy file: that is the developer's real one.
+  const engineFor = () => new PolicyEngine({ policyFile: '/nonexistent-by-design' });
+
+  it('CONTROL: a rule the file loader accepts still loads and still enforces', () => {
+    const e = engineFor();
+    e.loadRules([{ ...BASE, constraints: { timeWindow: CLOSED } }]);
+    expect(e.ruleCount).toBe(1);
+    // A closed window denies — so the constraint is genuinely being applied,
+    // which is what makes the refusals below mean something.
+    expect(e.evaluate('agent-1', 'ANY_CRED').allowed).toBe(false);
+  });
+
+  it('refuses a misspelled constraint, which otherwise deleted the restriction', () => {
+    // Pre-fix: loaded, and evaluate() ALLOWED over the same closed window.
+    const e = engineFor();
+    expect(() => e.loadRules([{ ...BASE, constraints: { timeWindoww: CLOSED } } as never]))
+      .toThrow(/unknown constraint "timeWindoww"/);
+    expect(e.getRules()).toEqual([]);
+  });
+
+  it('refuses scopeCheck — the exact key the published advisory says is refused at load', () => {
+    // The advisory sentence carries no qualifier naming the policy file, so it
+    // was false through this method until now.
+    const e = engineFor();
+    expect(() => e.loadRules([{ ...BASE, constraints: { scopeCheck: true } } as never]))
+      .toThrow(/does not enforce scopeCheck/);
+    expect(e.getRules()).toEqual([]);
+  });
+
+  it('refuses a rule that would make evaluate() throw rather than decide', () => {
+    // Pre-fix this loaded and `evaluate()` died with a raw TypeError from
+    // inside the decision function — the engine accepted a rule it could not
+    // enforce and only found out at request time.
+    const e = engineFor();
+    expect(() => e.loadRules([{ ...BASE, constraints: { timeWindow: { start: 0, end: 1 } } } as never]))
+      .toThrow(/timeWindow/);
+    expect(() => e.evaluate('agent-1', 'ANY_CRED')).not.toThrow();
+    expect(e.evaluate('agent-1', 'ANY_CRED').allowed).toBe(false);
+  });
+
+  it('holds no reference the caller can still reach', () => {
+    // Pre-fix `{ ...r }` was shallow, so `constraints` stayed the CALLER's
+    // object: deleting a key from it after this returned turned a denying
+    // policy into an allowing one, with no call into the engine.
+    const mine: Record<string, unknown> = { timeWindow: { ...CLOSED } };
+    const e = engineFor();
+    e.loadRules([{ ...BASE, constraints: mine } as never]);
+    expect(e.evaluate('agent-1', 'ANY_CRED').allowed).toBe(false);
+
+    delete mine.timeWindow;
+    expect(e.evaluate('agent-1', 'ANY_CRED').allowed, 'the caller mutated the engine from outside').toBe(false);
+  });
+
+  it('the accept-set is the SAME function the file loader uses, not a copy of its list', () => {
+    // Oracle is behavioural, not a key list: whatever the file path refuses,
+    // this path must refuse, so a constraint added to validateRule later
+    // reaches both surfaces without anyone remembering to update a second one.
+    for (const bad of [
+      { constraints: { rateLimit: { maxPerMinute: 60, maxPerHour: 1 } } },
+      { constraints: { requireCapability: '' } },
+      { contraints: { timeWindow: CLOSED } },
+      { agentSelector: '' },
+    ]) {
+      const e = engineFor();
+      expect(() => e.loadRules([{ ...BASE, ...bad } as never]), JSON.stringify(bad)).toThrow();
+    }
+  });
+});

--- a/src/broker/policy.ts
+++ b/src/broker/policy.ts
@@ -153,10 +153,40 @@ export class PolicyEngine {
   }
 
   /**
-   * Load policies from an in-memory array (for testing).
+   * Load policies from an in-memory array.
+   *
+   * ACCEPTS EXACTLY WHAT `loadPolicies()` ACCEPTS INSIDE A `rules` ARRAY, and
+   * throws on anything else — the same `validateRule`, not a subset and not a
+   * parallel check. Two public methods that load the same type into the same
+   * field and decide the same requests must have one accept-set, or every
+   * constraint added to `validateRule` later applies to one caller and not the
+   * other. That is not a defect to fix once, it is a defect generator.
+   *
+   * It used to validate nothing. Measured on 0.22.1: a closed `timeWindow`
+   * denied, the SAME window under a misspelled `timeWindoww` allowed, and
+   * `scopeCheck: true` allowed — the key `loadPolicies()` refuses outright.
+   * That is the 0.22.1 fail-open reached through a second entry point, and it
+   * made a sentence in our published advisory false: "a rule naming
+   * `scopeCheck` is refused at load" carries no qualifier naming the file.
+   *
+   * It also used to ALIAS the caller's objects — `{ ...r }` is shallow, so
+   * `constraints` stayed the caller's. Measured: deleting `timeWindow` from
+   * one's own object AFTER this returned turned a denying policy into an
+   * allowing one with no call into the engine. `validateRule` reconstructs
+   * `constraints` from scratch, so the engine now holds nothing the caller can
+   * reach.
+   *
+   * Stays SYNCHRONOUS. `loadPolicies()` is async only because the raw-text
+   * duplicate scan is an ESM import, and a parsed JS object cannot carry two
+   * members of the same name — there is no in-memory analogue of that check,
+   * nor of the envelope check. That is the entire delta between the two.
+   *
+   * Stays EXPORTED. It is the only in-memory path to a loaded policy; removing
+   * it would route every programmatic consumer onto a policy file on disk,
+   * which is the weaker of the two surfaces.
    */
   loadRules(rules: PolicyRule[]): void {
-    this.rules = rules.map(r => ({ ...r }));
+    this.rules = rules.map(r => validateRule(r));
   }
 
   /**

--- a/src/broker/policy.ts
+++ b/src/broker/policy.ts
@@ -37,15 +37,86 @@ export class PolicyEngine {
   /**
    * Load policies from the policy file. Safe to call multiple times (reloads).
    * Returns the number of rules loaded.
+   *
+   * ASYNC because the duplicate-member scan it depends on lives in
+   * `@opena2a/atx-verify`, which is ESM-only while this package is CommonJS —
+   * the same dynamic-import mechanism the `/grant` path already uses in
+   * `server.ts`. The whole chain above this call is already async
+   * (`commands/broker.ts` -> `daemon.ts` -> `server.start()`), so the await
+   * costs one keyword at the single call site. The signature change IS
+   * consumer-visible for anyone using `PolicyEngine` as a library; a call left
+   * un-awaited leaves the engine at zero rules, which is default-deny.
    */
-  loadPolicies(): number {
+  async loadPolicies(): Promise<number> {
     if (!fs.existsSync(this.policyFile)) {
       this.rules = [];
       return 0;
     }
 
+    // Resolved BEFORE the load block and with its OWN message, because a module
+    // that will not load is an installation fault and not a fault in the
+    // operator's file. Reporting it as "Failed to load policies from <their
+    // file>" would send them to debug the wrong artifact.
+    //
+    // There is deliberately no catch that continues without the scan. Falling
+    // back to a bare JSON.parse here is not a degraded mode — it is the
+    // pre-0.23.0 code path verbatim, the one this check exists to close. A
+    // security check that cannot run must withhold, not wave the input through.
+    let firstDuplicateMember: (text: string) => string | null;
+    try {
+      ({ firstDuplicateMember } = await import('@opena2a/atx-verify'));
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `Cannot load policies from ${this.policyFile}: the duplicate-member scanner ` +
+        `(@opena2a/atx-verify) could not be loaded, so the policy file was NOT applied and no ` +
+        `credential will be served. This is an installation fault, not a fault in your policy ` +
+        `file — do not edit or delete the file to clear it.\n` +
+        `  Verify: node -e "import('@opena2a/atx-verify').then(() => console.log('ok'))"\n` +
+        `  Fix:    npm install   # and check node -v is >= 20.19.0\n` +
+        `  Cause:  ${detail}`,
+      );
+    }
+
     try {
       const raw = fs.readFileSync(this.policyFile, 'utf-8');
+
+      // Scanned on the RAW TEXT, and on the SAME binding `JSON.parse` consumes
+      // below — never a re-read and never a normalised copy, or the two would
+      // be judging different bytes.
+      //
+      // It has to happen out here because `JSON.parse` resolves a duplicated
+      // key before any consumer of the parsed object can see it: a reviver is
+      // handed each member exactly once, already collapsed. Issue #140's filed
+      // direction proposed that reviver; it cannot work, and the control it
+      // would produce never fires.
+      let duplicate: string | null;
+      try {
+        duplicate = firstDuplicateMember(raw);
+      } catch {
+        // StrictParseError. The scanner is lax on scalar tokens but strict on
+        // structure, so this is text it cannot vouch for as a single JSON
+        // value. Refusing here rather than letting JSON.parse decide keeps the
+        // accept-set of the file and the accept-set of the check identical.
+        throw new Error(
+          `Policy file is not a single well-formed JSON value that the duplicate-member ` +
+          `scanner can vouch for, so it was not applied. Check the file for truncation, ` +
+          `trailing content after the closing brace, or a malformed string escape.`,
+        );
+      }
+      if (duplicate !== null) {
+        throw new Error(
+          `Policy file has a duplicate member "${duplicate}". A member name that collides with ` +
+          `another member of the same object is refused rather than resolved: where the collision ` +
+          `is exact, JSON.parse keeps the LAST occurrence, so the half of the rule that RESTRICTS ` +
+          `is the half that disappears — while the rule count, getRules() and /health all report ` +
+          `it loaded. ` +
+          `The colliding member may be spelled differently in the file than it reads here: names ` +
+          `are compared after JSON escape decoding and case folding, so a case variant or an ` +
+          `escaped spelling collides too. Remove the duplicate and keep the one you meant.`,
+        );
+      }
+
       const parsed = JSON.parse(raw);
 
       // Accept both { rules: [...] } and bare array [...] formats

--- a/src/broker/policy.ts
+++ b/src/broker/policy.ts
@@ -69,9 +69,9 @@ export class PolicyEngine {
       const detail = err instanceof Error ? err.message : String(err);
       throw new Error(
         `Cannot load policies from ${this.policyFile}: the duplicate-member scanner ` +
-        `(@opena2a/atx-verify) could not be loaded, so the policy file was NOT applied and no ` +
+        `(@opena2a/atx-verify) could not be loaded, so the policy file was not applied and no ` +
         `credential will be served. This is an installation fault, not a fault in your policy ` +
-        `file — do not edit or delete the file to clear it.\n` +
+        `file. Do not edit or delete the file to clear it.\n` +
         `  Verify: node -e "import('@opena2a/atx-verify').then(() => console.log('ok'))"\n` +
         `  Fix:    npm install   # and check node -v is >= 20.19.0\n` +
         `  Cause:  ${detail}`,
@@ -107,10 +107,10 @@ export class PolicyEngine {
       if (duplicate !== null) {
         throw new Error(
           `Policy file has a duplicate member "${duplicate}". A member name that collides with ` +
-          `another member of the same object is refused rather than resolved: where the collision ` +
-          `is exact, JSON.parse keeps the LAST occurrence, so the half of the rule that RESTRICTS ` +
-          `is the half that disappears — while the rule count, getRules() and /health all report ` +
-          `it loaded. ` +
+          `another member of the same object is refused rather than resolved. Where the collision ` +
+          `is exact, JSON.parse keeps the last occurrence, so the restrictive half of the rule is ` +
+          `the half that disappears, while the rule count, getRules() and /health all report it ` +
+          `loaded. ` +
           `The colliding member may be spelled differently in the file than it reads here: names ` +
           `are compared after JSON escape decoding and case folding, so a case variant or an ` +
           `escaped spelling collides too. Remove the duplicate and keep the one you meant.`,

--- a/src/broker/server.ts
+++ b/src/broker/server.ts
@@ -102,7 +102,14 @@ export class BrokerServer {
     // next move is to delete the policy file — which is a fail-open again, by
     // hand. A daemon that cannot apply the policy it was given must say so and
     // stop, not pick a direction quietly.
-    this.policy.loadPolicies();
+    // Awaited, and deliberately unguarded: `loadPolicies()` became async in
+    // 0.23.0 so it could scan the raw file for duplicate members before
+    // JSON.parse collapses them. An un-awaited call would resolve to a Promise
+    // and leave the engine at zero rules, so the throw has to reach here.
+    // Everything below — including the bearer token write — is downstream, so a
+    // refused policy file leaves no socket and no token for a client to
+    // authenticate against.
+    await this.policy.loadPolicies();
 
     // Generate and persist bearer token for caller authentication
     const tokenFile = this.config.tokenFile ?? TOKEN_FILE;
@@ -407,8 +414,31 @@ export class BrokerServer {
       // fold-colliding case variant — refuses the request. Dynamic import:
       // @opena2a/atx-verify is ESM-only and this package is CJS (same pattern
       // as the cli-ui/telemetry consumers in src/cli.ts).
+      // The module resolution and the scan get SEPARATE arms. One `catch` used
+      // to cover both, and its comment named only `StrictParseError` — so if
+      // `@opena2a/atx-verify` ever failed to resolve, every grant request
+      // returned `400 Invalid JSON` and told each caller their body was
+      // malformed while the security module was silently absent. Nothing
+      // anywhere said the check had not run. That is an undiagnosable outage,
+      // and the rational operator response to one is to disable whatever looks
+      // broken. Our fault and the caller's fault are different answers.
+      let firstDuplicateMember: (text: string) => string | null;
       try {
-        const { firstDuplicateMember } = await import('@opena2a/atx-verify');
+        ({ firstDuplicateMember } = await import('@opena2a/atx-verify'));
+      } catch (err) {
+        this.audit.logEvent(
+          'error', 'broker', '', '', 'denied',
+          `Duplicate-member scanner (@opena2a/atx-verify) failed to load; every grant request is ` +
+          `refused until it resolves: ${err instanceof Error ? err.message : String(err)}`,
+          0,
+        );
+        this.sendJson(res, 503, {
+          error: 'Credential authorization is unavailable on this broker (see the broker audit log)',
+        });
+        return;
+      }
+
+      try {
         const dup = firstDuplicateMember(body);
         if (dup !== null) {
           this.sendJson(res, 400, {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -523,3 +523,132 @@ describe('a flag never widens scope (0.22.1 argv layer)', () => {
     expect(res.stderr).toContain(ABSENT);
   });
 });
+
+/**
+ * An unrecognised SUBCOMMAND is refused, not answered with the default view.
+ *
+ * `cache` and `backend` were the last two subcommand dispatchers in the tree
+ * that fell through to their status page on a token they did not recognise —
+ * eight siblings already refused it. `telemetry` was a third instance wearing a
+ * different coat: it printed "Unknown action" to STDOUT and returned 0, so the
+ * message existed and the exit code still said success.
+ *
+ * Measured on 0.22.1, every row exit 0: `cache zzz`, `cache clea`, `cache ttls`,
+ * `backend lst`, `backend sett`, `backend purg`. The last is the sharp one — a
+ * near miss of the DESTRUCTIVE `purge`, where nothing in the output or the exit
+ * code separated "purged" from "never ran".
+ */
+describe('an unknown subcommand is refused rather than answered', () => {
+  const CLI_PATH2 = path.resolve(__dirname, '..', 'dist', 'cli.js');
+  const hasBuild = fs.existsSync(CLI_PATH2);
+  const itIfBuilt = hasBuild ? it : it.skip;
+
+  function run(args: string[]) {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-subcmd-'));
+    try {
+      return spawnSync(process.execPath, [CLI_PATH2, ...args], {
+        encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], cwd: tmp,
+        env: { ...process.env, OPENA2A_TELEMETRY: 'off', NO_COLOR: '1' },
+      });
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  }
+
+  // CONTROLS FIRST. Absent is not the same as unrecognised: a bare verb is an
+  // exploration and still prints its status view at exit 0. If these went red,
+  // the guard below would be "refuses everything" rather than "refuses what it
+  // does not know", and every row under it would pass for the wrong reason.
+  itIfBuilt.each(['cache', 'backend', 'telemetry'])(
+    'CONTROL: bare `%s` still prints its status view at exit 0',
+    (verb) => {
+      const res = run([verb]);
+      expect(res.status, `${verb} bare must stay exit 0`).toBe(0);
+      expect(res.stderr).not.toMatch(/Unknown/);
+    },
+  );
+
+  itIfBuilt('`cache zzz` is refused instead of showing the cache status', () => {
+    const res = run(['cache', 'zzz']);
+    expect(res.status).toBe(1);
+    expect(res.stderr).toMatch(/Unknown cache command: zzz/);
+    expect(res.stdout).not.toMatch(/Secret Cache/);
+  });
+
+  itIfBuilt('`cache clea` names the command it nearly matched', () => {
+    const res = run(['cache', 'clea']);
+    expect(res.status).toBe(1);
+    expect(res.stderr).toMatch(/did you mean `clear`/);
+  });
+
+  itIfBuilt('`backend purg` — a near miss of a DESTRUCTIVE verb — is refused and named', () => {
+    const res = run(['backend', 'purg']);
+    expect(res.status).toBe(1);
+    expect(res.stderr).toMatch(/did you mean `purge`/);
+    expect(res.stdout).not.toMatch(/Secretless Backend/);
+  });
+
+  itIfBuilt('`telemetry bogus` refuses and says the setting was not changed', () => {
+    const res = run(['telemetry', 'bogus']);
+    expect(res.status).toBe(2);
+    expect(res.stderr).toMatch(/Unknown telemetry action: bogus/);
+    // The whole point: the exit code used to be 0 while nothing was applied.
+    expect(res.stderr).toMatch(/NOT changed/);
+  });
+
+  /**
+   * The class, not the instances. Named rather than derived, so a dispatcher
+   * added later with a silent fall-through has to show up here as a deliberate
+   * edit instead of slipping past a predicate.
+   *
+   * Every verb below is safe to invoke with an unrecognised token precisely
+   * BECAUSE it refuses first — that is the property under test. None is ever
+   * invoked bare, which for `install` would install a launch agent.
+   */
+  itIfBuilt.each([
+    'secret', 'broker', 'vault', 'scope', 'hook', 'rules', 'watch', 'install', 'cache', 'backend',
+  ])('%s refuses an unrecognised subcommand and does not act on it', (verb) => {
+    const res = run([verb, 'zzz-not-a-subcommand']);
+    expect(res.status, `${verb} answered an unknown subcommand with success`).not.toBe(0);
+    expect(`${res.stdout}${res.stderr}`).toMatch(/Unknown/);
+  });
+});
+
+/**
+ * `secret list` takes no argument. It used to accept one and ignore it —
+ * measured on 0.22.1, `secret list <token>` returned every stored name,
+ * byte-identical to the unfiltered run, at exit 0. A user who believes they
+ * filtered and sees every name reads that as "these all match".
+ */
+describe('secret list does not accept a filter it will not apply', () => {
+  const CLI_PATH3 = path.resolve(__dirname, '..', 'dist', 'cli.js');
+  const hasBuild = fs.existsSync(CLI_PATH3);
+  const itIfBuilt = hasBuild ? it : it.skip;
+
+  function run(args: string[]) {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-seclist-'));
+    try {
+      return spawnSync(process.execPath, [CLI_PATH3, ...args], {
+        encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], cwd: tmp,
+        env: { ...process.env, OPENA2A_TELEMETRY: 'off', NO_COLOR: '1' },
+      });
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  }
+
+  itIfBuilt('refuses a positional rather than silently listing everything', () => {
+    const res = run(['secret', 'list', 'ZZZ_NO_SUCH_PREFIX']);
+    expect(res.status).toBe(2);
+    expect(res.stderr).toMatch(/takes no arguments/);
+    expect(res.stderr).toMatch(/NOT filtered/);
+    // It must not have printed the store contents anyway.
+    expect(res.stdout).not.toMatch(/secret\(s\):/);
+  });
+
+  itIfBuilt('CONTROL: `secret list` with no argument still lists, exit 0', () => {
+    const res = run(['secret', 'list']);
+    expect(res.status).toBe(0);
+    expect(res.stderr).not.toMatch(/takes no arguments/);
+  });
+});

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -271,12 +271,34 @@ describe('scan warns on unknown flags / secret usage (regression: #80, #81)', ()
     });
   }
 
-  itIfBuilt('`scan --show-placeholder` (typo) warns instead of silently no-opping (#81)', () => {
+  itIfBuilt('`scan --show-placeholder` (typo) is refused, not answered (#81, #137)', () => {
+    // The tree is CLEAN and that is the point. Under the previous
+    // warn-and-continue this exited 0 with "No hardcoded credentials found." —
+    // the strongest clean claim the tool makes, over a scan whose scope the
+    // user asked to change and did not get. The earlier evidence that warning
+    // was safe read exit 1, but that 1 came from a tree that happened to hold a
+    // credential; it was never the flag.
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-scan-flag-'));
     try {
       const res = runCliSpawn(['scan', '.', '--show-placeholder'], tmp);
-      expect(res.stderr).toMatch(/ignoring unknown flag --show-placeholder/);
-      expect(res.status).toBe(0); // warning is non-fatal; clean dir still exits 0
+      expect(res.status).toBe(2);
+      expect(res.stderr).toMatch(/--show-placeholder/);
+      expect(res.stderr).toMatch(/did you mean --show-placeholders/);
+      // Nothing may read as a verdict on a run that did not happen.
+      expect(res.stdout).not.toMatch(/No hardcoded credentials found/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  itIfBuilt('CONTROL: the same clean tree with NO typo still answers, exit 0', () => {
+    // Without this, the test above passes just as well against a scan that
+    // refuses everything.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'secretless-scan-clean-'));
+    try {
+      const res = runCliSpawn(['scan', '.'], tmp);
+      expect(res.status).toBe(0);
+      expect(res.stdout).toMatch(/No hardcoded credentials found/);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,7 @@ import { runIgnore } from './commands/ignore';
 import { runDiff } from './commands/diff';
 import { printHelp, OWN_HELP } from './commands/help';
 import { prepareArgv, supportedFlags, VERBS, EXIT_USAGE, type PreparedArgv } from './argv';
+import { nearestMatch } from './near-miss';
 
 /**
  * The stderr block for a refused command.
@@ -55,6 +56,12 @@ function formatArgvErrors(verb: string, errors: string[]): string[] {
 }
 
 const TOOL = 'secretless-ai';
+/**
+ * Mirrors `TelemetryAction` in @opena2a/cli-ui, which is a type and therefore
+ * erased at compile — so it cannot validate anything at runtime. A test pins
+ * this list against the helper's own accepted set.
+ */
+const TELEMETRY_ACTIONS = ['on', 'off', 'status'];
 // Subcommands we don't track: pure-help / pure-config calls don't represent
 // the user actually using the tool, and tracking 'telemetry' itself creates
 // confusing self-referential events.
@@ -115,7 +122,23 @@ async function main(): Promise<number> {
 
   // telemetry subcommand
   if (command === 'telemetry') {
-    console.log(runTelemetryCommand(args[1] as TelemetryAction, {
+    // The action is validated HERE rather than left to the helper. Measured on
+    // 0.22.1: `telemetry bogus` printed "Unknown action 'bogus'" to STDOUT and
+    // returned 0, so a caller checking the exit code was told the opt-out had
+    // been applied when nothing was called. Third instance of the same shape as
+    // `cache` and `backend` — a token we do not recognise answered with
+    // success — and the only one whose message came from a dependency, which
+    // is why it is caught before the call rather than parsed out of the reply.
+    const action = args[1];
+    if (action !== undefined && !TELEMETRY_ACTIONS.includes(action)) {
+      const near = nearestMatch(action, TELEMETRY_ACTIONS);
+      console.error(`\n  Unknown telemetry action: ${action}${near ? ` (did you mean \`${near}\`?)` : ''}`);
+      console.error('  Telemetry was NOT changed.');
+      console.log(`  Usage: ${CLI_BARE} telemetry <${TELEMETRY_ACTIONS.join('|')}>`);
+      console.log(`  Run \`${CLI_BARE} telemetry\` with no action to see the current setting.\n`);
+      return EXIT_USAGE;
+    }
+    console.log(runTelemetryCommand(action as TelemetryAction, {
       tool: TOOL,
       getStatus: tele.status,
       setOptOut: tele.setOptOut,

--- a/src/commands/backend.silence.test.ts
+++ b/src/commands/backend.silence.test.ts
@@ -97,7 +97,7 @@ describe('read-only commands stay silent (no biometric / 1P prompts)', () => {
 
   it('runStatus does not invoke `security` or `op`', async () => {
     const { runStatus } = await import('./core');
-    const exitCode = runStatus(fakeHome);
+    const exitCode = await runStatus(fakeHome);
     expect(exitCode).toBe(0);
     expect(offending()).toEqual([]);
   });

--- a/src/commands/backend.ts
+++ b/src/commands/backend.ts
@@ -5,6 +5,42 @@ import { readBackendConfig, writeBackendConfig, resolveBackendType, readCacheTtl
 import { clearCacheFile } from '../backends/cache';
 import { migrateSecrets } from '../backends/migrate';
 import type { SelectableBackendType } from '../backends/config';
+import { nearestMatch } from '../near-miss';
+import { CLI_BARE } from './utils';
+
+/**
+ * The subcommands each dispatcher answers to, named once so the refusal below
+ * and the usage line cannot drift apart.
+ */
+const BACKEND_SUBCOMMANDS = ['list', 'set', 'purge'];
+const CACHE_SUBCOMMANDS = ['clear', 'ttl'];
+
+/**
+ * Refuse a subcommand token we do not recognise, instead of falling through to
+ * the status page.
+ *
+ * `cache` and `backend` were the only two subcommand dispatchers in this tree
+ * that answered an unrecognised token with a normal-looking report at exit 0 —
+ * eight siblings (`secret`, `broker`, `vault`, `scope`, `hook`, `install`,
+ * `rules`, `watch`) already refused it. Measured on 0.22.1: `cache clea`,
+ * `cache ttls`, `backend lst` and `backend sett` all printed the status page
+ * and exited 0. The sharp one is `backend purg`, a near-miss of the
+ * DESTRUCTIVE `purge`: exit 0 and a status page, with nothing in the output or
+ * the exit code separating "purged" from "never ran".
+ *
+ * ABSENT is not the same as UNRECOGNISED, and that distinction is the whole
+ * guard: a bare `cache` or `backend` is an exploration and still prints the
+ * status page at exit 0, exactly as it does today. Six of the eight siblings
+ * behave the same way, so this matches the tree rather than inventing a third
+ * convention.
+ */
+function refuseUnknownSubcommand(verb: string, token: string, known: string[]): number {
+  const near = nearestMatch(token, known);
+  console.error(`\n  Unknown ${verb} command: ${token}${near ? ` (did you mean \`${near}\`?)` : ''}`);
+  console.log(`  Usage: ${CLI_BARE} ${verb} <${known.join('|')}>`);
+  console.log(`  Run \`${CLI_BARE} ${verb}\` with no arguments to see current status.\n`);
+  return 1;
+}
 
 export async function runBackend(args: string[]): Promise<number> {
   const subcommand = args[0];
@@ -169,6 +205,10 @@ export async function runBackend(args: string[]): Promise<number> {
     console.log('  Run `npx secretless-ai protect-mcp` to re-protect MCP servers with the new backend.');
     console.log('  Or use `npx secretless-ai migrate` to migrate existing secrets.\n');
     return 0;
+  }
+
+  if (subcommand !== undefined) {
+    return refuseUnknownSubcommand('backend', subcommand, BACKEND_SUBCOMMANDS);
   }
 
   // Default: show current backend status.
@@ -359,6 +399,10 @@ export function runCache(args: string[]): number {
       console.log(`\n  Cache TTL set to ${formatTtl(seconds)}.\n`);
     }
     return 0;
+  }
+
+  if (subcommand !== undefined) {
+    return refuseUnknownSubcommand('cache', subcommand, CACHE_SUBCOMMANDS);
   }
 
   // Default: show cache status

--- a/src/commands/core.ts
+++ b/src/commands/core.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import { init } from '../init';
-import { scan } from '../scan';
+import { scan, emptySkips } from '../scan';
 import { status } from '../status';
 import { verify } from '../verify';
 import { toolDisplayName } from '../detect';
@@ -241,7 +241,7 @@ export async function runScan(projectDir: string, options?: { includeTests?: boo
     }
     const stats = {
       placeholdersSuppressed: 0, truncated: false, unreadable: [] as string[], outOfRoot: [] as string[],
-      oversize: [] as Array<{ path: string; bytes: number; capBytes: number }>,
+      oversize: [] as Array<{ path: string; bytes: number; capBytes: number }>, skips: emptySkips(),
     };
     const findings = scan(projectDir, scanOpts, stats);
     const critical = findings.filter(f => f.severity === 'critical').length;
@@ -262,10 +262,22 @@ export async function runScan(projectDir: string, options?: { includeTests?: boo
         // Files skipped for size were never opened, so they are coverage lost,
         // not content judged clean.
         oversize: stats.oversize.length,
+        // DECLARED BOUNDARIES, not broken claims — so, like outOfRoot, these do
+        // NOT set the exit code. A count that is non-zero on every repository
+        // is not a signal; gating on it would turn every clean scan into a
+        // failure. A consumer who wants to gate on a boundary gates on these
+        // explicitly.
+        skippedUnsupported: stats.skips.fileCount,
+        notEntered: stats.skips.dirCount,
       },
       unreadableFiles: stats.unreadable,
       outOfRootLinks: stats.outOfRoot,
       oversizeFiles: stats.oversize,
+      // Samples, capped. The counts above carry the magnitude; these carry the
+      // REASON, because `notEntered: 171` on a repo with dependencies installed
+      // is not something a human can act on without knowing which 171.
+      skippedUnsupportedFiles: stats.skips.files,
+      notEnteredDirs: stats.skips.dirs,
     }, null, 2));
     // An incomplete scan is not a pass. `total: 0` with `truncated: true`, an
     // unreadable file, or a file skipped for size means part of the tree was
@@ -286,7 +298,7 @@ export async function runScan(projectDir: string, options?: { includeTests?: boo
 
   const stats = {
     placeholdersSuppressed: 0, truncated: false, unreadable: [] as string[], outOfRoot: [] as string[],
-    oversize: [] as Array<{ path: string; bytes: number; capBytes: number }>,
+    oversize: [] as Array<{ path: string; bytes: number; capBytes: number }>, skips: emptySkips(),
   };
   const findings = scan(projectDir, scanOpts, stats);
 
@@ -359,6 +371,33 @@ export async function runScan(projectDir: string, options?: { includeTests?: boo
       console.log(`  ${c.dim('The cap bounds memory use; it says nothing about the contents.')}`);
       console.log(`  ${c.cyan('Verify:')} head -c 4096 ${runnable(stats.oversize[0].path)}`);
       console.log(`  ${c.cyan('Fix:')}    npx secretless-ai scan ${runnable('.')} --max-file-size ${Math.ceil(stats.oversize[0].bytes / (1024 * 1024)) + 1}mb\n`);
+    }
+
+    // Declared boundaries. Reported in the same place as the gaps above and
+    // deliberately NOT in the same class: these do not change the exit code and
+    // do not stop the scan reading as clean, because the scanner never claimed
+    // to open a `.png` or to walk `node_modules`.
+    //
+    // A directory is named rather than counted because the count alone is not
+    // actionable — the entry that matters on a real repo is a hidden directory
+    // like `.claude/`, and it is invisible inside a single total. Each line is
+    // followed by the command that scans it, so naming a gap is never a dead
+    // end.
+    if (stats.skips.dirCount > 0) {
+      const n = stats.skips.dirCount;
+      console.log(`  ${c.dim(`${n} director${n > 1 ? 'ies' : 'y'} not entered`)} — declared boundaries, not findings.`);
+      for (const d of stats.skips.dirs.slice(0, 8)) {
+        console.log(`  ${c.dim(`  ${runnable(d.path)} — ${d.reason}`)}`);
+      }
+      if (n > 8) console.log(`  ${c.dim(`  … and ${n - 8} more`)}`);
+      const first = stats.skips.dirs[0];
+      if (first) {
+        console.log(`  ${c.cyan('Scan one:')} npx secretless-ai scan ${runnable(first.path)}`);
+      }
+      if (stats.skips.fileCount > 0) {
+        console.log(`  ${c.dim(`${stats.skips.fileCount} file(s) were not opened (unsupported type, or a test file).`)}`);
+      }
+      console.log();
     }
   };
   // An out-of-root link is a reported boundary, not a gap in what we claimed to

--- a/src/commands/core.ts
+++ b/src/commands/core.ts
@@ -551,8 +551,8 @@ async function runScanWithExplanations(findings: ReturnType<typeof scan>): Promi
   return findings.length > 0 ? 1 : 0;
 }
 
-export function runStatus(projectDir: string, options?: { json?: boolean }): number {
-  const s = status(projectDir);
+export async function runStatus(projectDir: string, options?: { json?: boolean }): Promise<number> {
+  const s = await status(projectDir);
   const session = getSessionStatus();
   const brokerStatus = getDaemonStatus();
   const brokerInstalled = isDaemonInstalled();
@@ -583,8 +583,21 @@ export function runStatus(projectDir: string, options?: { json?: boolean }): num
       label: `${s.settingsUnreadable.path} does not parse — deny patterns and hook wiring cannot be read`,
       action: `node -e 'JSON.parse(require("fs").readFileSync("${s.settingsUnreadable.path}","utf8"))'`,
     });
+  } else if (s.settingsAmbiguous) {
+    // Ahead of the hookInstalled branch on purpose: the file's authorization
+    // content cannot be read as written, so no row about it renders green.
+    // Claude Code, not this tool, is what enforces these patterns — the loss is
+    // real and it happened there; our defect was reporting fine over it.
+    addRow({
+      glyph: '⚠',
+      label: `${s.settingsAmbiguous.path} ${s.settingsAmbiguous.reason} — the deny patterns cannot be read as configured`,
+      // NOT a grep and NOT `node -e JSON.parse`: both exit 0 on a duplicate and
+      // print nothing, and an escape-spelled or case-variant collision survives
+      // a grep and a diff review. Re-running status is what actually re-checks.
+      action: 'delete the repeated key, then re-run: secretless-ai status',
+    });
   } else if (s.hookInstalled) {
-    const denyText = s.denyRuleCount > 0 ? ` — ${s.denyRuleCount} deny pattern${s.denyRuleCount === 1 ? '' : 's'}` : '';
+    const denyText = (s.denyRuleCount ?? 0) > 0 ? ` — ${s.denyRuleCount} deny pattern${s.denyRuleCount === 1 ? '' : 's'}` : '';
     addRow({ glyph: '✓', label: `Claude Code hook installed (.claude/settings.json${denyText})` });
   } else {
     addRow({ glyph: '⚠', label: 'Claude Code hook not installed', action: 'secretless-ai init' });
@@ -681,10 +694,13 @@ export function runStatus(projectDir: string, options?: { json?: boolean }): num
       // it could not read the whole tree. A CI consumer gating on this needs to
       // tell "found nothing" from "could not look".
       scanIncomplete: s.scanIncomplete,
-      // Present only when `.claude/settings.json` exists and does not parse as
-      // a JSON object. `denyRuleCount: 0` alongside it means "could not read",
-      // not "none configured".
+      // Two distinct unknowns, and `denyRuleCount` is NULL for both — a number
+      // implies a measurement. `settingsUnreadable`: the file does not parse as
+      // a JSON object. `settingsAmbiguous`: it parses, but a repeated member
+      // means only the last copy is in effect, so what it configures cannot be
+      // read as written. `denyRuleCount: 0` now means measured, and none.
       settingsUnreadable: s.settingsUnreadable ?? null,
+      settingsAmbiguous: s.settingsAmbiguous ?? null,
       transcriptProtection: tp,
       backend: effectiveBackend,
       configuredBackend: configuredBackend ?? null,

--- a/src/commands/secrets.ts
+++ b/src/commands/secrets.ts
@@ -115,6 +115,25 @@ export async function runSecret(args: string[]): Promise<number> {
     }
 
     case 'list': {
+      // `secret list` takes no argument (help.ts, README). It used to ACCEPT
+      // one and ignore it: measured on 0.22.1, `secret list ZZZ_NO_SUCH_PREFIX`
+      // returned all 81 stored names, byte-identical to the unfiltered run, at
+      // exit 0, with nothing saying the token was dropped. A user who believes
+      // they filtered and sees every name reads that as "these all match".
+      //
+      // Refused rather than implemented as a filter: adding a filter is a
+      // feature with its own design questions (substring or prefix? case
+      // sensitivity? exit code on no match?), and inventing one here to excuse
+      // a swallowed token is how a parsing surface grows. Naming the token is
+      // the fix; the feature is a separate decision.
+      const extra = args[1];
+      if (extra !== undefined) {
+        console.error(`\n  \`secret list\` takes no arguments, but "${extra}" was given.`);
+        console.error('  It lists every stored name, and it was NOT filtered by that token.');
+        console.log(`\n  List all:  ${CLI_BARE} secret list`);
+        console.log(`  Filter:    ${CLI_BARE} secret list | grep ${JSON.stringify(extra)}\n`);
+        return 2;
+      }
       const store = new SecretStore();
       try {
         const names = await store.listSecrets();

--- a/src/commands/status-json.test.ts
+++ b/src/commands/status-json.test.ts
@@ -20,12 +20,12 @@ function tmpProject(files: Record<string, string> = {}): string {
 describe('runStatus --json', () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it('emits valid parseable JSON with protection facts and a summary verdict', () => {
+  it('emits valid parseable JSON with protection facts and a summary verdict', async () => {
     const dir = tmpProject();
     const lines: string[] = [];
     vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => { lines.push(a.map(String).join(' ')); });
 
-    const code = runStatus(dir, { json: true });
+    const code = await runStatus(dir, { json: true });
     const doc = JSON.parse(lines.join('\n')); // throws if not valid JSON
 
     expect(code).toBe(0);
@@ -45,12 +45,12 @@ describe('runStatus --json', () => {
     expect(['not-protected', 'protected-clean', 'protected-warnings']).toContain(doc.summary.verdict);
   });
 
-  it('reports not-protected for an empty project directory', () => {
+  it('reports not-protected for an empty project directory', async () => {
     const dir = tmpProject();
     const lines: string[] = [];
     vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => { lines.push(a.map(String).join(' ')); });
 
-    runStatus(dir, { json: true });
+    await runStatus(dir, { json: true });
     const doc = JSON.parse(lines.join('\n'));
 
     expect(doc.hookInstalled).toBe(false);
@@ -59,14 +59,14 @@ describe('runStatus --json', () => {
     expect(doc.summary.verdict).toBe('not-protected');
   });
 
-  it('reports protected when the guard hook is installed', () => {
+  it('reports protected when the guard hook is installed', async () => {
     const dir = tmpProject({
       '.claude/hooks/secretless-guard.sh': '#!/bin/bash\nexit 0\n',
     });
     const lines: string[] = [];
     vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => { lines.push(a.map(String).join(' ')); });
 
-    runStatus(dir, { json: true });
+    await runStatus(dir, { json: true });
     const doc = JSON.parse(lines.join('\n'));
 
     expect(doc.hookInstalled).toBe(true);
@@ -74,26 +74,111 @@ describe('runStatus --json', () => {
     expect(doc.summary.verdict).toMatch(/^protected-/);
   });
 
-  it('does NOT print the human "Secretless Status" banner in JSON mode', () => {
+  it('does NOT print the human "Secretless Status" banner in JSON mode', async () => {
     const dir = tmpProject();
     const lines: string[] = [];
     vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => { lines.push(a.map(String).join(' ')); });
 
-    runStatus(dir, { json: true });
+    await runStatus(dir, { json: true });
     expect(lines.join('\n')).not.toContain('Secretless Status');
   });
 
-  it('human mode is unchanged: banner, observations, verdict', () => {
+  it('human mode is unchanged: banner, observations, verdict', async () => {
     const dir = tmpProject();
     const lines: string[] = [];
     vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => { lines.push(a.map(String).join(' ')); });
 
-    const code = runStatus(dir);
+    const code = await runStatus(dir);
     const out = lines.join('\n');
 
     expect(code).toBe(0);
     expect(out).toContain('Secretless Status');
     expect(out).toContain('Observations');
     expect(out).toContain('Verdict');
+  });
+});
+
+/**
+ * A settings file that repeats a key does not say what it reads as.
+ *
+ * `JSON.parse` keeps the LAST copy of `permissions`, so a file carrying three
+ * deny patterns in its first copy and none in its second loses all three — in
+ * Claude Code, which is what enforces them. This tool's defect was reporting
+ * that as `denyRuleCount: 0` with `settingsUnreadable: null`, byte-identical to
+ * a project that configured none, and rendering a green check over it.
+ *
+ * Three states have to be distinguishable, and `denyRuleCount` is a number in
+ * exactly one of them: a number implies a measurement.
+ */
+describe('a settings file whose keys collide is reported as unknown, not as zero', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  const THREE_DENY = '{"permissions":{"deny":["Read(./alpha/**)","Read(./bravo/**)","Bash(charlie --list)"]}}';
+  const REPEATED = '{"permissions":{"deny":["Read(./alpha/**)","Read(./bravo/**)","Bash(charlie --list)"]},"permissions":{"deny":[]}}';
+
+  async function statusOf(settings: string, extra: Record<string, string> = {}) {
+    const dir = tmpProject({ '.claude/settings.json': settings, ...extra });
+    const lines: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => { lines.push(a.map(String).join(' ')); });
+    await runStatus(dir, { json: true });
+    return JSON.parse(lines.join('\n'));
+  }
+
+  it('CONTROL: the same three deny patterns, written once, are counted', async () => {
+    const doc = await statusOf(THREE_DENY);
+    expect(doc.denyRuleCount).toBe(3);
+    expect(doc.settingsAmbiguous).toBeNull();
+    expect(doc.settingsUnreadable).toBeNull();
+  });
+
+  it('the repeated key is reported, and the count is null rather than 0', async () => {
+    const doc = await statusOf(REPEATED);
+    // The defect: this used to be 0, indistinguishable from "none configured".
+    expect(doc.denyRuleCount).toBeNull();
+    expect(doc.settingsAmbiguous).not.toBeNull();
+    expect(doc.settingsAmbiguous.path).toBe('.claude/settings.json');
+    // The key has to be named or the user has a warning and no way to act.
+    expect(doc.settingsAmbiguous.reason).toContain('permissions');
+    // It parsed fine, so it is NOT the unreadable state.
+    expect(doc.settingsUnreadable).toBeNull();
+  });
+
+  it('a file that does not parse stays a DIFFERENT state, also with a null count', async () => {
+    const doc = await statusOf('{"permissions": }');
+    expect(doc.denyRuleCount).toBeNull();
+    expect(doc.settingsUnreadable).not.toBeNull();
+    expect(doc.settingsAmbiguous).toBeNull();
+  });
+
+  it('the three states are mutually distinguishable from the JSON alone', async () => {
+    const measured = await statusOf(THREE_DENY);
+    const ambiguous = await statusOf(REPEATED);
+    const unreadable = await statusOf('{"permissions": }');
+    const shape = (d: Record<string, unknown>) =>
+      `${d.denyRuleCount === null ? 'null' : 'n'}/${d.settingsAmbiguous ? 'amb' : '-'}/${d.settingsUnreadable ? 'unr' : '-'}`;
+    const shapes = [shape(measured), shape(ambiguous), shape(unreadable)];
+    expect(new Set(shapes).size, `states collapsed: ${shapes.join(' ')}`).toBe(3);
+  });
+
+  it('does not render a green check over a file it could not read as configured', async () => {
+    // The hook being installed is what produced the check. With the guard
+    // script present AND the settings ambiguous, nothing about that file may
+    // render green.
+    const dir = tmpProject({
+      '.claude/settings.json': REPEATED,
+      '.claude/hooks/secretless-guard.sh': '#!/bin/sh\n# secretless-ai guard\n',
+    });
+    const lines: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => { lines.push(a.map(String).join(' ')); });
+    await runStatus(dir);
+    const out = lines.join('\n');
+
+    expect(out).not.toMatch(/✓ Claude Code hook installed/);
+    expect(out).toMatch(/repeats/);
+    // No dead end: neither grep nor `node -e JSON.parse` can see a duplicate,
+    // and this release's own notes say an escaped or case-variant collision
+    // survives both. The action has to be something that actually re-checks.
+    expect(out).toMatch(/secretless-ai status/);
+    expect(out).not.toMatch(/JSON\.parse\(require/);
   });
 });

--- a/src/coverage-disclosure.test.ts
+++ b/src/coverage-disclosure.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { runScan } from './commands/core';
+
+/**
+ * What the scan did NOT look at, disclosed beside what it did.
+ *
+ * The defect this closes is not "a gap exists" — gaps are fine and declared.
+ * It is that the summary ASSERTED full coverage while a gap existed, and on the
+ * sharpest case it did so beside evidence pointing the other way:
+ *
+ *   findings: [".claude/settings.json", "src/app.ts"]
+ *   summary : { truncated:false, unreadable:0, outOfRoot:0, oversize:0 }
+ *
+ * `.claude/agent.ts` — byte-identical to `src/app.ts` — was absent, because the
+ * SOURCE walk blanket-prunes dot-directories while the config and key walks
+ * deliberately do not (`scan.ts`, and the comment on the key walker says so
+ * outright). A user reading a finding from inside `.claude/` alongside four
+ * zeros concludes the directory was read. The disclosure has to sit where the
+ * loss happens, or it endorses the wrong conclusion instead of qualifying it.
+ *
+ * These counters are NON-GATING by ruling: a declared boundary is not a broken
+ * claim, and a count that is non-zero on every repository on earth cannot be an
+ * exit condition.
+ */
+
+function tree(files: Record<string, string>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'coverage-'));
+  for (const [rel, content] of Object.entries(files)) {
+    const full = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+  return dir;
+}
+
+const TOKEN = ['ghp_', 'A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8'].join('');
+
+describe('the summary discloses what was not looked at', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  async function scanned(dir: string) {
+    const lines: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => { lines.push(a.map(String).join(' ')); });
+    const code = await runScan(dir, { json: true });
+    return { doc: JSON.parse(lines.join('\n')), code };
+  }
+
+  it('names a pruned hidden directory instead of implying it was read', async () => {
+    const dir = tree({
+      'src/app.ts': `const t = "${TOKEN}";\n`,
+      '.claude/agent.ts': `const t = "${TOKEN}";\n`,
+      '.claude/settings.json': `{"env":{"GITHUB_TOKEN":"${TOKEN}"}}\n`,
+    });
+    const { doc } = await scanned(dir);
+
+    // The pre-fix shape: a finding from inside `.claude/` and four zeros.
+    const files = doc.findings.map((f: { file: string }) => f.file);
+    expect(files).toContain('.claude/settings.json');
+    expect(files).not.toContain('.claude/agent.ts');
+
+    // The disclosure that stops that reading as full coverage.
+    expect(doc.summary.notEntered).toBeGreaterThan(0);
+    const dirs = doc.notEnteredDirs.map((d: { path: string }) => d.path);
+    expect(dirs).toContain('.claude');
+    const claude = doc.notEnteredDirs.find((d: { path: string }) => d.path === '.claude');
+    expect(claude.reason).toMatch(/hidden/);
+  });
+
+  it('CONTROL: the missed file IS detectable — the gap is coverage, not the pattern', async () => {
+    const dir = tree({ '.claude/agent.ts': `const t = "${TOKEN}";\n` });
+    const { doc } = await scanned(path.join(dir, '.claude'));
+    expect(doc.findings.length).toBeGreaterThan(0);
+  });
+
+  it('CONTROL: a tree with nothing to skip reports zero, so the counter is not a constant', async () => {
+    const dir = tree({ 'src/app.ts': 'export const x = 1;\n' });
+    const { doc, code } = await scanned(dir);
+    expect(doc.summary.notEntered).toBe(0);
+    expect(doc.summary.skippedUnsupported).toBe(0);
+    expect(code).toBe(0);
+  });
+
+  it('counts a file it enumerated but did not open, with the reason', async () => {
+    const dir = tree({
+      'src/app.ts': 'export const x = 1;\n',
+      'notes.md': `a token in prose: ${TOKEN}\n`,
+      'logo.png': 'not really a png\n',
+    });
+    const { doc } = await scanned(dir);
+    expect(doc.summary.skippedUnsupported).toBeGreaterThanOrEqual(2);
+    const reasons = doc.skippedUnsupportedFiles.map((f: { reason: string }) => f.reason);
+    expect(reasons.some((r: string) => /unsupported/.test(r))).toBe(true);
+  });
+
+  /**
+   * The ruling that governs this field: a declared boundary is not a failure of
+   * a claim the scanner made. Every repository contains a `.md` or a lockfile,
+   * so a gating counter would be non-zero everywhere — not a signal, a constant,
+   * and the largest breaking change in the release that is about honesty.
+   */
+  it('is NON-GATING: a clean tree with skips still exits 0', async () => {
+    const dir = tree({
+      'src/app.ts': 'export const x = 1;\n',
+      'README.md': 'no credentials here\n',
+      '.github/workflows/ci.yml': 'name: ci\n',
+      'node_modules/pkg/index.js': 'module.exports = 1;\n',
+    });
+    const { doc, code } = await scanned(dir);
+    expect(doc.summary.total).toBe(0);
+    expect(doc.summary.notEntered).toBeGreaterThan(0);
+    expect(doc.summary.skippedUnsupported).toBeGreaterThan(0);
+    expect(code, 'a declared boundary must not gate CI').toBe(0);
+  });
+
+  it('CONTROL: the gaps that ARE broken claims still gate', async () => {
+    // `unreadable` is the other class — we said we would read it and did not.
+    // Without this the test above would pass against a build where nothing
+    // gates at all.
+    const dir = tree({ 'src/app.ts': `const t = "${TOKEN}";\n` });
+    const { code } = await scanned(dir);
+    expect(code).toBe(1);
+  });
+
+  it('reports `.git` as git metadata, not as build output', async () => {
+    // It sits in the build-output set, so without an explicit arm the
+    // disclosure named it wrongly. The set that skips is unchanged; a reason a
+    // user cannot trust is worse than a count.
+    const dir = tree({ 'src/app.ts': 'export const x = 1;\n', '.git/config': '[core]\n' });
+    const { doc } = await scanned(dir);
+    const git = doc.notEnteredDirs.find((d: { path: string }) => d.path === '.git');
+    expect(git).toBeDefined();
+    expect(git.reason).toMatch(/git metadata/);
+  });
+
+  it('counts a pruned directory ONCE, not once per walker', async () => {
+    // Three walks share the traversal and all three prune `node_modules`. Only
+    // the source walk discloses; if another opts in, this doubles.
+    const dir = tree({
+      'src/app.ts': 'export const x = 1;\n',
+      'node_modules/pkg/index.js': 'module.exports = 1;\n',
+    });
+    const { doc } = await scanned(dir);
+    const hits = doc.notEnteredDirs.filter((d: { path: string }) => d.path === 'node_modules');
+    expect(hits).toHaveLength(1);
+    expect(doc.summary.notEntered).toBe(1);
+  });
+});

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -903,11 +903,11 @@ describe('init', () => {
       expect(result.settingsUnusable?.reason).toMatch(/JSON|position|token/i);
     });
 
-    it('status reports unreadable settings as unknown, not as zero rules', () => {
+    it('status reports unreadable settings as unknown, not as zero rules', async () => {
       seed(JSONC);
       init(dir);
 
-      const s = status(dir);
+      const s = await status(dir);
 
       // "0 deny patterns" and "could not read the deny patterns" are different
       // answers. Reporting the first for the second made an unprotected
@@ -1063,26 +1063,26 @@ describe('status', () => {
   beforeEach(() => { dir = tmpDir(); });
   afterEach(() => { cleanup(dir); });
 
-  it('reports unprotected project', () => {
-    const s = status(dir);
+  it('reports unprotected project', async () => {
+    const s = await status(dir);
     expect(s.isProtected).toBe(false);
     expect(s.configuredTools).toHaveLength(0);
     expect(s.hookInstalled).toBe(false);
   });
 
-  it('reports protected project after init', () => {
+  it('reports protected project after init', async () => {
     init(dir);
 
-    const s = status(dir);
+    const s = await status(dir);
     expect(s.isProtected).toBe(true);
     expect(s.hookInstalled).toBe(true);
     expect(s.denyRuleCount).toBeGreaterThan(0);
   });
 
-  it('counts secrets found', () => {
+  it('counts secrets found', async () => {
     fs.writeFileSync(path.join(dir, '.env'), 'KEY=sk-ant-api03-abc123def456abc123def456abc123');
 
-    const s = status(dir);
+    const s = await status(dir);
     expect(s.secretsFound).toBe(1);
   });
 });
@@ -1095,13 +1095,13 @@ describe('status next steps stay runnable when settings.json does not parse', ()
   beforeEach(() => { dir = tmpDir(); });
   afterEach(() => { cleanup(dir); });
 
-  it('does not claim protection from a guard script nothing wires in', () => {
+  it('does not claim protection from a guard script nothing wires in', async () => {
     fs.mkdirSync(path.join(dir, '.claude', 'hooks'), { recursive: true });
     fs.writeFileSync(path.join(dir, '.claude', 'settings.json'), '{\n // c\n "model": "opus"\n}\n');
     // The script exists on disk but settings.json never references it.
     fs.writeFileSync(path.join(dir, '.claude', 'hooks', 'secretless-guard.sh'), '#!/bin/sh\n', { mode: 0o755 });
 
-    const s = status(dir);
+    const s = await status(dir);
 
     expect(s.hookInstalled).toBe(true);      // the file is really there
     expect(s.isProtected).toBe(false);       // but it is not wired in

--- a/src/json-flag.test.ts
+++ b/src/json-flag.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { prepareArgv, prepareBinArgv, supportedFlags, jsonVerbs, VERBS, MCP_WRAPPER, EXIT_USAGE } from './argv';
+
+/**
+ * `--json` is honored or refused — never accepted and ignored (#126).
+ *
+ * The 2026-08-12 `[CHIEF-CPO]` ruling: a flag the tool accepts is a flag the
+ * tool honors. Measured on 0.22.1 across all 32 verbs — 2 honored it, and of
+ * the other 30, 15 truly ignored it, 11 mistook it for a SUBCOMMAND and 4
+ * mistook it for a POSITIONAL. The last group is why this is a correctness fix
+ * rather than a tidy-up: `verify --json` resolved `--json` as the project
+ * directory and printed `AI context: clean (no credentials found)` about a
+ * directory whose `CLAUDE.md` held a live key.
+ */
+
+describe('--json is refused by every verb that does not implement it', () => {
+  const honoring = jsonVerbs();
+
+  it('CONTROL: the registry names exactly the verbs cli.ts reads --json for', () => {
+    // The oracle is the SOURCE, not the table being checked, so the two cannot
+    // agree by construction. A verb that starts implementing --json without
+    // declaring it, or declares it without implementing it, fails here.
+    const cli = fs.readFileSync(path.join(__dirname, 'cli.ts'), 'utf-8');
+
+    // Segment the dispatch switch at each `case`, so a read site is attributed
+    // to the verb whose block CONTAINS it. A window-based regex reads across
+    // the boundary and blamed `init` for `scan`'s read of the flag.
+    const marks = [...cli.matchAll(/^\s+case '([a-z-]+)':/gm)];
+    expect(marks.length, 'the case-boundary predicate found no verbs').toBeGreaterThan(25);
+
+    const readSites: string[] = [];
+    for (let i = 0; i < marks.length; i++) {
+      const start = marks[i].index! + marks[i][0].length;
+      const end = i + 1 < marks.length ? marks[i + 1].index! : cli.length;
+      if (cli.slice(start, end).includes("args.includes('--json')")) readSites.push(marks[i][1]);
+    }
+
+    expect(readSites.length, 'the --json read-site predicate found nothing').toBeGreaterThan(0);
+    expect([...new Set(readSites)].sort()).toEqual(honoring);
+  });
+
+  it('CONTROL: a verb that honors --json binds it with no error', () => {
+    for (const verb of honoring) {
+      const p = prepareArgv(verb, [verb, '--json']);
+      expect(p.errors, `${verb} must accept --json`).toEqual([]);
+      expect(p.warnings).toEqual([]);
+      expect(p.args).toContain('--json');
+    }
+  });
+
+  it('CONTROL: --json binds in the LEADING position too, not only trailing', () => {
+    // `docs/testing/release-smoke.md` runs the leading form and README the
+    // trailing one, so a fix tested in one order only would break the other.
+    for (const verb of honoring) {
+      const lead = prepareArgv(verb, [verb, '--json', '/some/dir']);
+      const trail = prepareArgv(verb, [verb, '/some/dir', '--json']);
+      expect(lead.errors, `${verb} --json <dir>`).toEqual([]);
+      expect(trail.errors, `${verb} <dir> --json`).toEqual([]);
+      // The path is the positional in both orders; --json never becomes one.
+      expect(lead.positionals).toEqual(['/some/dir']);
+      expect(trail.positionals).toEqual(['/some/dir']);
+    }
+  });
+
+  const nonHonoring = Object.keys(VERBS).filter((v) => VERBS[v].honorsJson !== true);
+
+  it('there are non-honoring verbs to test, and they are the majority', () => {
+    // Guards against a future registry change making the sweep below vacuous.
+    expect(nonHonoring.length).toBeGreaterThan(20);
+    expect(honoring.length).toBeGreaterThan(0);
+  });
+
+  it.each(nonHonoring)('%s refuses --json rather than ignoring it', (verb) => {
+    const p = prepareArgv(verb, [verb, '--json']);
+    expect(p.errors.length, `${verb} accepted --json`).toBe(1);
+    expect(p.errors[0]).toMatch(/--json is not implemented/);
+    // The refusal has to say where JSON DOES live, or it is a dead end.
+    for (const h of honoring) expect(p.errors[0]).toContain(h);
+    // An error, never a warning: a warning would leave exit 0 in place.
+    expect(p.warnings).toEqual([]);
+  });
+
+  /**
+   * The trap this test exists for: routing `--json` through the ordinary
+   * unknown-flag path would refuse it on the twelve verbs that REJECT and
+   * merely warn on the read-only ones — leaving exit 0 plus human text, which
+   * is the false-clean shape the ruling names. These six are the warn verbs.
+   */
+  it.each(Object.keys(VERBS).filter((v) => VERBS[v].unknownFlags === 'warn' && VERBS[v].honorsJson !== true))(
+    '%s refuses --json even though it WARNS about other unknown flags',
+    (verb) => {
+      const json = prepareArgv(verb, [verb, '--json']);
+      expect(json.errors.length, `${verb} warned about --json instead of refusing`).toBe(1);
+      expect(json.warnings).toEqual([]);
+
+      // CONTROL, same verb, same run: an ordinary unknown flag still warns and
+      // still runs, because #81's warn-and-continue is deliberate and survives.
+      const other = prepareArgv(verb, [verb, '--nosuchflag']);
+      expect(other.errors, `${verb} must still warn on a non-json unknown flag`).toEqual([]);
+      expect(other.warnings.length).toBe(1);
+    },
+  );
+
+  it('the refusal exit code is the usage code, not the scanner findings code', () => {
+    expect(EXIT_USAGE).toBe(2);
+  });
+});
+
+describe('--json is not advertised where it is not implemented', () => {
+  it('only the honoring verbs list it as supported', () => {
+    for (const [verb, spec] of Object.entries(VERBS)) {
+      const listed = supportedFlags(spec).some((f) => f.startsWith('--json'));
+      expect(listed, `${verb} advertises --json`).toBe(spec.honorsJson === true);
+    }
+  });
+
+  /**
+   * `supportedFlags` hid `--json` from the "Supported:" line while
+   * `nearestMatch` still suggested it two lines earlier, because the suggestion
+   * ranked against the global set. Measured on 0.22.1:
+   *
+   *   verify --jsonn
+   *     Unknown option: --jsonn (did you mean --json?)
+   *     Supported: --all, --help
+   *
+   * One message pointed at a flag the next line withheld — and following the
+   * suggestion produced the silent mistarget. Since `--json` is no longer in a
+   * non-honoring verb's known set, it can no longer be suggested by one.
+   */
+  it('a near miss of --json is never suggested by a verb that does not implement it', () => {
+    for (const verb of Object.keys(VERBS)) {
+      if (VERBS[verb].honorsJson === true) continue;
+      const p = prepareArgv(verb, [verb, '--jsonn']);
+      const text = [...p.errors, ...p.warnings].join(' ');
+      expect(text, `${verb} suggested --json`).not.toMatch(/did you mean.*--json/);
+    }
+  });
+
+  it('CONTROL: a verb that DOES implement it still suggests it on a near miss', () => {
+    const p = prepareArgv('scan', ['scan', '--jsonn']);
+    const text = [...p.errors, ...p.warnings].join(' ');
+    expect(text).toMatch(/did you mean --json/);
+  });
+});
+
+describe('the second bin keeps its own contract', () => {
+  /**
+   * `secretless-mcp`'s argv lines are written into MCP client configs by
+   * `protect-mcp` and hand-edited afterwards, so refusing an unrecognised token
+   * there breaks a user's MCP server at startup. Its `warn` policy is a
+   * deliberate decision with a different blast radius, and the `--json`
+   * refusal — a statement about THIS CLI's verb contract — does not reach it.
+   */
+  it('secretless-mcp warns about --json rather than refusing to start', () => {
+    const p = prepareBinArgv(MCP_WRAPPER, ['--server', 'github', '--json', '--', 'npx', 'srv']);
+    expect(p.errors).toEqual([]);
+    expect(p.warnings.length).toBe(1);
+    expect(p.warnings[0]).toMatch(/--json/);
+  });
+
+  it('CONTROL: it still binds the flags it does implement', () => {
+    const p = prepareBinArgv(MCP_WRAPPER, ['--vault-dir=/tmp/v', '--', 'x']);
+    expect(p.errors).toEqual([]);
+    expect(p.args).toEqual(['--vault-dir', '/tmp/v', '--', 'x']);
+  });
+});

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -176,6 +176,16 @@ export interface ScanStats {
    * never opened rendered as a clean scan (#120).
    */
   oversize?: Array<{ path: string; bytes: number; capBytes: number }>;
+  /**
+   * What the SOURCE walk chose not to look at, with the reason.
+   *
+   * DISCLOSURE, NOT A FAILURE. These are boundaries the scanner declared, not
+   * claims it broke, so they do not set the exit code — the same class as
+   * `outOfRoot`. Populated only by the source walk; the config and key walks
+   * prune the same heavy directories and counting all three would treble the
+   * number and bury the entry that matters.
+   */
+  skips?: CoverageSkips;
 }
 
 /** Per-file size caps. A file above the cap is skipped and reported, never dropped silently. */
@@ -549,6 +559,15 @@ export function scan(projectDir: string, options?: ScanOptions, stats?: ScanStat
       const k = dedupeKey(p);
       if (stats.outOfRoot && !seenOutOfRoot.has(k)) { seenOutOfRoot.add(k); stats.outOfRoot.push(p); }
     }
+    // Only the disclosing walk contributes; the others return an empty set, so
+    // this is an accumulate rather than a filter and cannot silently pick up a
+    // second walk if one ever opts in.
+    if (stats.skips) {
+      stats.skips.dirCount += walk.skips.dirCount;
+      stats.skips.fileCount += walk.skips.fileCount;
+      for (const d of walk.skips.dirs) if (stats.skips.dirs.length < SKIP_SAMPLE_CAP) stats.skips.dirs.push(d);
+      for (const f of walk.skips.files) if (stats.skips.files.length < SKIP_SAMPLE_CAP) stats.skips.files.push(f);
+    }
   };
 
   const configWalk = walkConfigFiles(projectDir, options?.maxSourceFiles ?? 5000, includeTestsOpt, ignore);
@@ -810,6 +829,45 @@ interface WalkResult {
    * same fail-open in a new place.
    */
   outOfRoot: string[];
+  /**
+   * What this walk chose not to look at, with the reason it chose that.
+   *
+   * DISCLOSURE ONLY — see `CoverageSkips`. Populated on the walk that opts in
+   * via `discloseSkips`, which is the SOURCE walk alone: the config and key
+   * walks prune the same heavy directories, so counting all three would report
+   * `node_modules` three times and produce a number nobody can act on.
+   */
+  skips: CoverageSkips;
+}
+
+/**
+ * Directories not entered and files not opened, each with the reason.
+ *
+ * These are DECLARED BOUNDARIES, not failures of a claim the scanner made, so
+ * they do not set the exit code — the same class as `outOfRoot` and the same
+ * treatment. `truncated`, `unreadable` and `oversize` are the other class: we
+ * said we would read something and did not.
+ *
+ * The reason travels with the path because the count alone is not actionable.
+ * On this repository the raw count is dominated by dependency and build output,
+ * which every user already expects to be skipped; the entry that matters is a
+ * hidden directory, and it is invisible inside a single total.
+ */
+export interface CoverageSkips {
+  /** Directories not descended into: `{ path, reason }`, capped. */
+  dirs: Array<{ path: string; reason: string }>;
+  /** Files enumerated but not opened: `{ path, reason }`, capped. */
+  files: Array<{ path: string; reason: string }>;
+  /** True counts, which keep rising after the samples above stop growing. */
+  dirCount: number;
+  fileCount: number;
+}
+
+/** Samples are for a human; the counts carry the magnitude. */
+const SKIP_SAMPLE_CAP = 20;
+
+export function emptySkips(): CoverageSkips {
+  return { dirs: [], files: [], dirCount: 0, fileCount: 0 };
 }
 
 /**
@@ -993,12 +1051,25 @@ function realpathOrNull(p: string): string | null {
 
 /** Per-walk behaviour: which directories to descend, which files to keep. */
 interface WalkSpec {
-  /** True to NOT descend into this directory. */
-  skipDir(name: string, relFromRoot: string): boolean;
-  /** True to keep this file. */
-  acceptFile(name: string, relFromRoot: string): boolean;
+  /**
+   * A REASON string to skip this directory, or false to descend.
+   *
+   * It returns the reason rather than a boolean so the disclosure and the
+   * decision come from the same expression. A separate `skipReason` predicate
+   * beside a boolean `skipDir` would be two statements of one rule, free to
+   * drift — and a disclosure that disagrees with the walk is worse than none.
+   */
+  skipDir(name: string, relFromRoot: string): string | false;
+  /** A REASON string to reject this file, or false to keep it. Same rule. */
+  rejectFile(name: string, relFromRoot: string): string | false;
   /** What to push into `files` — an absolute path or a root-relative one. */
   collect(entryPath: string, relFromRoot: string): string;
+  /**
+   * Record what was skipped. Only the SOURCE walk sets this: all three walks
+   * prune `node_modules` and friends, so disclosing every walk would treble the
+   * count and bury the one entry a user needs to see.
+   */
+  discloseSkips?: boolean;
 }
 
 /**
@@ -1022,6 +1093,7 @@ interface WalkSpec {
 function walkTree(dir: string, maxFiles: number, spec: WalkSpec): WalkResult {
   const files: string[] = [];
   const unreadable: string[] = [];
+  const skips = emptySkips();
   const outOfRoot: string[] = [];
   let truncated = false;
 
@@ -1073,7 +1145,14 @@ function walkTree(dir: string, maxFiles: number, spec: WalkSpec): WalkResult {
         // coverage warning. Reporting `node_modules -> /pnpm-store` as an
         // unfollowed boundary — and telling the user to go scan it — is noise
         // about a directory that was never going to be walked.
-        if (spec.skipDir(entry.name, relFromRoot)) continue;
+        const skipReason = spec.skipDir(entry.name, relFromRoot);
+        if (skipReason) {
+          if (spec.discloseSkips) {
+            skips.dirCount++;
+            if (skips.dirs.length < SKIP_SAMPLE_CAP) skips.dirs.push({ path: relFromRoot, reason: skipReason });
+          }
+          continue;
+        }
 
         // Containment applies to DIRECTORY links only. Following one is
         // unbounded: a repo holding `link -> $HOME` would pull the whole home
@@ -1088,7 +1167,14 @@ function walkTree(dir: string, maxFiles: number, spec: WalkSpec): WalkResult {
         if (files.length >= maxFiles) { truncated = true; break; }
         queue.push({ dir: entryPath, ancestors: childAncestors });
       } else {
-        if (!spec.acceptFile(entry.name, relFromRoot)) continue;
+        const rejectReason = spec.rejectFile(entry.name, relFromRoot);
+        if (rejectReason) {
+          if (spec.discloseSkips) {
+            skips.fileCount++;
+            if (skips.files.length < SKIP_SAMPLE_CAP) skips.files.push({ path: relFromRoot, reason: rejectReason });
+          }
+          continue;
+        }
         // A symlinked FILE is NOT contained, even out of the root. Reading one
         // file the repository explicitly names is bounded work, and it is the
         // shape every dotfile manager produces: `pkg/.env -> ../../shared/.env`
@@ -1101,7 +1187,7 @@ function walkTree(dir: string, maxFiles: number, spec: WalkSpec): WalkResult {
     }
   }
 
-  return { files, truncated, unreadable, outOfRoot };
+  return { files, truncated, unreadable, outOfRoot, skips };
 }
 
 /**
@@ -1120,13 +1206,14 @@ function walkKeyFiles(
     // `.certs/`, `.aws/`), so we do NOT blanket-skip dot-dirs here. We still skip the
     // heavy/irrelevant ones (node_modules, .git) and honor the ignore matcher.
     skipDir: (name, rel) =>
-      SOURCE_SKIP_DIRS.has(name) || name === '.git'
-      || (!includeTests && TEST_DIRS.has(name))
-      || !!(ignore && ignore.matches(rel + '/.')),
-    acceptFile: (name, rel) =>
-      KEY_FILE_EXTENSIONS.has(path.extname(name).toLowerCase())
-      && (includeTests || !isTestFile(name))
-      && !(ignore && ignore.matches(rel)),
+      (SOURCE_SKIP_DIRS.has(name) && 'dependency or build output')
+      || (name === '.git' && 'git metadata')
+      || (!includeTests && TEST_DIRS.has(name) && 'test directory')
+      || (!!(ignore && ignore.matches(rel + '/.')) && 'ignore rule'),
+    rejectFile: (name, rel) =>
+      (!KEY_FILE_EXTENSIONS.has(path.extname(name).toLowerCase()) && 'not a key file')
+      || (!(includeTests || !isTestFile(name)) && 'test file')
+      || (!!(ignore && ignore.matches(rel)) && 'ignore rule'),
     collect: (entryPath) => entryPath,
   });
 }
@@ -1140,12 +1227,13 @@ function walkConfigFiles(
   const matcher = buildConfigNameMatcher();
   return walkTree(dir, maxFiles, {
     skipDir: (name, rel) =>
-      SOURCE_SKIP_DIRS.has(name) || name === '.git'
-      || (!includeTests && TEST_DIRS.has(name))
-      || !!(ignore && ignore.matches(rel + '/.')),
-    acceptFile: (name, rel) =>
-      matchesConfigName(name, rel, matcher)
-      && !(ignore && ignore.matches(rel)),
+      (SOURCE_SKIP_DIRS.has(name) && 'dependency or build output')
+      || (name === '.git' && 'git metadata')
+      || (!includeTests && TEST_DIRS.has(name) && 'test directory')
+      || (!!(ignore && ignore.matches(rel + '/.')) && 'ignore rule'),
+    rejectFile: (name, rel) =>
+      (!matchesConfigName(name, rel, matcher) && 'not a recognised config file')
+      || (!!(ignore && ignore.matches(rel)) && 'ignore rule'),
     collect: (_entryPath, rel) => rel,
   });
 }
@@ -1159,14 +1247,21 @@ function walkSourceFiles(
   return walkTree(dir, maxFiles, {
     // Prune whole-tree ignored directories. The matcher's directory patterns
     // end with `/`, so we test the dir path with a trailing segment.
+    // `.git` is tested BEFORE the build-output set purely so the disclosure
+    // names it accurately: it is in SOURCE_SKIP_DIRS, so without this arm it
+    // reported as "dependency or build output", which it is not. The set that
+    // skips is unchanged; only the reason differs.
     skipDir: (name, rel) =>
-      SOURCE_SKIP_DIRS.has(name) || name.startsWith('.')
-      || (!includeTests && TEST_DIRS.has(name))
-      || !!(ignore && ignore.matches(rel + '/.')),
-    acceptFile: (name, rel) =>
-      SOURCE_FILE_EXTENSIONS.has(path.extname(name))
-      && (includeTests || !isTestFile(name))
-      && !(ignore && ignore.matches(rel)),
+      (name === '.git' && 'git metadata')
+      || (SOURCE_SKIP_DIRS.has(name) && 'dependency or build output')
+      || (name.startsWith('.') && 'hidden directory')
+      || (!includeTests && TEST_DIRS.has(name) && 'test directory (--include-tests)')
+      || (!!(ignore && ignore.matches(rel + '/.')) && 'ignore rule (--no-ignore)'),
+    rejectFile: (name, rel) =>
+      (!SOURCE_FILE_EXTENSIONS.has(path.extname(name)) && 'unsupported file type')
+      || (!(includeTests || !isTestFile(name)) && 'test file (--include-tests)')
+      || (!!(ignore && ignore.matches(rel)) && 'ignore rule (--no-ignore)'),
     collect: (entryPath) => entryPath,
+    discloseSkips: true,
   });
 }

--- a/src/status-transcript-scope.test.ts
+++ b/src/status-transcript-scope.test.ts
@@ -46,8 +46,8 @@ describe('status transcript scope', () => {
   });
   afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
 
-  it('separates how many transcripts exist from how many were read', () => {
-    const result = status(dir);
+  it('separates how many transcripts exist from how many were read', async () => {
+    const result = await status(dir);
     const tp = result.transcriptProtection;
 
     expect(tp.transcriptFiles).toBe(DISCOVERED);
@@ -58,21 +58,21 @@ describe('status transcript scope', () => {
     expect(tp.transcriptFilesScanned).toBeLessThan(tp.transcriptFiles);
   });
 
-  it('reads the most recent transcripts, which is what the output claims', () => {
-    status(dir);
+  it('reads the most recent transcripts, which is what the output claims', async () => {
+    await status(dir);
     // discoverTranscripts sorts by mtime descending, so "most recent" is the
     // head of the list. If that ever changes, the wording in the status row
     // becomes false and this fails.
     expect(filesActuallyRead).toEqual(FAKE_TRANSCRIPTS.slice(0, TRANSCRIPT_SAMPLE_SIZE));
   });
 
-  it('never reports the discovery count as the number of files scanned', () => {
+  it('never reports the discovery count as the number of files scanned', async () => {
     const logs: string[] = [];
     const spy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
       logs.push(args.join(' '));
     });
     try {
-      runStatus(dir);
+      await runStatus(dir);
     } finally {
       spy.mockRestore();
     }

--- a/src/status.ts
+++ b/src/status.ts
@@ -21,7 +21,15 @@ export interface StatusResult {
   isProtected: boolean;
   configuredTools: AITool[];
   hookInstalled: boolean;
-  denyRuleCount: number;
+  /**
+   * Deny patterns in effect, or NULL when the count was not measured.
+   *
+   * Null in BOTH unknown states — a settings file that would not parse, and one
+   * whose keys collide. A number implies a measurement, and `0` over a file we
+   * could not read is a parse artifact, not a count. Two different spellings of
+   * unknown in one contract is the defect class this release exists to close.
+   */
+  denyRuleCount: number | null;
   secretsFound: number;
   /**
    * True when the scan behind `secretsFound` could not cover the whole tree, so
@@ -39,6 +47,23 @@ export interface StatusResult {
    * `truncated` closes for scan coverage.
    */
   settingsUnreadable?: { path: string; reason: string };
+  /**
+   * Present when the settings file PARSES but carries a colliding member name,
+   * so what it configures cannot be read as written.
+   *
+   * Distinct from `settingsUnreadable`: the file is valid JSON and throws
+   * nothing. `JSON.parse` keeps the last copy of a repeated key, so a file
+   * whose `permissions` block appears twice loses every deny pattern in the
+   * first copy — silently, in Claude Code, which is what enforces them. This
+   * tool's defect was reporting `0` for that, indistinguishable from a project
+   * that configured none.
+   *
+   * Also carries the case where the duplicate scanner itself could not load.
+   * `status` is a reporting command: it does not throw on an installation
+   * fault the way the policy loader does, and it does not continue as though
+   * the check had passed. It reports that it could not tell.
+   */
+  settingsAmbiguous?: { path: string; reason: string };
   transcriptProtection: {
     stopHookInstalled: boolean;
     watcherRunning: boolean;
@@ -62,7 +87,7 @@ export interface StatusResult {
 /**
  * Check the current protection status of the project.
  */
-export function status(projectDir: string): StatusResult {
+export async function status(projectDir: string): Promise<StatusResult> {
   const result: StatusResult = {
     isProtected: false,
     configuredTools: [],
@@ -90,8 +115,14 @@ export function status(projectDir: string): StatusResult {
     // it. Both used to render as "0 deny patterns", so a project whose
     // protection had never been wired up looked exactly like a healthy one.
     let settings: any;
+    // Hoisted so the duplicate scan below reads the SAME bytes the parser
+    // consumed. Re-reading the file there would let the two judge different
+    // content, which is the defect one level over.
+    let rawSettings = '';
     try {
-      const parsed = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+      rawSettings = fs.readFileSync(settingsPath, 'utf-8');
+
+      const parsed = JSON.parse(rawSettings);
       if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
         result.settingsUnreadable = {
           path: '.claude/settings.json',
@@ -107,8 +138,48 @@ export function status(projectDir: string): StatusResult {
       };
     }
 
+    if (!settings) {
+      // Could not read it at all: the initial 0 would read as a measurement.
+      result.denyRuleCount = null;
+    }
+
+    // Scanned on the RAW TEXT — the same bytes JSON.parse consumed, never the
+    // parsed object, because the parser resolves a repeated member before any
+    // consumer can see it.
+    //
+    // Ordered AFTER the parse has classified the file, not because the scan
+    // needs the result but because the two failures are DIFFERENT states: text
+    // that does not parse is `settingsUnreadable`, and running the scan on it
+    // first set both flags and collapsed the distinction the fix exists to
+    // create. A file only reaches here if it parsed.
     if (settings) {
-      result.denyRuleCount = settings?.permissions?.deny?.length || 0;
+      try {
+        const { firstDuplicateMember } = await import('@opena2a/atx-verify');
+        const dup = firstDuplicateMember(rawSettings);
+        if (dup !== null) {
+          result.settingsAmbiguous = {
+            path: '.claude/settings.json',
+            reason: `repeats "${dup}", so only the last copy is in effect`,
+          };
+        }
+      } catch (err) {
+        // The scan could not run over text that DID parse: an installation
+        // fault, or input the parser accepted and the scanner will not vouch
+        // for. Reported, not thrown — this is a reporting command and an
+        // installation fault is not a broken project — and not swallowed,
+        // which would restore the green this exists to remove.
+        result.settingsAmbiguous = {
+          path: '.claude/settings.json',
+          reason: `keys could not be checked for collisions: ${(err as Error).message}`,
+        };
+      }
+    }
+
+    if (settings) {
+      // Left null when a collision means the file does not say what it reads as.
+      result.denyRuleCount = result.settingsAmbiguous
+        ? null
+        : settings?.permissions?.deny?.length || 0;
 
       // Check for Stop hook
       const stopHooks = settings?.hooks?.Stop || [];


### PR DESCRIPTION
Lands the 0.23.0 work on `main`. **0.23.0 is already published** — under Trusted Publishing the tag push is the publish event, and this branch was held unpushed until the tag, so the tag was cut from the branch rather than from `main`. `main` is currently at 0.22.1 while npm `latest` is 0.23.0; this closes that gap.

Every change here is a case where a command accepted something, did something narrower or different, and reported success.

## Three user-visible changes

1. **`--json` on a command that does not implement it now exits 2.** It is implemented by `scan` and `status`; the other 30 verbs accepted and ignored it. The sharpest case was not accept-and-ignore: `verify --json` resolved `--json` as the project directory and printed `AI context: clean (no credentials found)` for a directory whose `CLAUDE.md` held a live key.
2. **`scan`, `scan-staged` and `scan-history` refuse an unrecognised flag** instead of warning and continuing. On a clean tree `scan --nosuchflag` changes from exit 0 to exit 2; on a tree with findings, from 1 to 2. The reason is that warn-and-continue produced `No hardcoded credentials found.` — the strongest clean claim the tool makes — over a scan whose scope the caller asked to change and did not get.
3. **`PolicyEngine.loadPolicies()` is now `async`.** Library consumers only. An un-awaited call leaves the engine holding zero rules, which is default-deny.

## Security

- **A duplicated key in a broker policy file no longer decides the rule** (#140). `JSON.parse` keeps the last of a repeated member and resolves it before the loader sees anything, so a rule whose text read `"effect": "deny"` then `"effect": "allow"` loaded as an allow while the rule count, `getRules()` and `/health` all reported it loaded. Now refused at every nesting level, scanned on the raw text, with names compared after escape decoding and case folding. Disclosed in GHSA-4x65-2hwf-fwpm, which now carries a dated update.
- **`PolicyEngine.loadRules()` validates what it is handed**, through the same `validateRule` the file loader uses. It previously validated nothing: a closed `timeWindow` denied, the same window under a misspelled `timeWindoww` allowed, and `scopeCheck: true` allowed. It also aliased the caller's `constraints`, so mutating your own rule after the call changed the engine's decision.
- **`status` distinguishes "no deny patterns" from "we could not tell."** `denyRuleCount` is `number | null`, null in both unknown states.

## Verification

The branch was held under embargo, so it had no CI. Compensating checks ran locally: full suite 1668 green across 84 files; `/release-test` walkthrough against a clean checkout of the tag commit, packed with `npm pack` and installed from the tarball, 28/32 verbs, P1 0. All three behavioural claims above were measured against published 0.22.1 rather than against this build — 0.22.1 has 6 warn verbs, this has 3, exactly the three the notes claim changed.

**This PR is the first CI this work has run.** CI triggers only on `main` pushes and PRs, so the branch push did not start it.

Known and filed rather than fixed here: #145, #146, #147, #148.

## Merge method

Merge commit, **not squash.** Every prior release tag in this repo is an ancestor of `main`, and `v0.23.0` points at a commit on this branch. Squashing or rebasing would rewrite that commit and leave the published tag dangling off a deleted branch.
