### PR TITLE
Refuse a grant binding that cannot be applied as written, and a credential that does not sign what it is matched on

### DIFF
--- a/src/broker/aap-conformance.test.ts
+++ b/src/broker/aap-conformance.test.ts
@@ -21,7 +21,13 @@ import * as path from 'path';
 
 import { BrokerServer } from './server';
 import { GrantResolver } from './grant-resolver';
-import { LocalAtxVerifier, canonicalPayload, type Atx, type AtxTrustAnchors } from '@opena2a/atx-verify';
+import {
+  LocalAtxVerifier,
+  canonicalPayload,
+  canonicalPayloadV11,
+  type Atx,
+  type AtxTrustAnchors,
+} from '@opena2a/atx-verify';
 import { GrantPolicy, type GrantBinding } from './grant-policy';
 import { MapProviderRegistry } from './cpi/registry';
 import { createOktaExchangeProvider } from './cpi/okta-adapter';
@@ -45,11 +51,21 @@ function makeKeypair(): { privateKey: crypto.KeyObject; pubHex: string } {
   return { privateKey, pubHex };
 }
 
-/** Build a valid, Ed25519-signed ATX (and the matching public key hex). */
+/**
+ * Build a valid, Ed25519-signed ATX (and the matching public key hex).
+ *
+ * The default is credential version 1.1, and that is load-bearing rather than incidental. The
+ * v1.0 signature covers identity, issuer, trust level and validity window but NOT `capabilities`
+ * or `scanSummary` — a holder edits those after signing and the credential still verifies. This
+ * suite asserts that a grant is served to an agent matching `trustClass` and `oasbLevel`, so on
+ * a v1.0 fixture it would have been asserting that the broker honours predicates the agent set
+ * for itself. `GrantPolicy` now requires `signedCapabilities`, and this fixture supplies a
+ * credential that actually carries them. Pass `atcVersion: '1.0'` to build the refused case.
+ */
 function makeSignedAtx(overrides: Partial<Atx> = {}): { atx: Atx; pubHex: string } {
   const { privateKey, pubHex } = makeKeypair();
   const base: Atx = {
-    atcVersion: '1.0',
+    atcVersion: '1.1',
     agentId: 'aim_orders_reader',
     agentDid: 'did:opena2a:agent:acme/orders-reader',
     version: '1.0.0',
@@ -66,7 +82,8 @@ function makeSignedAtx(overrides: Partial<Atx> = {}): { atx: Atx; pubHex: string
     signatures: [],
     ...overrides,
   };
-  const sig = crypto.sign(null, canonicalPayload(base), privateKey);
+  const payload = base.atcVersion === '1.1' ? canonicalPayloadV11(base) : canonicalPayload(base);
+  const sig = crypto.sign(null, payload, privateKey);
   base.signatures = [{ keyId: 'test#ed25519', algorithm: 'Ed25519', value: sig.toString('base64') }];
   return { atx: base, pubHex };
 }
@@ -262,6 +279,43 @@ describe('AAP v1 conformance: no credential or backend identifier in the agent c
     expect(agentVisible).not.toMatch(/eyJ[A-Za-z0-9_-]+\./); // no broker assertion JWT
     // The grant reference itself IS allowed in context.
     expect(agentVisible).toContain('grant://orders-db');
+  });
+
+  it('refuses a credential whose signature does not cover the predicates it is matched on', async () => {
+    // The refusal path the v1.1 fixture above would otherwise leave untested.
+    //
+    // A v1.0 credential is cryptographically valid — the same issuer, the same key, a genuine
+    // Ed25519 signature — but its signature covers neither `capabilities` nor `scanSummary`.
+    // Built HONESTLY here (orders:read, L2, trustLevel 4), so it satisfies every predicate in
+    // ORDERS_BINDING and would be granted on the strength of fields its holder could rewrite at
+    // will. The denial is about the credential version, not about this agent being unqualified.
+    const { atx: v10Atx, pubHex: v10Pub } = makeSignedAtx({ atcVersion: '1.0' });
+
+    const denied = await brokerPost(socketPath, '/grant', brokerToken, {
+      agentId: 'aim_orders_reader',
+      atx: v10Atx,
+      grant: 'grant://orders-db',
+      operation: { method: 'GET', path: '/orders' },
+    });
+    expect(denied.status).toBe(403);
+    // The denial stays opaque: it names neither the credential version nor the predicate.
+    expect(denied.text).not.toMatch(/1\.0|signedCapabilities|oasbLevel|capabilit/i);
+
+    // Control on the SAME key and the SAME claims, differing only in credential version, so the
+    // assertion above cannot pass because the fixture was broken in some other way.
+    const { atx: v11Atx, pubHex: v11Pub } = makeSignedAtx({ atcVersion: '1.1' });
+    expect(v10Pub).not.toBe(v11Pub); // each fixture mints its own key, as the helper does
+    const verifier = new LocalAtxVerifier(makeTrustAnchors(v11Pub));
+    const policy = new GrantPolicy([ORDERS_BINDING]);
+    const v11 = verifier.verify(v11Atx);
+    expect(v11.valid).toBe(true);
+    expect(v11.context?.signedCapabilities).toBe(true);
+    expect(policy.evaluate('orders-db', v11.context!).allowed).toBe(true);
+
+    const v10 = new LocalAtxVerifier(makeTrustAnchors(v10Pub)).verify(v10Atx);
+    expect(v10.valid).toBe(true); // valid, and still refused — the point of the test
+    expect(v10.context?.signedCapabilities).toBe(false);
+    expect(policy.evaluate('orders-db', v10.context!).allowed).toBe(false);
   });
 
   it('the signed audit log records the decision but never the scoped token', async () => {

--- a/src/broker/aap-conformance.test.ts
+++ b/src/broker/aap-conformance.test.ts
@@ -61,9 +61,17 @@ function makeKeypair(): { privateKey: crypto.KeyObject; pubHex: string } {
  * a v1.0 fixture it would have been asserting that the broker honours predicates the agent set
  * for itself. `GrantPolicy` now requires `signedCapabilities`, and this fixture supplies a
  * credential that actually carries them. Pass `atcVersion: '1.0'` to build the refused case.
+ *
+ * Pass `keypair` to sign with a key the server already trusts. Without it every call mints a
+ * fresh key, so a fixture handed to a running broker is rejected at signature verification and
+ * never reaches policy — which makes any assertion about a POLICY decision vacuous.
  */
-function makeSignedAtx(overrides: Partial<Atx> = {}): { atx: Atx; pubHex: string } {
-  const { privateKey, pubHex } = makeKeypair();
+function makeSignedAtx(
+  overrides: Partial<Atx> = {},
+  keypair?: { privateKey: crypto.KeyObject; pubHex: string },
+): { atx: Atx; pubHex: string; keypair: { privateKey: crypto.KeyObject; pubHex: string } } {
+  const kp = keypair ?? makeKeypair();
+  const { privateKey, pubHex } = kp;
   const base: Atx = {
     atcVersion: '1.1',
     agentId: 'aim_orders_reader',
@@ -85,7 +93,7 @@ function makeSignedAtx(overrides: Partial<Atx> = {}): { atx: Atx; pubHex: string
   const payload = base.atcVersion === '1.1' ? canonicalPayloadV11(base) : canonicalPayload(base);
   const sig = crypto.sign(null, payload, privateKey);
   base.signatures = [{ keyId: 'test#ed25519', algorithm: 'Ed25519', value: sig.toString('base64') }];
-  return { atx: base, pubHex };
+  return { atx: base, pubHex, keypair: kp };
 }
 
 function makeTrustAnchors(
@@ -197,9 +205,11 @@ describe('AAP v1 conformance: no credential or backend identifier in the agent c
     // which a real broker may own and which would otherwise race across test instances.
     tokenPath = path.join(tmpDir, 'broker.token');
 
-    const { atx, pubHex } = makeSignedAtx();
+    const { atx, pubHex, keypair } = makeSignedAtx();
     // Stash a valid ATX the "agent" will present. (In production the agent carries its own.)
     (globalThis as any).__aapTestAtx = atx;
+    // And the key behind it, so a test can mint a DIFFERENT credential this same server trusts.
+    (globalThis as any).__aapTestKeypair = keypair;
 
     const signingKey = generateBrokerSigningKey('https://broker.acme.example', 'broker-key-1');
     idp = new FakeIdp();
@@ -282,14 +292,23 @@ describe('AAP v1 conformance: no credential or backend identifier in the agent c
   });
 
   it('refuses a credential whose signature does not cover the predicates it is matched on', async () => {
-    // The refusal path the v1.1 fixture above would otherwise leave untested.
+    // The refusal path the v1.1 fixture would otherwise leave untested.
     //
-    // A v1.0 credential is cryptographically valid — the same issuer, the same key, a genuine
-    // Ed25519 signature — but its signature covers neither `capabilities` nor `scanSummary`.
-    // Built HONESTLY here (orders:read, L2, trustLevel 4), so it satisfies every predicate in
-    // ORDERS_BINDING and would be granted on the strength of fields its holder could rewrite at
-    // will. The denial is about the credential version, not about this agent being unqualified.
-    const { atx: v10Atx, pubHex: v10Pub } = makeSignedAtx({ atcVersion: '1.0' });
+    // Signed with the key THIS SERVER TRUSTS, and built honestly (orders:read, L2, trustLevel 4),
+    // so it satisfies every predicate in ORDERS_BINDING. The only thing wrong with it is its
+    // credential version. Using a fresh key here would have the server reject it at signature
+    // verification, and the 403 would prove nothing about policy — the assertion would pass
+    // against a build with no gate at all.
+    const keypair = (globalThis as any).__aapTestKeypair;
+    const { atx: v10Atx } = makeSignedAtx({ atcVersion: '1.0' }, keypair);
+
+    // Discriminating control FIRST: this server does verify a v1.0 credential from this key, so
+    // whatever the broker answers below is a policy decision and not a crypto rejection.
+    const verified = new LocalAtxVerifier(makeTrustAnchors(keypair.pubHex)).verify(v10Atx);
+    expect(verified.valid).toBe(true);
+    expect(verified.context?.signedCapabilities).toBe(false);
+    expect(verified.context?.capabilities).toContain('orders:read');
+    expect(verified.context?.oasbLevel).toBe('L2');
 
     const denied = await brokerPost(socketPath, '/grant', brokerToken, {
       agentId: 'aim_orders_reader',
@@ -301,21 +320,16 @@ describe('AAP v1 conformance: no credential or backend identifier in the agent c
     // The denial stays opaque: it names neither the credential version nor the predicate.
     expect(denied.text).not.toMatch(/1\.0|signedCapabilities|oasbLevel|capabilit/i);
 
-    // Control on the SAME key and the SAME claims, differing only in credential version, so the
-    // assertion above cannot pass because the fixture was broken in some other way.
-    const { atx: v11Atx, pubHex: v11Pub } = makeSignedAtx({ atcVersion: '1.1' });
-    expect(v10Pub).not.toBe(v11Pub); // each fixture mints its own key, as the helper does
-    const verifier = new LocalAtxVerifier(makeTrustAnchors(v11Pub));
-    const policy = new GrantPolicy([ORDERS_BINDING]);
-    const v11 = verifier.verify(v11Atx);
-    expect(v11.valid).toBe(true);
-    expect(v11.context?.signedCapabilities).toBe(true);
-    expect(policy.evaluate('orders-db', v11.context!).allowed).toBe(true);
-
-    const v10 = new LocalAtxVerifier(makeTrustAnchors(v10Pub)).verify(v10Atx);
-    expect(v10.valid).toBe(true); // valid, and still refused — the point of the test
-    expect(v10.context?.signedCapabilities).toBe(false);
-    expect(policy.evaluate('orders-db', v10.context!).allowed).toBe(false);
+    // Second control: the SAME agent, the SAME key, the SAME claims, differing only in version,
+    // is served. So the 403 is attributable to the version and to nothing else.
+    const { atx: v11Atx } = makeSignedAtx({ atcVersion: '1.1' }, keypair);
+    const allowed = await brokerPost(socketPath, '/grant', brokerToken, {
+      agentId: 'aim_orders_reader',
+      atx: v11Atx,
+      grant: 'grant://orders-db',
+      operation: { method: 'GET', path: '/orders' },
+    });
+    expect(allowed.status).toBe(200);
   });
 
   it('the signed audit log records the decision but never the scoped token', async () => {

--- a/src/broker/grant-policy.test.ts
+++ b/src/broker/grant-policy.test.ts
@@ -278,7 +278,7 @@ describe('GrantPolicy: the denial reason states what actually happened', () => {
  * express `null` and `"high"`.
  */
 describe('GrantPolicy: a minimum trust level the comparison cannot order is refused at load', () => {
-  for (const bad of [null, 'high', '3', -1, Infinity, -Infinity, [], {}, true]) {
+  for (const bad of [null, 'high', '3', -1, 1.5, 2.5, 0.1, Infinity, -Infinity, NaN, [], {}, true]) {
     it(`refuses minTrustLevel ${JSON.stringify(bad)}`, () => {
       expect(() => new GrantPolicy([withMatch({ minTrustLevel: bad })])).toThrow(/minTrustLevel/);
     });
@@ -295,14 +295,24 @@ describe('GrantPolicy: a minimum trust level the comparison cannot order is refu
     expect(p.evaluate('orders-db', { ...CTX, trustLevel: 2 }).allowed).toBe(false);
   });
 
-  it('accepts a fractional floor, which orders perfectly well', () => {
-    // Deliberately NOT refused. The reason this check exists is that the comparison cannot
-    // ORDER the value; 2.5 orders fine and worked as a floor before this change. Refusing it
-    // would be a break with no security argument, justified by an error message that is untrue
-    // of the value it rejects. `trustLevel` is declared `number`, not an integer.
-    const p = new GrantPolicy([withMatch({ minTrustLevel: 2.5 })]);
-    expect(p.evaluate('orders-db', { ...CTX, trustLevel: 3 }).allowed).toBe(true);
-    expect(p.evaluate('orders-db', { ...CTX, trustLevel: 2 }).allowed).toBe(false);
+  it('refuses a FRACTIONAL floor, and says the signature reason', () => {
+    // This test previously asserted the opposite, on the reasoning that 2.5 orders perfectly well
+    // so refusing it was a break with no security argument. There is one, and it is measured:
+    // both canonical ATX payloads project trustLevel through `Math.trunc` while the resolution
+    // context carries the raw value, so a holder edits a signed 3 to 3.999999 and the credential
+    // still verifies. Against a 3.5 floor the honest credential is denied and the forged one is
+    // served. A whole-number floor cannot be crossed that way, because truncation preserves the
+    // integer part. The relaxation was the vulnerability.
+    expect(() => new GrantPolicy([withMatch({ minTrustLevel: 2.5 })])).toThrow(/whole number/);
+    expect(() => new GrantPolicy([withMatch({ minTrustLevel: 2.5 })])).toThrow(/signature/);
+  });
+
+  it('a whole-number floor is not crossed by the fractional bits a signature does not cover', () => {
+    // The property the refusal above protects, asserted on the policy directly: whatever a holder
+    // can add below 1.0, an integer floor still denies it.
+    const p = new GrantPolicy([withMatch({ minTrustLevel: 4 })]);
+    expect(p.evaluate('orders-db', { ...CTX, trustLevel: 3.999999 }).allowed).toBe(false);
+    expect(p.evaluate('orders-db', { ...CTX, trustLevel: 4 }).allowed).toBe(true);
   });
 
   it('accepts a floor of 0 and omitting the predicate entirely', () => {
@@ -692,5 +702,129 @@ describe('GrantPolicy: a binding is what it was when it was validated', () => {
       delete (handle.match as Record<string, unknown>).minTrustLevel;
     }).toThrow(TypeError); // frozen: strict mode, and test files are modules
     expect(p.evaluate('orders-db', { ...CTX, trustLevel: 1 }).allowed).toBe(false);
+  });
+});
+
+/**
+ * Read-once, completed. Three fields were hoisted into locals in an earlier commit and two were
+ * missed — `match.trustClass` and the binding's own `grant` key — which is the same class the
+ * commit claimed to have swept. Each test asserts the field is read EXACTLY once and that the
+ * value loaded is the one the first read returned.
+ */
+describe('GrantPolicy: every validated field is read exactly once', () => {
+  it('reads trustClass once, and loads what that read returned', () => {
+    // This one also travels: the resolver copies match.trustClass into the broker assertion's
+    // trust_class claim, so a second read would mint a credential naming a class nobody authored.
+    let reads = 0;
+    const match = {
+      get trustClass() {
+        reads += 1;
+        return reads > 1 ? 'public:read' : 'admin:write';
+      },
+    };
+    const p = new GrantPolicy([{ ...binding(), match }]);
+    expect(reads).toBe(1);
+    const r = p.evaluate('orders-db', { ...CTX, capabilities: ['public:read'] });
+    expect(r.allowed).toBe(false); // the loaded class is admin:write, which this ATX lacks
+    expect(p.evaluate('orders-db', { ...CTX, capabilities: ['admin:write'] }).allowed).toBe(true);
+  });
+
+  it('reads the grant key once, so the reference check and the duplicate check see what loads', () => {
+    let reads = 0;
+    const b = {
+      get grant() {
+        reads += 1;
+        return reads > 1 ? 'not-a-grant-ref://evil' : 'grant://orders-db';
+      },
+      match: { trustClass: 'orders:read' },
+      resolve: { ...(BINDING.resolve as object) },
+    };
+    const p = new GrantPolicy([b]);
+    expect(reads).toBe(1);
+    expect(p.evaluate('orders-db', CTX).allowed).toBe(true);
+  });
+
+  it('refuses a duplicate whose key changes between reads', () => {
+    const mk = (first: string, later: string) => {
+      let n = 0;
+      return {
+        get grant() { n += 1; return n > 1 ? later : first; },
+        match: { trustClass: 'orders:read' },
+        resolve: { ...(BINDING.resolve as object) },
+      };
+    };
+    expect(() =>
+      new GrantPolicy([mk('grant://orders-db', 'grant://other'), mk('grant://orders-db', 'grant://other2')]),
+    ).toThrow(/duplicate binding/);
+  });
+});
+
+/**
+ * The loaded policy is immutable all the way down. The element freeze landed earlier; the ARRAY
+ * and the nested federation predicates did not, and the array is what the `as number` cast in
+ * `evaluate()` rests on — an appended binding never passes validation, so an unrankable floor
+ * could reach the comparison, where `1 < undefined` is false.
+ */
+describe('GrantPolicy: the loaded policy cannot be extended or reshaped', () => {
+  it('freezes the bindings array, not just its elements', () => {
+    const p = new GrantPolicy([BINDING]);
+    const internals = (p as unknown as { bindings: GrantBinding[] }).bindings;
+    expect(Object.isFrozen(internals)).toBe(true);
+    expect(() => internals.push({ ...BINDING, grant: 'grant://smuggled' })).toThrow(TypeError);
+    expect(p.size).toBe(1);
+  });
+
+  it('an unrankable floor cannot reach evaluate() through the array', () => {
+    const p = new GrantPolicy([withMatch({ oasbLevel: '>=L3' })]);
+    const internals = (p as unknown as { bindings: GrantBinding[] }).bindings;
+    expect(() =>
+      internals.push({
+        grant: 'grant://evil',
+        match: { trustClass: 'orders:read', oasbLevel: 'L9' },
+        resolve: BINDING.resolve,
+      }),
+    ).toThrow(TypeError);
+    expect(p.evaluate('evil', { ...CTX, oasbLevel: 'L1' }).allowed).toBe(false);
+  });
+
+  it('freezes the federation predicates nested inside match', () => {
+    const r = new GrantPolicy([BINDING]).evaluate('orders-db', CTX);
+    expect(Object.isFrozen(r.binding?.match.jurisdiction)).toBe(true);
+    expect(Object.isFrozen(r.binding?.match.jurisdiction?.in)).toBe(true);
+    expect(Object.isFrozen(r.binding?.match.issuerChainIncludes)).toBe(true);
+  });
+});
+
+/** evaluate() denies; it never throws, whatever a library consumer hands it. */
+describe('GrantPolicy: evaluate() denies rather than throwing', () => {
+  for (const [label, name] of [
+    ['a throwing toString', { toString() { throw new Error('boom'); } }],
+    ['a symbol', Symbol('orders-db')],
+    ['undefined', undefined],
+    ['a number', 42],
+  ] as [string, unknown][]) {
+    it(`denies when the grant name is ${label}`, () => {
+      const p = new GrantPolicy([BINDING]);
+      const r = p.evaluate(name as string, CTX);
+      expect(r.allowed).toBe(false);
+    });
+  }
+
+  it('denies a capability list that lies about includes', () => {
+    // Array.isArray is true for a subclass and for a Proxy over an array, either of which can
+    // override includes. The check scans members directly instead.
+    class Liar extends Array { includes() { return true; } }
+    const liar = new Liar();
+    expect(Array.isArray(liar)).toBe(true);
+    expect(new GrantPolicy([BINDING]).evaluate('orders-db', { ...CTX, capabilities: liar }).allowed).toBe(false);
+
+    const proxied = new Proxy(['nothing:useful'], {
+      get(t, prop) { return prop === 'includes' ? () => true : (t as never)[prop as never]; },
+    });
+    expect(new GrantPolicy([BINDING]).evaluate('orders-db', { ...CTX, capabilities: proxied as string[] }).allowed).toBe(false);
+  });
+
+  it('still grants on an honest capability list', () => {
+    expect(new GrantPolicy([BINDING]).evaluate('orders-db', CTX).allowed).toBe(true);
   });
 });

--- a/src/broker/grant-policy.test.ts
+++ b/src/broker/grant-policy.test.ts
@@ -810,18 +810,45 @@ describe('GrantPolicy: evaluate() denies rather than throwing', () => {
     });
   }
 
-  it('denies a capability list that lies about includes', () => {
-    // Array.isArray is true for a subclass and for a Proxy over an array, either of which can
-    // override includes. The check scans members directly instead.
-    class Liar extends Array { includes() { return true; } }
-    const liar = new Liar();
-    expect(Array.isArray(liar)).toBe(true);
-    expect(new GrantPolicy([BINDING]).evaluate('orders-db', { ...CTX, capabilities: liar }).allowed).toBe(false);
-
-    const proxied = new Proxy(['nothing:useful'], {
-      get(t, prop) { return prop === 'includes' ? () => true : (t as never)[prop as never]; },
+  // All four method-override shapes, because closing one and opening the other is exactly what
+  // happened here once: replacing `includes` with a `for…of` denied the Proxy-traps-includes case
+  // and started ALLOWING a subclass whose `Symbol.iterator` yields a class it does not contain —
+  // weaker than the released build, under a comment claiming a loop could not be redirected.
+  // Reading by index is redirected by neither.
+  for (const [label, make] of [
+    ['a subclass overriding Symbol.iterator', () => {
+      class C extends Array { *[Symbol.iterator]() { yield 'orders:read'; } }
+      const c = new C(); c.push('nothing:useful'); return c;
+    }],
+    ['a subclass overriding includes', () => {
+      class C extends Array { includes() { return true; } }
+      const c = new C(); c.push('nothing:useful'); return c;
+    }],
+    ['a Proxy trapping Symbol.iterator', () => new Proxy(['nothing:useful'], {
+      get(t, p) { return p === Symbol.iterator ? function* () { yield 'orders:read'; } : (t as never)[p as never]; },
+    })],
+    ['a Proxy trapping includes', () => new Proxy(['nothing:useful'], {
+      get(t, p) { return p === 'includes' ? () => true : (t as never)[p as never]; },
+    })],
+  ] as [string, () => unknown][]) {
+    it(`denies a capability list that lies via ${label}`, () => {
+      const caps = make();
+      expect(Array.isArray(caps)).toBe(true); // it passes the shape guard, which is the point
+      const r = new GrantPolicy([BINDING]).evaluate('orders-db', { ...CTX, capabilities: caps as string[] });
+      expect(r.allowed).toBe(false);
+      expect(r.reason).toMatch(/trust class/);
     });
-    expect(new GrantPolicy([BINDING]).evaluate('orders-db', { ...CTX, capabilities: proxied as string[] }).allowed).toBe(false);
+  }
+
+  it('does NOT claim to defend against a Proxy that traps every read', () => {
+    // Recorded as a known limit rather than left as a silent surprise. An object that lies about
+    // `length` and about each element cannot be read honestly in place by any means, so a caller
+    // supplying a hostile verifier decides the verdict — that is the trust boundary, not a gap.
+    // Asserted so that if a future change appears to close it, someone checks why.
+    const total = new Proxy(['nothing:useful'], {
+      get(t, p) { if (p === 'length') return 1; if (p === '0') return 'orders:read'; return (t as never)[p as never]; },
+    });
+    expect(new GrantPolicy([BINDING]).evaluate('orders-db', { ...CTX, capabilities: total as string[] }).allowed).toBe(true);
   });
 
   it('still grants on an honest capability list', () => {

--- a/src/broker/grant-policy.test.ts
+++ b/src/broker/grant-policy.test.ts
@@ -126,9 +126,17 @@ describe('GrantPolicy: a floor this build cannot rank is refused at load', () =>
     });
   }
 
-  for (const empty of ['', '   ', '>=', '>= ']) {
-    it(`refuses the empty-ish floor ${JSON.stringify(empty)} rather than dropping the check`, () => {
-      expect(() => new GrantPolicy([withMatch({ oasbLevel: empty })])).toThrow();
+  it('refuses an empty floor with the message written for it, not the unrankable one', () => {
+    // A bare `.toThrow()` here cannot tell which guard fired. Weakening `isNonEmptyString` to a
+    // plain `typeof === 'string'` still throws — from the unrankable branch — so the empty-floor
+    // message that explains the actual mistake would never be seen and no test would notice.
+    expect(() => new GrantPolicy([withMatch({ oasbLevel: '' })])).toThrow(/removes the check/);
+  });
+
+  for (const empty of ['   ', '>=', '>= ']) {
+    it(`refuses the whitespace-only floor ${JSON.stringify(empty)} rather than dropping the check`, () => {
+      // These are non-empty strings, so they reach the rankable check and fail there.
+      expect(() => new GrantPolicy([withMatch({ oasbLevel: empty })])).toThrow(/cannot rank/);
     });
   }
 
@@ -193,9 +201,31 @@ describe('GrantPolicy: a presented level this build cannot rank satisfies no flo
     });
   }
 
-  for (const level of ['L4', 'L9', 'l3', 'L3 ', ' L3', 'none', 'HARDENED', '']) {
+  for (const level of ['L4', 'L9', 'l3', 'L3 ', ' L3', 'none', 'HARDENED']) {
     it(`denies an agent presenting the unrankable level ${JSON.stringify(level)}`, () => {
       expect(l3().evaluate('orders-db', { ...CTX, oasbLevel: level }).allowed).toBe(false);
+    });
+  }
+
+  it('classifies an empty presented level as absent, not as unrankable', () => {
+    // An empty string is what an unset template variable produces, so "you sent nothing" is the
+    // more accurate record. Asserted because the two branches must not disagree about it, and a
+    // verdict-only assertion cannot see which one ran.
+    const r = l3().evaluate('orders-db', { ...CTX, oasbLevel: '' });
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toMatch(/absent/);
+  });
+
+  for (const weird of [{ toString: 1 }, { valueOf: 1, toString: 1 }, Object.create(null)]) {
+    it('denies rather than throwing on a presented level that cannot be stringified', () => {
+      // Reachable on a v1.1 credential whose signature still verifies: the TBS projects this
+      // field through the verifier's asString, which maps every non-string to '', so a holder
+      // substitutes an object post-signing without changing the signed bytes. `String()` on it
+      // throws from inside the decision function, which empties the audit record's policyId and
+      // lets an agent make its own denial unattributable to the binding it violated.
+      const r = l3().evaluate('orders-db', { ...CTX, oasbLevel: weird } as unknown as ResolutionContext);
+      expect(r.allowed).toBe(false);
+      expect(r.reason).toMatch(/satisfies no floor/);
     });
   }
 
@@ -248,7 +278,7 @@ describe('GrantPolicy: the denial reason states what actually happened', () => {
  * express `null` and `"high"`.
  */
 describe('GrantPolicy: a minimum trust level the comparison cannot order is refused at load', () => {
-  for (const bad of [null, 'high', '3', -1, 1.5, [], {}, true]) {
+  for (const bad of [null, 'high', '3', -1, Infinity, -Infinity, [], {}, true]) {
     it(`refuses minTrustLevel ${JSON.stringify(bad)}`, () => {
       expect(() => new GrantPolicy([withMatch({ minTrustLevel: bad })])).toThrow(/minTrustLevel/);
     });
@@ -265,6 +295,16 @@ describe('GrantPolicy: a minimum trust level the comparison cannot order is refu
     expect(p.evaluate('orders-db', { ...CTX, trustLevel: 2 }).allowed).toBe(false);
   });
 
+  it('accepts a fractional floor, which orders perfectly well', () => {
+    // Deliberately NOT refused. The reason this check exists is that the comparison cannot
+    // ORDER the value; 2.5 orders fine and worked as a floor before this change. Refusing it
+    // would be a break with no security argument, justified by an error message that is untrue
+    // of the value it rejects. `trustLevel` is declared `number`, not an integer.
+    const p = new GrantPolicy([withMatch({ minTrustLevel: 2.5 })]);
+    expect(p.evaluate('orders-db', { ...CTX, trustLevel: 3 }).allowed).toBe(true);
+    expect(p.evaluate('orders-db', { ...CTX, trustLevel: 2 }).allowed).toBe(false);
+  });
+
   it('accepts a floor of 0 and omitting the predicate entirely', () => {
     expect(() => new GrantPolicy([withMatch({ minTrustLevel: 0 })])).not.toThrow();
     const b = binding();
@@ -272,19 +312,35 @@ describe('GrantPolicy: a minimum trust level the comparison cannot order is refu
     expect(() => new GrantPolicy([b])).not.toThrow();
   });
 
-  it('denies rather than throwing when the ATX trust level is not a number', () => {
+  for (const bad of ['high', NaN, Infinity, -Infinity, null, undefined, '4', [4]]) {
+    it(`denies rather than throwing when the ATX trust level is ${String(bad)}`, () => {
+      // NaN and Infinity are the sharp cases and `typeof` alone does not catch them: `4 < NaN`
+      // is false, so a NaN trust level satisfies every floor. A string is caught by `typeof`,
+      // so testing only that would leave `Number.isFinite` unpinned.
+      const p = new GrantPolicy([withMatch({ minTrustLevel: 3 })]);
+      const r = p.evaluate('orders-db', { ...CTX, trustLevel: bad } as unknown as ResolutionContext);
+      expect(r.allowed).toBe(false);
+      expect(r.reason).toMatch(/not a number/);
+    });
+  }
+
+  it('grants on a fractional trust level, which is a number and does order', () => {
     const p = new GrantPolicy([withMatch({ minTrustLevel: 3 })]);
-    const r = p.evaluate('orders-db', { ...CTX, trustLevel: 'high' } as unknown as ResolutionContext);
-    expect(r.allowed).toBe(false);
-    expect(r.reason).toMatch(/not a number/);
+    expect(p.evaluate('orders-db', { ...CTX, trustLevel: 3.5 }).allowed).toBe(true);
   });
 
-  it('denies rather than throwing when the ATX carries no capability list', () => {
-    const p = new GrantPolicy([BINDING]);
-    const r = p.evaluate('orders-db', { ...CTX, capabilities: undefined } as unknown as ResolutionContext);
-    expect(r.allowed).toBe(false);
-    expect(r.reason).toMatch(/no capability list/);
-  });
+  for (const bad of [undefined, null, 'orders:read', { includes: () => true }, 42]) {
+    it(`denies rather than throwing when capabilities is ${JSON.stringify(bad) ?? String(bad)}`, () => {
+      // The string and the duck-typed object are why this is `Array.isArray` and not a
+      // truthiness check: `'orders:read'.includes('orders:read')` is true, and an object with an
+      // `includes` method answers whatever it likes. Testing only `undefined` would pass on any
+      // weaker guard, which is the axis the guard exists for.
+      const p = new GrantPolicy([BINDING]);
+      const r = p.evaluate('orders-db', { ...CTX, capabilities: bad } as unknown as ResolutionContext);
+      expect(r.allowed).toBe(false);
+      expect(r.reason).toMatch(/no capability list/);
+    });
+  }
 });
 
 /**
@@ -329,6 +385,31 @@ describe('GrantPolicy: a field this build does not read is refused at load', () 
       new GrantPolicy([withMatch({ issuerChainIncludes: { partnersSet: 'p', partnerSet: 'q' } })]),
     ).toThrow(/unknown field "partnerSet"/);
   });
+
+  it('refuses an unknown sub-key of the jurisdiction predicate', () => {
+    // The sibling of the case above. Without this, `jurisdiction: { in: ['us'], residency: ['cn'] }`
+    // loaded silently — asymmetric coverage of the exact guard class this change is about.
+    expect(() =>
+      new GrantPolicy([withMatch({ jurisdiction: { in: ['us'], residency: ['cn'] } })]),
+    ).toThrow(/unknown field "residency"/);
+  });
+
+  for (const bad of [null, 'orders:read', 42, []]) {
+    it(`refuses a match container that is ${JSON.stringify(bad)}, naming the binding`, () => {
+      // Without the container type check these produce a raw TypeError with no binding label,
+      // or the misleading `unknown field "0"` from iterating a string's indices. The constructor
+      // is written for a config loader, so a JSON-expressible shape gets a real message.
+      const b = binding();
+      b.match = bad;
+      expect(() => new GrantPolicy([b])).toThrow(/match must be an object/);
+    });
+
+    it(`refuses a resolve container that is ${JSON.stringify(bad)}, naming the binding`, () => {
+      const b = binding();
+      b.resolve = bad;
+      expect(() => new GrantPolicy([b])).toThrow(/resolve must be an object/);
+    });
+  }
 
   it('shape-validates the federation predicates it parses but does not enforce', () => {
     expect(() => new GrantPolicy([withMatch({ issuerChainIncludes: { partnersSet: '' } })])).toThrow();
@@ -523,5 +604,93 @@ describe('GrantPolicy: a credential that does not sign what we match on is denie
     expect(r.allowed).toBe(false);
     expect(r.reason).toMatch(/trust class/);
     expect(r.reason).not.toMatch(/signature/);
+  });
+});
+
+/**
+ * Inputs that are not what they appear to be at the moment they are read.
+ *
+ * Each of these validated clean and then behaved differently, so `size` and the constructor's
+ * own promise ("every binding is validated here") were false for them.
+ */
+describe('GrantPolicy: a binding is what it was when it was validated', () => {
+  it('refuses a hole in a sparse array rather than skipping it', () => {
+    // `Array.prototype.map` skips holes; `find` does not. So `new Array(3)` with one real
+    // binding reported size 3, validated one, and threw on `undefined.grant` at the first
+    // evaluation.
+    const sparse = new Array(3);
+    sparse[1] = BINDING;
+    expect(() => new GrantPolicy(sparse)).toThrow(/must be an object/);
+    expect(() => new GrantPolicy([, ] as unknown[])).toThrow(/must be an object/);
+  });
+
+  // Each of the three below asserts the field is read EXACTLY ONCE, and that the value loaded is
+  // the one the first read returned. Counting the reads is the point: a threshold picked to be
+  // "somewhere after validation" is a guess about the implementation's internals, and a guess
+  // that lands too high makes the test pass against the very re-read it exists to catch. Three
+  // such tests survived exactly that way before this was tightened.
+
+  it('reads minTrustLevel once, and loads what that read returned', () => {
+    // `4 < NaN` is false, so loading NaN on a later read would grant every trust level under a
+    // floor the operator wrote as 9.
+    let reads = 0;
+    const match = {
+      trustClass: 'orders:read',
+      get minTrustLevel() {
+        reads += 1;
+        return reads > 1 ? NaN : 9;
+      },
+    };
+    const p = new GrantPolicy([{ ...binding(), match }]);
+    expect(reads).toBe(1);
+    expect(p.evaluate('orders-db', { ...CTX, trustLevel: 0 }).allowed).toBe(false);
+    expect(p.evaluate('orders-db', { ...CTX, trustLevel: 9 }).allowed).toBe(true);
+  });
+
+  it('reads oasbLevel once, and loads what that read returned', () => {
+    let reads = 0;
+    const match = {
+      trustClass: 'orders:read',
+      get oasbLevel() {
+        reads += 1;
+        return reads > 1 ? '>=L1' : '>=L3';
+      },
+    };
+    const p = new GrantPolicy([{ ...binding(), match }]);
+    expect(reads).toBe(1);
+    expect(p.evaluate('orders-db', { ...CTX, oasbLevel: 'L1' }).allowed).toBe(false);
+    expect(p.evaluate('orders-db', { ...CTX, oasbLevel: 'L3' }).allowed).toBe(true);
+  });
+
+  it('reads ttlSeconds once, and loads what that read returned', () => {
+    let reads = 0;
+    const resolve = {
+      mode: 'exchange',
+      providerId: 'orders-idp',
+      scope: 'orders.read',
+      audience: 'https://api.orders.internal',
+      get ttlSeconds() {
+        reads += 1;
+        return reads > 1 ? 315360000 : 60; // ten years, vs one minute
+      },
+    };
+    const p = new GrantPolicy([{ ...binding(), resolve }]);
+    expect(reads).toBe(1);
+    expect(p.evaluate('orders-db', CTX).binding?.resolve.ttlSeconds).toBe(60);
+  });
+
+  it('does not hand the caller a live handle through the evaluation result', () => {
+    // The return path, which the in-direction reconstruction does not close. Measured before
+    // freezing: take the binding off a DENIED evaluation, delete its floors, and the next
+    // evaluation of the same low-trust agent was allowed.
+    const p = new GrantPolicy([BINDING]);
+    const denied = p.evaluate('orders-db', { ...CTX, trustLevel: 1 });
+    expect(denied.allowed).toBe(false);
+
+    const handle = denied.binding as GrantBinding;
+    expect(() => {
+      delete (handle.match as Record<string, unknown>).minTrustLevel;
+    }).toThrow(TypeError); // frozen: strict mode, and test files are modules
+    expect(p.evaluate('orders-db', { ...CTX, trustLevel: 1 }).allowed).toBe(false);
   });
 });

--- a/src/broker/grant-policy.test.ts
+++ b/src/broker/grant-policy.test.ts
@@ -11,6 +11,10 @@ const CTX: ResolutionContext = {
   trustScore: 0.95,
   capabilities: ['orders:read'],
   oasbLevel: 'L2',
+  // v1.1: `capabilities` and `scanSummary` are inside the signature. Every test below that
+  // expects a grant needs this, because a credential that does not carry these fields under
+  // its signature is denied before any predicate is compared.
+  signedCapabilities: true,
 };
 
 const BINDING: GrantBinding = {
@@ -434,4 +438,90 @@ describe('GrantPolicy: a loaded binding cannot be altered from outside', () => {
   // way out buys no adversarial protection — the same measurement that put `PolicyEngine`'s
   // `getRules()` at P3 rather than in a fix. The IN direction above is the one that matters,
   // because before this change the caller kept the only reference and the class had none.
+});
+
+/**
+ * The credential version gate.
+ *
+ * `trustClass` and `oasbLevel` read `capabilities` and `scanSummary.oasbLevel`. The ATX v1.0
+ * signature covers neither, so a holder rewrites them after signing and the credential still
+ * verifies — measured with a real Ed25519 key: `scanSummary.oasbLevel` L2 -> L3 admitted the
+ * holder to a `>=L3` binding, and injecting a capability that was never issued admitted them
+ * too, while the control of rewriting the signature-covered `trustLevel` correctly failed
+ * verification. Comparing those predicates reports a decision the agent made as one the
+ * operator made.
+ */
+describe('GrantPolicy: a credential that does not sign what we match on is denied', () => {
+  const p = () => new GrantPolicy([BINDING]);
+
+  it('denies a v1.0 credential that satisfies every predicate honestly', () => {
+    // Not an unqualified agent: identical to CTX in every field the binding matches on.
+    const r = p().evaluate('orders-db', { ...CTX, signedCapabilities: false });
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toMatch(/signature/);
+  });
+
+  it('denies the holder who raised their own OASB level', () => {
+    // What the forgery buys on v1.0: the agent writes L3 into its own scan summary.
+    const r = p().evaluate('orders-db', { ...CTX, oasbLevel: 'L3', signedCapabilities: false });
+    expect(r.allowed).toBe(false);
+  });
+
+  it('denies the holder who granted themselves the trust class', () => {
+    const r = p().evaluate('orders-db', {
+      ...CTX,
+      capabilities: ['orders:read', 'orders:write'],
+      signedCapabilities: false,
+    });
+    expect(r.allowed).toBe(false);
+  });
+
+  it('treats an absent signedCapabilities as unsigned, not as signed', () => {
+    // `AtxVerifier` is a published interface. A third-party implementation that predates the
+    // field, or omits it, must not read as "these fields are covered".
+    const { signedCapabilities: _drop, ...noFlag } = CTX as Record<string, unknown> & {
+      signedCapabilities: boolean;
+    };
+    const r = p().evaluate('orders-db', noFlag as unknown as ResolutionContext);
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toMatch(/signature/);
+  });
+
+  for (const truthy of [1, 'true', {}, [] as unknown]) {
+    it(`treats a non-boolean signedCapabilities ${JSON.stringify(truthy)} as unsigned`, () => {
+      const r = p().evaluate('orders-db', {
+        ...CTX,
+        signedCapabilities: truthy,
+      } as unknown as ResolutionContext);
+      expect(r.allowed).toBe(false);
+    });
+  }
+
+  it('reports the credential version, not a predicate read from a field it does not sign', () => {
+    // Pins the ORDER, not just the outcome. With the gate after the trustClass comparison the
+    // verdict is still deny, so an outcome-only assertion cannot see the difference — but the
+    // audit record then says "ATX lacks trust class", a conclusion drawn from the very field
+    // we have just established the holder controls. We do not know what capabilities this agent
+    // has; we know we cannot tell.
+    const r = p().evaluate('orders-db', {
+      ...CTX,
+      capabilities: ['weather:read'],
+      signedCapabilities: false,
+    });
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toMatch(/signature/);
+    expect(r.reason).not.toMatch(/trust class/);
+  });
+
+  // Controls. Without these the block above passes on a build that denies everything.
+  it('grants the same agent on a credential that does sign those fields', () => {
+    expect(p().evaluate('orders-db', CTX).allowed).toBe(true);
+  });
+
+  it('still denies an unqualified agent on a signed credential, for the RIGHT reason', () => {
+    const r = p().evaluate('orders-db', { ...CTX, capabilities: ['weather:read'] });
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toMatch(/trust class/);
+    expect(r.reason).not.toMatch(/signature/);
+  });
 });

--- a/src/broker/grant-policy.test.ts
+++ b/src/broker/grant-policy.test.ts
@@ -31,6 +31,28 @@ const BINDING: GrantBinding = {
   },
 };
 
+/** A fresh, deeply independent copy, so a test that mutates one cannot leak into another. */
+function binding(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return JSON.parse(JSON.stringify({ ...BINDING, ...overrides }));
+}
+
+/** A binding whose `match` is BINDING's with the given patch applied. */
+function withMatch(patch: Record<string, unknown>): Record<string, unknown> {
+  const b = binding();
+  b.match = { ...(b.match as object), ...patch };
+  return b;
+}
+
+/** A binding whose `resolve` is BINDING's with the given patch applied. */
+function withResolve(patch: Record<string, unknown>): Record<string, unknown> {
+  const b = binding();
+  b.resolve = { ...(b.resolve as object), ...patch };
+  return b;
+}
+
+/** An agent presenting NO OASB level — the party an unenforced floor lets through. */
+const NO_OASB = { ...CTX, oasbLevel: undefined } as ResolutionContext;
+
 describe('GrantPolicy (decision/enforcement split, AAP §3/§7)', () => {
   it('grants when the ATX satisfies the enforced predicates', () => {
     const r = new GrantPolicy([BINDING]).evaluate('orders-db', CTX);
@@ -72,4 +94,344 @@ describe('GrantPolicy (decision/enforcement split, AAP §3/§7)', () => {
     });
     expect(r.allowed).toBe(true);
   });
+
+  it('is an empty default-deny policy when constructed with no bindings', () => {
+    const p = new GrantPolicy();
+    expect(p.size).toBe(0);
+    expect(p.evaluate('orders-db', CTX).allowed).toBe(false);
+  });
+});
+
+/**
+ * The floor an operator writes.
+ *
+ * `parseOasbFloor` used to return rank 0 for a level this build cannot order, and nothing is
+ * below 0 — so the STRICTEST floor an operator could write was the one that enforced nothing.
+ * Each spelling below is asserted separately because they fail for different reasons: a level
+ * outside the vocabulary, a case difference, a word from another vocabulary, an operator
+ * comparison syntax we do not parse, and a template that produced an empty string.
+ */
+describe('GrantPolicy: a floor this build cannot rank is refused at load', () => {
+  for (const spec of ['L4', 'L0', 'L9', 'none', 'high', 'hardened', 'l3', 'L2+', '> L2', '>=L4', '>= high']) {
+    it(`refuses oasbLevel ${JSON.stringify(spec)}, naming it and the levels this build ranks`, () => {
+      expect(() => new GrantPolicy([withMatch({ oasbLevel: spec })])).toThrow(/cannot rank/);
+      expect(() => new GrantPolicy([withMatch({ oasbLevel: spec })])).toThrow(
+        new RegExp(spec.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+      );
+      expect(() => new GrantPolicy([withMatch({ oasbLevel: spec })])).toThrow(/L1, L2, L3/);
+    });
+  }
+
+  for (const empty of ['', '   ', '>=', '>= ']) {
+    it(`refuses the empty-ish floor ${JSON.stringify(empty)} rather than dropping the check`, () => {
+      expect(() => new GrantPolicy([withMatch({ oasbLevel: empty })])).toThrow();
+    });
+  }
+
+  for (const bad of [null, 0, false, 2, [], {}]) {
+    it(`refuses a non-string oasbLevel ${JSON.stringify(bad)}`, () => {
+      expect(() => new GrantPolicy([withMatch({ oasbLevel: bad })])).toThrow(/oasbLevel/);
+    });
+  }
+
+  it('suggests the correct casing for a case-only near miss', () => {
+    expect(() => new GrantPolicy([withMatch({ oasbLevel: 'l3' })])).toThrow(/did you mean "L3"/);
+  });
+
+  it('does NOT suggest a WEAKER level for an out-of-vocabulary one', () => {
+    // nearestMatch('L4', ['L1','L2','L3']) returns 'L1' on a Levenshtein tie broken by array
+    // order. Suggesting it would talk an operator into the weakest floor in the vocabulary
+    // while they believe they are fixing a typo.
+    for (const spec of ['L4', 'L0', 'L9']) {
+      let message = '';
+      try {
+        new GrantPolicy([withMatch({ oasbLevel: spec })]);
+      } catch (e) {
+        message = e instanceof Error ? e.message : String(e);
+      }
+      // Both halves matter. Without the first, this passes vacuously on a build that does not
+      // refuse the level at all — there is no message, so there is no suggestion in it either.
+      expect(message).toMatch(/cannot rank/);
+      expect(message).not.toMatch(/did you mean/);
+    }
+  });
+
+  // The absence direction: every level this build DOES rank still loads, and ranks in order.
+  for (const spec of ['L1', 'L2', 'L3', '>=L1', '>=L2', '>=L3', '>= L2']) {
+    it(`accepts the rankable floor ${JSON.stringify(spec)}`, () => {
+      expect(() => new GrantPolicy([withMatch({ oasbLevel: spec })])).not.toThrow();
+    });
+  }
+
+  it('orders the levels it ranks, so a higher floor denies what a lower one grants', () => {
+    const l1 = new GrantPolicy([withMatch({ oasbLevel: '>=L1' })]);
+    const l3 = new GrantPolicy([withMatch({ oasbLevel: '>=L3' })]);
+    expect(l1.evaluate('orders-db', { ...CTX, oasbLevel: 'L2' }).allowed).toBe(true);
+    expect(l3.evaluate('orders-db', { ...CTX, oasbLevel: 'L2' }).allowed).toBe(false);
+  });
+});
+
+/**
+ * The level an agent presents.
+ *
+ * This side cannot be refused at load — it arrives at request time inside the credential — so it
+ * denies instead. It was NOT fail-closed before: `OASB_RANK` was an object literal, so a lookup
+ * of a prototype key returned a function rather than undefined, `?? 0` never fired, and
+ * `function < 3` is false, so the deny branch never ran.
+ */
+describe('GrantPolicy: a presented level this build cannot rank satisfies no floor', () => {
+  const l3 = () => new GrantPolicy([withMatch({ oasbLevel: '>=L3' })]);
+
+  for (const key of ['constructor', '__proto__', 'toString', 'valueOf', 'hasOwnProperty', 'isPrototypeOf']) {
+    it(`denies an agent presenting the prototype key ${JSON.stringify(key)}`, () => {
+      const r = l3().evaluate('orders-db', { ...CTX, oasbLevel: key });
+      expect(r.allowed).toBe(false);
+    });
+  }
+
+  for (const level of ['L4', 'L9', 'l3', 'L3 ', ' L3', 'none', 'HARDENED', '']) {
+    it(`denies an agent presenting the unrankable level ${JSON.stringify(level)}`, () => {
+      expect(l3().evaluate('orders-db', { ...CTX, oasbLevel: level }).allowed).toBe(false);
+    });
+  }
+
+  // Controls, both directions, so the block above cannot pass by denying everything.
+  it('grants an agent presenting exactly the required level', () => {
+    expect(l3().evaluate('orders-db', { ...CTX, oasbLevel: 'L3' }).allowed).toBe(true);
+  });
+
+  it('denies an agent presenting a lower ranked level', () => {
+    expect(l3().evaluate('orders-db', { ...CTX, oasbLevel: 'L1' }).allowed).toBe(false);
+  });
+
+  it('denies an agent presenting no level at all', () => {
+    expect(l3().evaluate('orders-db', NO_OASB).allowed).toBe(false);
+  });
+});
+
+/**
+ * The audit record must not assert a comparison that did not run. The single reason string this
+ * replaced reported an unrankable or absent level as "below required", which is a false
+ * statement written into the record an incident would be reconstructed from.
+ */
+describe('GrantPolicy: the denial reason states what actually happened', () => {
+  const l2 = () => new GrantPolicy([withMatch({ oasbLevel: '>=L2' })]);
+
+  it('says the level is absent, not that it is below the floor', () => {
+    const r = l2().evaluate('orders-db', NO_OASB);
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toMatch(/absent/);
+    expect(r.reason).not.toMatch(/below/);
+  });
+
+  it('says an unrankable level satisfies no floor, not that it is below the floor', () => {
+    const r = l2().evaluate('orders-db', { ...CTX, oasbLevel: 'L9' });
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toMatch(/not one of L1, L2, L3/);
+    expect(r.reason).not.toMatch(/below/);
+  });
+
+  it('says below only when a comparison of two ranked levels actually ran', () => {
+    const r = l2().evaluate('orders-db', { ...CTX, oasbLevel: 'L1' });
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toMatch(/L1 below required >=L2/);
+  });
+});
+
+/**
+ * `minTrustLevel` on the value axis. `4 < null`, `4 < NaN` and `4 < "high"` are all `false`, so a
+ * floor written with any of them passes `!== undefined`, loads, and then denies nothing. JSON can
+ * express `null` and `"high"`.
+ */
+describe('GrantPolicy: a minimum trust level the comparison cannot order is refused at load', () => {
+  for (const bad of [null, 'high', '3', -1, 1.5, [], {}, true]) {
+    it(`refuses minTrustLevel ${JSON.stringify(bad)}`, () => {
+      expect(() => new GrantPolicy([withMatch({ minTrustLevel: bad })])).toThrow(/minTrustLevel/);
+    });
+  }
+
+  it('refuses NaN, which JSON cannot carry but a programmatic caller can', () => {
+    expect(() => new GrantPolicy([withMatch({ minTrustLevel: NaN })])).toThrow(/minTrustLevel/);
+  });
+
+  // Absence direction: a real floor still loads and still discriminates.
+  it('accepts an integer floor and denies below it', () => {
+    const p = new GrantPolicy([withMatch({ minTrustLevel: 3 })]);
+    expect(p.evaluate('orders-db', { ...CTX, trustLevel: 3 }).allowed).toBe(true);
+    expect(p.evaluate('orders-db', { ...CTX, trustLevel: 2 }).allowed).toBe(false);
+  });
+
+  it('accepts a floor of 0 and omitting the predicate entirely', () => {
+    expect(() => new GrantPolicy([withMatch({ minTrustLevel: 0 })])).not.toThrow();
+    const b = binding();
+    delete (b.match as Record<string, unknown>).minTrustLevel;
+    expect(() => new GrantPolicy([b])).not.toThrow();
+  });
+
+  it('denies rather than throwing when the ATX trust level is not a number', () => {
+    const p = new GrantPolicy([withMatch({ minTrustLevel: 3 })]);
+    const r = p.evaluate('orders-db', { ...CTX, trustLevel: 'high' } as unknown as ResolutionContext);
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toMatch(/not a number/);
+  });
+
+  it('denies rather than throwing when the ATX carries no capability list', () => {
+    const p = new GrantPolicy([BINDING]);
+    const r = p.evaluate('orders-db', { ...CTX, capabilities: undefined } as unknown as ResolutionContext);
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toMatch(/no capability list/);
+  });
+});
+
+/**
+ * The key axis. A misspelled predicate leaves the field undefined, so the branch that reads it
+ * never runs and the binding loads as the WIDER rule the operator did not write — while `size`
+ * still reports it loaded. `policy.ts` refuses this at four nesting levels for `PolicyRule`.
+ */
+describe('GrantPolicy: a field this build does not read is refused at load', () => {
+  it('refuses an unknown key on the binding', () => {
+    expect(() => new GrantPolicy([binding({ effect: 'deny' })])).toThrow(/unknown field "effect"/);
+  });
+
+  it('refuses a misspelled match container rather than loading an unconstrained binding', () => {
+    const b = binding();
+    (b as Record<string, unknown>).matches = b.match;
+    delete (b as Record<string, unknown>).match;
+    expect(() => new GrantPolicy([b])).toThrow(/unknown field "matches"/);
+  });
+
+  for (const typo of ['oasbLevl', 'minTrustLvl', 'trustclass', 'scopeCheck', 'jurisdictions']) {
+    it(`refuses the match predicate ${JSON.stringify(typo)}`, () => {
+      expect(() => new GrantPolicy([withMatch({ [typo]: 'anything' })])).toThrow(
+        new RegExp(`unknown field "${typo}"`),
+      );
+    });
+  }
+
+  it('names the likely intended field without binding it', () => {
+    let message = '';
+    try {
+      new GrantPolicy([withMatch({ oasbLevl: '>=L3' })]);
+    } catch (e) {
+      message = e instanceof Error ? e.message : String(e);
+    }
+    expect(message).toMatch(/did you mean "oasbLevel"/);
+    // The suggestion is advice, not a rewrite: the binding did not load.
+    expect(() => new GrantPolicy([withMatch({ oasbLevl: '>=L3' })])).toThrow();
+  });
+
+  it('refuses an unknown sub-key of a federation predicate', () => {
+    expect(() =>
+      new GrantPolicy([withMatch({ issuerChainIncludes: { partnersSet: 'p', partnerSet: 'q' } })]),
+    ).toThrow(/unknown field "partnerSet"/);
+  });
+
+  it('shape-validates the federation predicates it parses but does not enforce', () => {
+    expect(() => new GrantPolicy([withMatch({ issuerChainIncludes: { partnersSet: '' } })])).toThrow();
+    expect(() => new GrantPolicy([withMatch({ issuerChainIncludes: 'trusted' })])).toThrow();
+    expect(() => new GrantPolicy([withMatch({ jurisdiction: { in: [] } })])).toThrow();
+    expect(() => new GrantPolicy([withMatch({ jurisdiction: { in: ['us', ''] } })])).toThrow();
+    expect(() => new GrantPolicy([withMatch({ jurisdiction: ['us'] })])).toThrow();
+    // Absence direction: the well-formed clauses in BINDING still load.
+    expect(() => new GrantPolicy([BINDING])).not.toThrow();
+  });
+
+  it('requires a trust class, the one predicate with no default', () => {
+    for (const bad of [undefined, '', null, 3]) {
+      expect(() => new GrantPolicy([withMatch({ trustClass: bad })])).toThrow(/trustClass/);
+    }
+  });
+});
+
+/**
+ * The resource half. A binding is one authorization unit: validating the predicate and not the
+ * TTL moves the fail-open rather than closing it. An absent `ttlSeconds` reaches the assertion
+ * builder as `nowSeconds + undefined` = NaN, which `JSON.stringify` emits as `"exp": null`.
+ */
+describe('GrantPolicy: the resource half is validated too', () => {
+  for (const bad of [undefined, null, '300', 0, -1, 1.5, NaN, Infinity]) {
+    it(`refuses ttlSeconds ${String(bad)}`, () => {
+      const b = withResolve({ ttlSeconds: bad });
+      if (bad === undefined) delete (b.resolve as Record<string, unknown>).ttlSeconds;
+      expect(() => new GrantPolicy([b])).toThrow(/ttlSeconds/);
+    });
+  }
+
+  it('refuses a CPI mode this build has no provider interface for', () => {
+    expect(() => new GrantPolicy([withResolve({ mode: 'impersonate' })])).toThrow(/resolve.mode/);
+    expect(() => new GrantPolicy([withResolve({ mode: 'exchang' })])).toThrow(/did you mean "exchange"/);
+  });
+
+  for (const key of ['providerId', 'scope', 'audience']) {
+    it(`refuses an empty ${key}`, () => {
+      expect(() => new GrantPolicy([withResolve({ [key]: '' })])).toThrow(new RegExp(key));
+    });
+  }
+
+  it('refuses an authored resolve.trustClass, which the resolver overwrites', () => {
+    expect(() => new GrantPolicy([withResolve({ trustClass: 'orders:write' })])).toThrow(/discarded/);
+  });
+
+  it('refuses an unknown resolve key', () => {
+    expect(() => new GrantPolicy([withResolve({ region: 'eu' })])).toThrow(/unknown field "region"/);
+  });
+});
+
+/** The binding key itself. A binding a request can never match is a policy that never applies. */
+describe('GrantPolicy: the grant reference is validated at load', () => {
+  for (const bad of ['orders-db', 'grant://', 'grant://orders/db', 'grant://host:8080', 'secret://a/b', '']) {
+    it(`refuses the binding key ${JSON.stringify(bad)}`, () => {
+      expect(() => new GrantPolicy([binding({ grant: bad })])).toThrow();
+    });
+  }
+
+  it('refuses a second binding for a grant the first already names', () => {
+    // `evaluate` resolves by `find`, so the first wins and a stricter replacement is dead policy.
+    const loose = withMatch({ oasbLevel: '>=L1' });
+    const strict = withMatch({ oasbLevel: '>=L3' });
+    expect(() => new GrantPolicy([loose, strict])).toThrow(/duplicate binding/);
+  });
+
+  it('accepts distinct grants in one policy', () => {
+    const other = binding({ grant: 'grant://payroll-db' });
+    const p = new GrantPolicy([BINDING, other]);
+    expect(p.size).toBe(2);
+  });
+
+  it('refuses a binding that is not an object', () => {
+    for (const bad of [null, undefined, 'grant://orders-db', 42, []]) {
+      expect(() => new GrantPolicy([bad])).toThrow();
+    }
+  });
+});
+
+/**
+ * A loaded policy is the class's own object. The engine previously stored the caller's array
+ * elements by reference, so an operator-side object mutated after load changed a live decision
+ * with no call into this class.
+ */
+describe('GrantPolicy: a loaded binding cannot be altered from outside', () => {
+  it('keeps denying after the caller deletes the floor from its own object', () => {
+    const b = binding() as { match: Record<string, unknown> };
+    const p = new GrantPolicy([b]);
+    expect(p.evaluate('orders-db', NO_OASB).allowed).toBe(false);
+
+    delete b.match.oasbLevel;
+    delete b.match.minTrustLevel;
+
+    expect(p.evaluate('orders-db', NO_OASB).allowed).toBe(false);
+  });
+
+  it('keeps denying after the caller lowers the trust floor on its own object', () => {
+    const b = binding() as { match: Record<string, unknown> };
+    const p = new GrantPolicy([b]);
+    b.match.minTrustLevel = 0;
+    expect(p.evaluate('orders-db', { ...CTX, trustLevel: 1 }).allowed).toBe(false);
+  });
+
+  // NOT asserted: that `evaluate()`'s returned `binding` is a copy. `private` is a compile-time
+  // marker only, so an in-process caller already reaches `bindings` directly and a copy on the
+  // way out buys no adversarial protection — the same measurement that put `PolicyEngine`'s
+  // `getRules()` at P3 rather than in a fix. The IN direction above is the one that matters,
+  // because before this change the caller kept the only reference and the class had none.
 });

--- a/src/broker/grant-policy.ts
+++ b/src/broker/grant-policy.ts
@@ -12,14 +12,17 @@
  * (AAP-BROKER-PROFILE §7.1). `minTrustLevel` is enforced here as well; it is this build's
  * addition, not a line of that list. Default-deny: no matching binding ⇒ denied (AAP §3.4).
  *
- * SCOPE OF WHAT THIS FILE CAN PROMISE. Two of the three predicates it enforces —
- * `trustClass` (from `ctx.capabilities`) and `oasbLevel` (from `ctx.scanSummary.oasbLevel`)
- * — are NOT covered by the ATX signature on credential version 1.0. `@opena2a/atx-verify`
- * publishes `ResolutionContext.signedCapabilities` precisely so a caller can refuse such a
- * credential, and this build does not yet read it. So these predicates are enforced against
- * an OPERATOR's configuration mistakes, and against a HOLDER only on a v1.1 credential.
- * Until the `signedCapabilities` gate lands, no surface may say this build "enforces" an
- * OASB level presented by an agent.
+ * WHAT THE PREDICATES BIND, AND AGAINST WHOM. Two of the three — `trustClass` (read from
+ * `ctx.capabilities`) and `oasbLevel` (read from `ctx.scanSummary.oasbLevel`) — sit outside
+ * the ATX signature on credential version 1.0. Measured with a real key: a holder rewrites
+ * `scanSummary.oasbLevel` from L2 to L3 after signing, the credential still verifies, and a
+ * `>=L3` binding admitted it; injecting a capability that was never issued admitted it too;
+ * the control, rewriting the signature-covered `trustLevel`, correctly failed verification.
+ * So on v1.0 the agent, not the operator, decides two of the three predicates.
+ *
+ * `@opena2a/atx-verify` publishes `ResolutionContext.signedCapabilities` for exactly this
+ * decision, and `evaluate()` requires it. A credential that does not carry these fields under
+ * its signature is denied rather than compared against predicates its holder chose.
  */
 
 import type { ResolutionContext } from '@opena2a/atx-verify' with { 'resolution-mode': 'import' };
@@ -31,23 +34,22 @@ export interface GrantMatch {
   /**
    * Trust class (capability) the ATX must carry, e.g. "orders:read".
    *
-   * Compared in v1, but read from `capabilities`, which the ATX v1.0 signature does NOT cover.
-   * On a v1.0 credential the holder can add this capability after signing and the credential
-   * still verifies, so against a holder this predicate binds only on v1.1. See the file header.
+   * Read from `capabilities`, which the ATX v1.0 signature does not cover, so a credential
+   * whose `signedCapabilities` is not true is denied before this predicate is compared. See
+   * the file header.
    */
   trustClass: string;
   /**
-   * Minimum ATX trust level. Enforced in v1, and `trustLevel` IS covered by the signature on
-   * both credential versions - the one predicate here a holder cannot rewrite.
+   * Minimum ATX trust level. `trustLevel` is covered by the signature on both credential
+   * versions — the one predicate here a holder could never have rewritten.
    */
   minTrustLevel?: number;
   /**
    * Minimum OASB level from the ATX scan summary, e.g. ">=L2".
    *
-   * Compared in v1, but read from `scanSummary.oasbLevel`, which the ATX v1.0 signature does
-   * NOT cover. On a v1.0 credential the holder sets their own level after signing, so against a
-   * holder this predicate binds only on v1.1. It does bind an operator's configuration: a level
-   * this build cannot rank is refused at load rather than loading as no floor.
+   * Read from `scanSummary.oasbLevel`, which the ATX v1.0 signature does not cover, so a
+   * credential whose `signedCapabilities` is not true is denied before this predicate is
+   * compared. A floor this build cannot rank is refused at load rather than loading as none.
    */
   oasbLevel?: string;
   /** Federation: issuer chain must include a node in this partner set. v1: parsed, in-org satisfied. */
@@ -175,6 +177,23 @@ export class GrantPolicy {
       return { allowed: false, reason: `No binding for ${target} (default deny)` };
     }
     const m = binding.match;
+
+    // The credential's own version decides whether the predicates below mean anything.
+    //
+    // `trustClass` and `oasbLevel` read `capabilities` and `scanSummary.oasbLevel`, and the
+    // v1.0 signature covers neither, so on a v1.0 credential the holder supplies the answers
+    // to the questions this policy asks. Comparing them would report a decision the agent made
+    // as one the operator made. `!== true` rather than `=== false`: a custom `AtxVerifier` — a
+    // published interface anyone may implement — that omits the field must not read as signed.
+    if (ctx.signedCapabilities !== true) {
+      return {
+        allowed: false,
+        binding,
+        reason:
+          'ATX does not cover capabilities or scan summary under its signature (credential ' +
+          'version 1.0), so the predicates this binding matches on are set by the holder',
+      };
+    }
 
     // Enforced predicates (v1).
     //

--- a/src/broker/grant-policy.ts
+++ b/src/broker/grant-policy.ts
@@ -8,19 +8,47 @@
  * The grammar is federation-aware from v1 so federation lights up later with no grammar
  * change (AAP §7.1). A v1 broker MUST parse the full clause — including the federation-only
  * predicates `issuerChainIncludes` and `jurisdiction` — and MAY treat those as satisfied
- * within its own org, while still enforcing `trustClass`, `minTrustLevel`, `oasbLevel`,
- * mode, scope, and ttl. Default-deny: no matching binding ⇒ denied (AAP §3.4).
+ * within its own org, while still enforcing `trustClass`, `oasbLevel`, mode, scope, and ttl
+ * (AAP-BROKER-PROFILE §7.1). `minTrustLevel` is enforced here as well; it is this build's
+ * addition, not a line of that list. Default-deny: no matching binding ⇒ denied (AAP §3.4).
+ *
+ * SCOPE OF WHAT THIS FILE CAN PROMISE. Two of the three predicates it enforces —
+ * `trustClass` (from `ctx.capabilities`) and `oasbLevel` (from `ctx.scanSummary.oasbLevel`)
+ * — are NOT covered by the ATX signature on credential version 1.0. `@opena2a/atx-verify`
+ * publishes `ResolutionContext.signedCapabilities` precisely so a caller can refuse such a
+ * credential, and this build does not yet read it. So these predicates are enforced against
+ * an OPERATOR's configuration mistakes, and against a HOLDER only on a v1.1 credential.
+ * Until the `signedCapabilities` gate lands, no surface may say this build "enforces" an
+ * OASB level presented by an agent.
  */
 
 import type { ResolutionContext } from '@opena2a/atx-verify' with { 'resolution-mode': 'import' };
-import type { ResourceBinding } from './cpi/types';
+import type { CpiMode, ResourceBinding } from './cpi/types';
+import { isGrantRef } from '../grant';
+import { nearestMatch } from '../near-miss';
 
 export interface GrantMatch {
-  /** Trust class (capability) the ATX must carry, e.g. "orders:read". Enforced in v1. */
+  /**
+   * Trust class (capability) the ATX must carry, e.g. "orders:read".
+   *
+   * Compared in v1, but read from `capabilities`, which the ATX v1.0 signature does NOT cover.
+   * On a v1.0 credential the holder can add this capability after signing and the credential
+   * still verifies, so against a holder this predicate binds only on v1.1. See the file header.
+   */
   trustClass: string;
-  /** Minimum ATX trust level. Enforced in v1. */
+  /**
+   * Minimum ATX trust level. Enforced in v1, and `trustLevel` IS covered by the signature on
+   * both credential versions - the one predicate here a holder cannot rewrite.
+   */
   minTrustLevel?: number;
-  /** Minimum OASB level from the ATX scan summary, e.g. ">=L2". Enforced in v1. */
+  /**
+   * Minimum OASB level from the ATX scan summary, e.g. ">=L2".
+   *
+   * Compared in v1, but read from `scanSummary.oasbLevel`, which the ATX v1.0 signature does
+   * NOT cover. On a v1.0 credential the holder sets their own level after signing, so against a
+   * holder this predicate binds only on v1.1. It does bind an operator's configuration: a level
+   * this build cannot rank is refused at load rather than loading as no floor.
+   */
   oasbLevel?: string;
   /** Federation: issuer chain must include a node in this partner set. v1: parsed, in-org satisfied. */
   issuerChainIncludes?: { partnersSet: string };
@@ -42,13 +70,94 @@ export interface GrantEvaluation {
   reason: string;
 }
 
-const OASB_RANK: Record<string, number> = { L1: 1, L2: 2, L3: 3 };
+/**
+ * The OASB levels this build can ORDER, and therefore the only ones it can treat as a floor.
+ *
+ * A `Map`, not an object literal, and the difference is not stylistic. `OASB_RANK` is indexed
+ * by a string that arrives on the wire inside the agent's own credential. As an object literal,
+ * `OASB_RANK["constructor"]` resolved up the prototype chain to `Object.prototype.constructor`
+ * — a function, so neither `null` nor `undefined`, so the `?? 0` that was meant to catch an
+ * unknown level never fired, and `function < 3` is `false`, so the deny branch never ran.
+ * Measured against a `>=L3` floor: `constructor`, `__proto__`, `toString` and `valueOf` were all
+ * ALLOWED while `L1` and an absent level were correctly denied. A `Map` has no prototype keys,
+ * so `.get()` returns `undefined` for every string that is not a level.
+ *
+ * The vocabulary is L1-L3, matching AAP-BROKER-PROFILE.md's own glossary ("OASB, Open Agent
+ * Security Benchmark (levels L1-L3)"). That reference is informative, not normative, and it is
+ * the only OASB definition anywhere in the AAP tree. The ATX WIRE schema is wider
+ * (`^L[0-9]$`) and deliberately does not govern here: what an operator may write as a floor and
+ * what an agent may present are different populations, and binding the policy vocabulary to
+ * what can arrive is the category error. A level outside this set is unrankable, and unrankable
+ * is refused on the policy side and denied on the wire side — never silently treated as zero.
+ */
+const OASB_RANK: ReadonlyMap<string, number> = new Map([
+  ['L1', 1],
+  ['L2', 2],
+  ['L3', 3],
+]);
+
+/** The three keys a grant binding may carry, mirroring `GrantBinding`. */
+const KNOWN_BINDING_KEYS = new Set(['grant', 'match', 'resolve']);
+
+/**
+ * The five predicates a `match` clause may carry, mirroring `GrantMatch`.
+ *
+ * A clause carrying anything else is REFUSED, not ignored. This is the same decision
+ * `policy.ts` makes for `PolicyRule` at four nesting levels, and it is here for the same
+ * measured reason: a misspelled predicate (`oasbLevl`, `minTrustLvl`) leaves the field
+ * `undefined`, so the enforcement branch that reads it never runs, and the binding loads as
+ * the WIDER rule the operator did not write — while `size` still counts it loaded.
+ */
+const KNOWN_MATCH_KEYS = new Set([
+  'trustClass',
+  'minTrustLevel',
+  'oasbLevel',
+  'issuerChainIncludes',
+  'jurisdiction',
+]);
+
+/** The five keys an operator may author on a `resolve` clause. See `OVERWRITTEN_RESOLVE_KEYS`. */
+const KNOWN_RESOLVE_KEYS = new Set(['mode', 'providerId', 'scope', 'audience', 'ttlSeconds']);
+
+/**
+ * Keys `ResourceBinding` declares but an operator must not author, with the reason.
+ *
+ * `resolve.trustClass` is injected by the resolver from the matched clause
+ * (`grant-resolver.ts` spreads `{ ...binding.resolve, trustClass: binding.match.trustClass }`),
+ * so a value written here is silently discarded — the `scopeCheck` shape, where a field the
+ * operator wrote had no effect while every surface reported the binding loaded.
+ */
+const OVERWRITTEN_RESOLVE_KEYS = new Map<string, string>([
+  [
+    'trustClass',
+    'resolve.trustClass is set by the broker from the matched clause\'s match.trustClass, so a ' +
+    'value written here is discarded. Remove it; the trust class the assertion carries is the ' +
+    'one in match.trustClass.',
+  ],
+]);
+
+/** The three CPI modes, mirroring `CpiMode` in ./cpi/types. */
+const CPI_MODES = new Set<string>(['retrieve', 'assume', 'exchange']);
 
 export class GrantPolicy {
   private readonly bindings: GrantBinding[];
 
-  constructor(bindings: GrantBinding[] = []) {
-    this.bindings = bindings;
+  /**
+   * Load grant bindings. Every binding is validated here and REFUSED if this build cannot
+   * apply it exactly as written.
+   *
+   * The constructor is the only write path to `this.bindings` and must stay the only one.
+   * When a grant-binding file loader lands, it parses the file and calls this constructor; it
+   * does not get its own accept-set. Two load paths that decide the same requests with two
+   * accept-sets is not a defect to fix once, it is a defect generator — every constraint added
+   * to one of them later applies to one caller and not the other.
+   *
+   * Each binding is RECONSTRUCTED rather than stored by reference, so a caller that mutates its
+   * own object after this returns cannot alter a loaded policy from outside the class.
+   */
+  constructor(bindings: readonly unknown[] = []) {
+    const seen = new Set<string>();
+    this.bindings = bindings.map((b) => validateGrantBinding(b, seen));
   }
 
   get size(): number {
@@ -68,30 +177,77 @@ export class GrantPolicy {
     const m = binding.match;
 
     // Enforced predicates (v1).
+    //
+    // The context is derived from the agent's credential, so each field is checked for the
+    // SHAPE the comparison needs before the comparison runs. A context that cannot be compared
+    // denies: the alternative is a raw TypeError thrown from inside the decision function, or a
+    // comparison against a non-number that is silently `false` and therefore never denies.
+    if (!Array.isArray(ctx.capabilities)) {
+      return { allowed: false, binding, reason: 'ATX carries no capability list' };
+    }
     if (!ctx.capabilities.includes(m.trustClass)) {
       return { allowed: false, binding, reason: `ATX lacks trust class "${m.trustClass}"` };
     }
-    if (m.minTrustLevel !== undefined && ctx.trustLevel < m.minTrustLevel) {
-      return {
-        allowed: false,
-        binding,
-        reason: `trust level ${ctx.trustLevel} below minimum ${m.minTrustLevel}`,
-      };
+    if (m.minTrustLevel !== undefined) {
+      if (typeof ctx.trustLevel !== 'number' || !Number.isFinite(ctx.trustLevel)) {
+        return {
+          allowed: false,
+          binding,
+          reason: `ATX trust level is not a number, so it satisfies no minimum (required ${m.minTrustLevel})`,
+        };
+      }
+      if (ctx.trustLevel < m.minTrustLevel) {
+        return {
+          allowed: false,
+          binding,
+          reason: `trust level ${ctx.trustLevel} below minimum ${m.minTrustLevel}`,
+        };
+      }
     }
-    if (m.oasbLevel) {
+    if (m.oasbLevel !== undefined) {
+      // Guaranteed rankable by the load-time refusal; recomputed rather than cached so there is
+      // one definition of what a floor means. `undefined` here would mean the invariant broke,
+      // and the safe reading of a floor we cannot resolve is that nothing satisfies it.
       const required = parseOasbFloor(m.oasbLevel);
-      const have = ctx.oasbLevel ? OASB_RANK[ctx.oasbLevel] ?? 0 : 0;
+      const have = typeof ctx.oasbLevel === 'string' ? OASB_RANK.get(ctx.oasbLevel) : undefined;
+      if (required === undefined) {
+        return {
+          allowed: false,
+          binding,
+          reason: `binding requires ${m.oasbLevel}, which this build cannot rank`,
+        };
+      }
+      // Three distinct reasons, because the single reason this replaced asserted a comparison
+      // that had not run: an unrankable level was reported as "below required", which is a
+      // false statement written into an audit record.
+      if (ctx.oasbLevel === undefined || ctx.oasbLevel === null || ctx.oasbLevel === '') {
+        return {
+          allowed: false,
+          binding,
+          reason: `OASB level absent; binding requires ${m.oasbLevel}`,
+        };
+      }
+      if (have === undefined) {
+        return {
+          allowed: false,
+          binding,
+          reason:
+            `OASB level "${String(ctx.oasbLevel)}" is not one of ${rankableLevels()}, so it ` +
+            `satisfies no floor; binding requires ${m.oasbLevel}`,
+        };
+      }
       if (have < required) {
         return {
           allowed: false,
           binding,
-          reason: `OASB level ${ctx.oasbLevel ?? 'none'} below required ${m.oasbLevel}`,
+          reason: `OASB level ${ctx.oasbLevel} below required ${m.oasbLevel}`,
         };
       }
     }
 
-    // Parsed-but-not-enforced-in-v1 predicates. Presence is validated so a malformed clause
-    // is caught now; evaluation is deferred to v2 (federation) / v3 (jurisdiction).
+    // Parsed-but-not-enforced-in-v1 predicates. The SHAPE of each is validated at load, so a
+    // malformed clause is refused there rather than discovered at request time; evaluation is
+    // deferred to v2 (federation) / v3 (jurisdiction).
     // m.issuerChainIncludes — federation (AAP §7): treated as satisfied within a single org.
     // m.jurisdiction        — residency  (AAP §9): parsed, not enforced.
 
@@ -99,8 +255,252 @@ export class GrantPolicy {
   }
 }
 
-/** Parse an OASB floor like ">=L2" or "L2" to a numeric rank. */
-function parseOasbFloor(spec: string): number {
+/** The levels this build can order, for an error or audit string. */
+function rankableLevels(): string {
+  return [...OASB_RANK.keys()].join(', ');
+}
+
+/**
+ * Parse an OASB floor like ">=L2" or "L2" to a numeric rank.
+ *
+ * Returns `undefined` for a level this build cannot order. It previously returned 0 for that
+ * case, which made the STRICTEST floor an operator could write the one that enforced nothing:
+ * nothing is below 0, so `oasbLevel: "L4"` — or `"l3"`, or `"high"` — granted an agent
+ * presenting no OASB level at all.
+ */
+function parseOasbFloor(spec: string): number | undefined {
   const level = spec.replace(/^>=\s*/, '').trim();
-  return OASB_RANK[level] ?? 0;
+  return OASB_RANK.get(level);
+}
+
+/** A non-empty string, the shape almost every field here needs. */
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === 'string' && v !== '';
+}
+
+/**
+ * Suggest a correction for an unrankable OASB level, and ONLY when it is a pure case difference.
+ *
+ * Deliberately NOT `nearestMatch`. Measured against the rankable set, `nearestMatch` returns
+ * "L1" for "L4", "L0" and "L9" — a Levenshtein tie broken by array order. Telling an operator
+ * who wrote "L4" that they may have meant "L1" talks them into the WEAKEST floor in the
+ * vocabulary while they believe they are fixing a typo. A case difference is the only near miss
+ * where the intended level is unambiguous.
+ */
+function caseOnlyMatch(level: string): string | undefined {
+  for (const known of OASB_RANK.keys()) {
+    if (known.toLowerCase() === level.toLowerCase()) return known;
+  }
+  return undefined;
+}
+
+/** Refuse an object carrying a key this build does not read. */
+function checkKeys(
+  what: string,
+  value: Record<string, unknown>,
+  known: Set<string>,
+  overwritten?: Map<string, string>,
+): void {
+  for (const key of Object.keys(value)) {
+    const reason = overwritten?.get(key);
+    if (reason) {
+      throw new Error(`${what}: ${reason}`);
+    }
+    if (known.has(key)) continue;
+    const near = nearestMatch(key, [...known]);
+    throw new Error(
+      `${what}: unknown field "${key}"${near ? ` (did you mean "${near}"?)` : ''}. ` +
+      `It may carry: ${[...known].join(', ')}. ` +
+      `A field this build does not read is refused rather than ignored, because ignoring ` +
+      `"${key}" would drop whatever it was meant to restrict and load the binding as written ` +
+      `without it.`,
+    );
+  }
+}
+
+/**
+ * Validate one grant binding, or throw naming what is wrong and why refusing beats ignoring.
+ *
+ * Module-private on purpose. Exporting it — or the `KNOWN_*` sets — would create a second
+ * accept-set reachable from outside the module, which is the shape that has already re-opened
+ * closed defects in this package.
+ *
+ * `seen` carries the grant references already loaded in this call, so a duplicate is refused.
+ * `evaluate()` resolves a grant by `find`, so the FIRST binding for a name wins and every later
+ * one is silently dead — including a stricter one written to replace it.
+ */
+function validateGrantBinding(raw: unknown, seen: Set<string>): GrantBinding {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('Grant binding must be an object');
+  }
+  const b = raw as Record<string, unknown>;
+
+  if (!isNonEmptyString(b.grant)) {
+    throw new Error('Grant binding must have a non-empty "grant" string, e.g. "grant://orders-db"');
+  }
+  const label = `Grant binding "${b.grant}"`;
+
+  if (!isGrantRef(b.grant)) {
+    throw new Error(
+      `${label}: not a grant reference. A binding is keyed by "grant://name", where name uses ` +
+      `RFC 3986 unreserved characters only and never carries a backend, host, path, or port. ` +
+      `A binding whose key is not a grant reference can never be matched by a request.`,
+    );
+  }
+  if (seen.has(b.grant)) {
+    throw new Error(
+      `${label}: duplicate binding. A grant resolves to the FIRST binding that names it, so a ` +
+      `second one never applies — including a stricter one written to replace it. Keep one ` +
+      `binding per grant.`,
+    );
+  }
+  seen.add(b.grant);
+
+  checkKeys(label, b, KNOWN_BINDING_KEYS);
+
+  if (!b.match || typeof b.match !== 'object' || Array.isArray(b.match)) {
+    throw new Error(`${label}: match must be an object naming the predicates the ATX must satisfy`);
+  }
+  if (!b.resolve || typeof b.resolve !== 'object' || Array.isArray(b.resolve)) {
+    throw new Error(`${label}: resolve must be an object naming the resource this grant maps to`);
+  }
+
+  const match = validateGrantMatch(label, b.match as Record<string, unknown>);
+  const resolve = validateResourceBinding(label, b.resolve as Record<string, unknown>);
+
+  // Reconstructed, not spread: a shallow copy would leave `match` and `resolve` as the caller's
+  // own objects, so deleting a predicate from one after loading would widen a live policy with
+  // no call into this class.
+  return { grant: b.grant, match, resolve };
+}
+
+function validateGrantMatch(label: string, m: Record<string, unknown>): GrantMatch {
+  checkKeys(`${label}: match`, m, KNOWN_MATCH_KEYS);
+
+  if (!isNonEmptyString(m.trustClass)) {
+    throw new Error(
+      `${label}: match.trustClass must be a non-empty string, e.g. "orders:read". It is the ` +
+      `capability the ATX must carry, and it is also the trust class the broker assertion claims.`,
+    );
+  }
+
+  const out: GrantMatch = { trustClass: m.trustClass };
+
+  if (m.minTrustLevel !== undefined) {
+    // `null`, `NaN` and any non-numeric string pass `!== undefined` and then make the comparison
+    // in `evaluate()` unconditionally false — `4 < null`, `4 < NaN` and `4 < "high"` are all
+    // `false` — so the floor loads and denies nothing. JSON can express `null` and `"high"`.
+    if (typeof m.minTrustLevel !== 'number' || !Number.isInteger(m.minTrustLevel) || m.minTrustLevel < 0) {
+      throw new Error(
+        `${label}: match.minTrustLevel must be a non-negative integer, not ` +
+        `${describe(m.minTrustLevel)}. A value the comparison cannot order is not a low ` +
+        `minimum — it is no minimum, and the binding would grant every trust level.`,
+      );
+    }
+    out.minTrustLevel = m.minTrustLevel;
+  }
+
+  if (m.oasbLevel !== undefined) {
+    if (!isNonEmptyString(m.oasbLevel)) {
+      throw new Error(
+        `${label}: match.oasbLevel must be a non-empty string like ">=L2", not ` +
+        `${describe(m.oasbLevel)}. An empty floor is not a floor everything satisfies — it ` +
+        `removes the check. Omit oasbLevel to require no OASB level.`,
+      );
+    }
+    if (parseOasbFloor(m.oasbLevel) === undefined) {
+      const bare = m.oasbLevel.replace(/^>=\s*/, '').trim();
+      const cased = caseOnlyMatch(bare);
+      throw new Error(
+        `${label}: match.oasbLevel "${m.oasbLevel}" names a level this build cannot rank` +
+        `${cased ? ` (did you mean "${cased}"? levels are case-sensitive)` : ''}. ` +
+        `This build ranks: ${rankableLevels()}. ` +
+        `A floor it cannot rank is refused rather than ignored, because ignoring it would ` +
+        `leave the binding with no OASB floor at all while reporting it loaded.`,
+      );
+    }
+    out.oasbLevel = m.oasbLevel;
+  }
+
+  // Federation predicates. AAP §7.1 requires a v1 broker to PARSE the full clause, so these are
+  // accepted rather than refused — but their shape is validated here, so the docstring's claim
+  // that a malformed clause is caught at load is true rather than aspirational.
+  if (m.issuerChainIncludes !== undefined) {
+    const ici = m.issuerChainIncludes;
+    if (!ici || typeof ici !== 'object' || Array.isArray(ici)) {
+      throw new Error(`${label}: match.issuerChainIncludes must be an object with "partnersSet"`);
+    }
+    const rec = ici as Record<string, unknown>;
+    checkKeys(`${label}: match.issuerChainIncludes`, rec, new Set(['partnersSet']));
+    if (!isNonEmptyString(rec.partnersSet)) {
+      throw new Error(
+        `${label}: match.issuerChainIncludes.partnersSet must be a non-empty string naming the ` +
+        `partner set.`,
+      );
+    }
+    out.issuerChainIncludes = { partnersSet: rec.partnersSet };
+  }
+
+  if (m.jurisdiction !== undefined) {
+    const j = m.jurisdiction;
+    if (!j || typeof j !== 'object' || Array.isArray(j)) {
+      throw new Error(`${label}: match.jurisdiction must be an object with an "in" array`);
+    }
+    const rec = j as Record<string, unknown>;
+    checkKeys(`${label}: match.jurisdiction`, rec, new Set(['in']));
+    if (!Array.isArray(rec.in) || rec.in.length === 0 || !rec.in.every(isNonEmptyString)) {
+      throw new Error(
+        `${label}: match.jurisdiction.in must be a non-empty array of non-empty strings. An ` +
+        `empty list names no jurisdiction, which is not the same as naming every one.`,
+      );
+    }
+    out.jurisdiction = { in: [...rec.in] };
+  }
+
+  return out;
+}
+
+function validateResourceBinding(label: string, r: Record<string, unknown>): ResourceBinding {
+  checkKeys(`${label}: resolve`, r, KNOWN_RESOLVE_KEYS, OVERWRITTEN_RESOLVE_KEYS);
+
+  if (!isNonEmptyString(r.mode) || !CPI_MODES.has(r.mode)) {
+    const near = typeof r.mode === 'string' ? nearestMatch(r.mode, [...CPI_MODES]) : undefined;
+    throw new Error(
+      `${label}: resolve.mode must be one of ${[...CPI_MODES].join(', ')}, not ` +
+      `${describe(r.mode)}${near ? ` (did you mean "${near}"?)` : ''}.`,
+    );
+  }
+  for (const key of ['providerId', 'scope', 'audience'] as const) {
+    if (!isNonEmptyString(r[key])) {
+      throw new Error(`${label}: resolve.${key} must be a non-empty string, not ${describe(r[key])}`);
+    }
+  }
+  // An absent or non-numeric TTL reaches the assertion builder as `nowSeconds + undefined`, which
+  // is NaN, which `JSON.stringify` emits as `"exp": null` — a broker assertion a downstream
+  // verifier may read as carrying no expiry at all.
+  if (typeof r.ttlSeconds !== 'number' || !Number.isInteger(r.ttlSeconds) || r.ttlSeconds <= 0) {
+    throw new Error(
+      `${label}: resolve.ttlSeconds must be a positive integer number of seconds, not ` +
+      `${describe(r.ttlSeconds)}. A TTL this build cannot add to a timestamp mints a credential ` +
+      `whose expiry serialises to null.`,
+    );
+  }
+
+  return {
+    mode: r.mode as CpiMode,
+    providerId: r.providerId as string,
+    scope: r.scope as string,
+    audience: r.audience as string,
+    ttlSeconds: r.ttlSeconds,
+  };
+}
+
+/** Describe a rejected value in an error without printing an object's contents. */
+function describe(v: unknown): string {
+  if (v === null) return 'null';
+  if (v === undefined) return 'undefined';
+  if (typeof v === 'number' && Number.isNaN(v)) return 'NaN';
+  if (typeof v === 'string') return `"${v}"`;
+  if (Array.isArray(v)) return 'an array';
+  return `a ${typeof v}`;
 }

--- a/src/broker/grant-policy.ts
+++ b/src/broker/grant-policy.ts
@@ -224,12 +224,25 @@ export class GrantPolicy {
     if (!Array.isArray(ctx.capabilities)) {
       return { allowed: false, binding, reason: 'ATX carries no capability list' };
     }
-    // Scanned directly rather than via `includes`. `Array.isArray` is true for an Array subclass
-    // and for a Proxy over an array, either of which can override `includes` to answer whatever
-    // it likes; a plain loop comparing string members cannot be redirected that way.
+    // Read by INDEX. `Array.isArray` is true for an Array subclass and for a Proxy over an array,
+    // and both can override `includes` — but a `for…of` is no better, because it consults
+    // `Symbol.iterator`, which is just as overridable. Measured: a subclass whose iterator yields
+    // a class it does not contain is granted by a `for…of` and denied by `includes`, and a Proxy
+    // trapping `includes` is the mirror image. Swapping one for the other moves the hole; an
+    // index read is redirected by neither.
+    //
+    // It is NOT a defence against a Proxy that traps every property read: such an object can lie
+    // about `length` and about each element, and nothing this function does while reading it in
+    // place can prevent that. A caller who supplies a hostile `AtxVerifier` already decides the
+    // verdict, so that is the boundary, not a gap. What this closes is the ordinary object that
+    // merely overrides a method.
     let hasTrustClass = false;
-    for (const cap of ctx.capabilities) {
-      if (typeof cap === 'string' && cap === m.trustClass) { hasTrustClass = true; break; }
+    const capCount = ctx.capabilities.length;
+    for (let i = 0; i < capCount; i += 1) {
+      // No `typeof` guard: `m.trustClass` is a validated non-empty string and `===` is strict,
+      // so a non-string member can never match it. A guard whose removal no test can detect is
+      // not a defence — it is dead code that reads as one.
+      if (ctx.capabilities[i] === m.trustClass) { hasTrustClass = true; break; }
     }
     if (!hasTrustClass) {
       return { allowed: false, binding, reason: `ATX lacks trust class "${m.trustClass}"` };

--- a/src/broker/grant-policy.ts
+++ b/src/broker/grant-policy.ts
@@ -40,8 +40,14 @@ export interface GrantMatch {
    */
   trustClass: string;
   /**
-   * Minimum ATX trust level. `trustLevel` is covered by the signature on both credential
-   * versions — the one predicate here a holder could never have rewritten.
+   * Minimum ATX trust level, as a whole number.
+   *
+   * `trustLevel` is inside the signature on both credential versions, but only its INTEGER part
+   * is: both canonical payloads project it through `Math.trunc` while the resolution context
+   * carries the raw value, so a holder can edit a signed `3` to `3.999999` and it still verifies.
+   * A whole-number floor is immune — truncation preserves the integer part, so the most a holder
+   * can add is just under 1.0, which cannot cross it. A fractional floor is NOT immune, and that
+   * is the second reason one is refused at load.
    */
   minTrustLevel?: number;
   /**
@@ -142,7 +148,7 @@ const OVERWRITTEN_RESOLVE_KEYS = new Map<string, string>([
 const CPI_MODES = new Set<string>(['retrieve', 'assume', 'exchange']);
 
 export class GrantPolicy {
-  private readonly bindings: GrantBinding[];
+  private readonly bindings: readonly GrantBinding[];
 
   /**
    * Load grant bindings. Every binding is validated here and REFUSED if this build cannot
@@ -163,7 +169,11 @@ export class GrantPolicy {
     // so `new Array(3)` — or a trailing elision — produced a policy whose `size` counted three
     // bindings that were never validated, and whose first evaluation threw on `undefined.grant`.
     // Spreading materialises each hole as `undefined`, which the check below already refuses.
-    this.bindings = [...bindings].map((b) => validateGrantBinding(b, seen));
+    // The ARRAY is frozen, not just its elements. Freezing only the elements left `push` open,
+    // and an appended binding never passes `validateGrantBinding` — so an unrankable floor could
+    // reach `evaluate()`, where `parseOasbFloor` returns undefined and `1 < undefined` is false:
+    // the exact fail-open this class exists to close, re-entered through the back of the array.
+    this.bindings = Object.freeze([...bindings].map((b) => validateGrantBinding(b, seen)));
   }
 
   get size(): number {
@@ -175,6 +185,12 @@ export class GrantPolicy {
    * `grantName` is the logical name (without the `grant://` scheme).
    */
   evaluate(grantName: string, ctx: ResolutionContext): GrantEvaluation {
+    // Interpolating a non-string calls its `toString`, which a hostile object can make throw —
+    // from inside the decision function, so a caller's catch decides the outcome. The in-tree
+    // caller always passes a parsed string; a library consumer need not.
+    if (typeof grantName !== 'string') {
+      return { allowed: false, reason: 'grant name is not a string (default deny)' };
+    }
     const target = `grant://${grantName}`;
     const binding = this.bindings.find((b) => b.grant === target);
     if (!binding) {
@@ -208,7 +224,14 @@ export class GrantPolicy {
     if (!Array.isArray(ctx.capabilities)) {
       return { allowed: false, binding, reason: 'ATX carries no capability list' };
     }
-    if (!ctx.capabilities.includes(m.trustClass)) {
+    // Scanned directly rather than via `includes`. `Array.isArray` is true for an Array subclass
+    // and for a Proxy over an array, either of which can override `includes` to answer whatever
+    // it likes; a plain loop comparing string members cannot be redirected that way.
+    let hasTrustClass = false;
+    for (const cap of ctx.capabilities) {
+      if (typeof cap === 'string' && cap === m.trustClass) { hasTrustClass = true; break; }
+    }
+    if (!hasTrustClass) {
       return { allowed: false, binding, reason: `ATX lacks trust class "${m.trustClass}"` };
     }
     if (m.minTrustLevel !== undefined) {
@@ -366,26 +389,30 @@ function validateGrantBinding(raw: unknown, seen: Set<string>): GrantBinding {
   }
   const b = raw as Record<string, unknown>;
 
-  if (!isNonEmptyString(b.grant)) {
+  // Read once. Six reads of `b.grant` meant the reference `isGrantRef` approved, the key `seen`
+  // recorded, and the key finally stored could all be different values when the source defines an
+  // accessor — defeating BOTH the grant-reference check and the duplicate check.
+  const grant = b.grant;
+  if (!isNonEmptyString(grant)) {
     throw new Error('Grant binding must have a non-empty "grant" string, e.g. "grant://orders-db"');
   }
-  const label = `Grant binding "${b.grant}"`;
+  const label = `Grant binding "${grant}"`;
 
-  if (!isGrantRef(b.grant)) {
+  if (!isGrantRef(grant)) {
     throw new Error(
       `${label}: not a grant reference. A binding is keyed by "grant://name", where name uses ` +
       `RFC 3986 unreserved characters only and never carries a backend, host, path, or port. ` +
       `A binding whose key is not a grant reference can never be matched by a request.`,
     );
   }
-  if (seen.has(b.grant)) {
+  if (seen.has(grant)) {
     throw new Error(
       `${label}: duplicate binding. A grant resolves to the FIRST binding that names it, so a ` +
       `second one never applies — including a stricter one written to replace it. Keep one ` +
       `binding per grant.`,
     );
   }
-  seen.add(b.grant);
+  seen.add(grant);
 
   checkKeys(label, b, KNOWN_BINDING_KEYS);
 
@@ -410,20 +437,25 @@ function validateGrantBinding(raw: unknown, seen: Set<string>): GrantBinding {
   // and buys nothing against a determined in-process caller, so this is a footgun guard rather
   // than a security boundary — but the footgun is on the return value of a published method,
   // costs one call to remove, and `GrantEvaluation.binding` gives a consumer no hint it is live.
-  return Object.freeze({ grant: b.grant, match: Object.freeze(match), resolve: Object.freeze(resolve) });
+  return Object.freeze({ grant, match: Object.freeze(match), resolve: Object.freeze(resolve) });
 }
 
 function validateGrantMatch(label: string, m: Record<string, unknown>): GrantMatch {
   checkKeys(`${label}: match`, m, KNOWN_MATCH_KEYS);
 
-  if (!isNonEmptyString(m.trustClass)) {
+  // Read once, like every other field below. Validating `m.trustClass` and then reading it AGAIN
+  // to store it let an accessor load a different class than the one that passed — and this one
+  // also travels: `grant-resolver.ts` copies it into the broker assertion's `trust_class` claim,
+  // so the minted credential would carry a class the operator never wrote.
+  const trustClass = m.trustClass;
+  if (!isNonEmptyString(trustClass)) {
     throw new Error(
       `${label}: match.trustClass must be a non-empty string, e.g. "orders:read". It is the ` +
       `capability the ATX must carry, and it is also the trust class the broker assertion claims.`,
     );
   }
 
-  const out: GrantMatch = { trustClass: m.trustClass };
+  const out: GrantMatch = { trustClass };
 
   // Read ONCE into a local, then validate and store THAT. Reading `m.minTrustLevel` again to
   // store it would validate one value and load another whenever the source object defines an
@@ -438,11 +470,13 @@ function validateGrantMatch(label: string, m: Record<string, unknown>): GrantMat
     // `4 < null`, `4 < NaN` and `4 < "high"` are all `false` — so the floor loads and denies
     // nothing. JSON can express `null` and `"high"`. A negative floor orders correctly but sits
     // below every trust level a verifier emits, so it is a floor that admits everyone.
-    if (typeof minTrustLevel !== 'number' || !Number.isFinite(minTrustLevel) || minTrustLevel < 0) {
+    if (typeof minTrustLevel !== 'number' || !Number.isInteger(minTrustLevel) || minTrustLevel < 0) {
       throw new Error(
-        `${label}: match.minTrustLevel must be a number of zero or more, not ` +
-        `${describe(minTrustLevel)}. A value the comparison cannot order is not a low ` +
-        `minimum — it is no minimum, and the binding would grant every trust level.`,
+        `${label}: match.minTrustLevel must be a whole number of zero or more, not ` +
+        `${describe(minTrustLevel)}. A value the comparison cannot order is not a low minimum — ` +
+        `it is no minimum, and the binding would grant every trust level. A FRACTIONAL floor is ` +
+        `refused for a second reason: only the integer part of trustLevel is inside the ATX ` +
+        `signature, so a holder can raise a signed 3 to 3.999999 and still verify.`,
       );
     }
     out.minTrustLevel = minTrustLevel;
@@ -487,7 +521,7 @@ function validateGrantMatch(label: string, m: Record<string, unknown>): GrantMat
         `partner set.`,
       );
     }
-    out.issuerChainIncludes = { partnersSet: rec.partnersSet };
+    out.issuerChainIncludes = Object.freeze({ partnersSet: rec.partnersSet });
   }
 
   if (m.jurisdiction !== undefined) {
@@ -503,7 +537,7 @@ function validateGrantMatch(label: string, m: Record<string, unknown>): GrantMat
         `empty list names no jurisdiction, which is not the same as naming every one.`,
       );
     }
-    out.jurisdiction = { in: [...rec.in] };
+    out.jurisdiction = Object.freeze({ in: Object.freeze([...rec.in]) as string[] });
   }
 
   return out;

--- a/src/broker/grant-policy.ts
+++ b/src/broker/grant-policy.ts
@@ -159,7 +159,11 @@ export class GrantPolicy {
    */
   constructor(bindings: readonly unknown[] = []) {
     const seen = new Set<string>();
-    this.bindings = bindings.map((b) => validateGrantBinding(b, seen));
+    // Spread first. `Array.prototype.map` SKIPS holes in a sparse array while `find` does not,
+    // so `new Array(3)` — or a trailing elision — produced a policy whose `size` counted three
+    // bindings that were never validated, and whose first evaluation threw on `undefined.grant`.
+    // Spreading materialises each hole as `undefined`, which the check below already refuses.
+    this.bindings = [...bindings].map((b) => validateGrantBinding(b, seen));
   }
 
   get size(): number {
@@ -224,21 +228,19 @@ export class GrantPolicy {
       }
     }
     if (m.oasbLevel !== undefined) {
-      // Guaranteed rankable by the load-time refusal; recomputed rather than cached so there is
-      // one definition of what a floor means. `undefined` here would mean the invariant broke,
-      // and the safe reading of a floor we cannot resolve is that nothing satisfies it.
-      const required = parseOasbFloor(m.oasbLevel);
+      // Recomputed rather than cached so there is one definition of what a floor means.
+      // Non-null asserted rather than branched: the constructor refuses an unrankable floor, and
+      // it is the only writer to `this.bindings`, so there is no input that reaches this line
+      // with an unrankable `m.oasbLevel`. A defensive branch here would be code no test can
+      // reach, which reads as covered while proving nothing.
+      const required = parseOasbFloor(m.oasbLevel) as number;
       const have = typeof ctx.oasbLevel === 'string' ? OASB_RANK.get(ctx.oasbLevel) : undefined;
-      if (required === undefined) {
-        return {
-          allowed: false,
-          binding,
-          reason: `binding requires ${m.oasbLevel}, which this build cannot rank`,
-        };
-      }
       // Three distinct reasons, because the single reason this replaced asserted a comparison
       // that had not run: an unrankable level was reported as "below required", which is a
       // false statement written into an audit record.
+      // An empty string is ABSENT, not unrankable: it is what an unset template variable
+      // produces, and "you sent nothing" is the more accurate record than "you sent something I
+      // cannot rank". Kept as one predicate so the two branches cannot disagree about it.
       if (ctx.oasbLevel === undefined || ctx.oasbLevel === null || ctx.oasbLevel === '') {
         return {
           allowed: false,
@@ -251,7 +253,17 @@ export class GrantPolicy {
           allowed: false,
           binding,
           reason:
-            `OASB level "${String(ctx.oasbLevel)}" is not one of ${rankableLevels()}, so it ` +
+            // `describe`, never `String()`. This branch is reached precisely when the value is
+            // NOT a string, and `String({ toString: 1 })` throws `TypeError: Cannot convert
+            // object to primitive value` — from inside the decision function, which is what the
+            // comment above says this code exists to avoid. It is reachable on a v1.1 credential
+            // whose signature still verifies: the TBS projects `scanSummary.oasbLevel` through
+            // the verifier's `asString`, which maps every non-string to the empty string, so a
+            // holder can substitute an object post-signing without changing the signed bytes.
+            // The throw cost us the audit record — `policyId` emptied and the reason became
+            // "resolution error", so an agent could make its own denial unattributable to the
+            // binding it violated.
+            `OASB level ${describe(ctx.oasbLevel)} is not one of ${rankableLevels()}, so it ` +
             `satisfies no floor; binding requires ${m.oasbLevel}`,
         };
       }
@@ -390,7 +402,15 @@ function validateGrantBinding(raw: unknown, seen: Set<string>): GrantBinding {
   // Reconstructed, not spread: a shallow copy would leave `match` and `resolve` as the caller's
   // own objects, so deleting a predicate from one after loading would widen a live policy with
   // no call into this class.
-  return { grant: b.grant, match, resolve };
+  //
+  // Frozen because `evaluate()` returns the matched binding, and that is the same object the
+  // class decides on. Measured before freezing: a caller took the `binding` off a DENIED
+  // evaluation, deleted `match.oasbLevel` and `match.minTrustLevel` from it, and the next
+  // evaluation of the same low-trust agent returned allowed. `private` is a compile-time marker
+  // and buys nothing against a determined in-process caller, so this is a footgun guard rather
+  // than a security boundary — but the footgun is on the return value of a published method,
+  // costs one call to remove, and `GrantEvaluation.binding` gives a consumer no hint it is live.
+  return Object.freeze({ grant: b.grant, match: Object.freeze(match), resolve: Object.freeze(resolve) });
 }
 
 function validateGrantMatch(label: string, m: Record<string, unknown>): GrantMatch {
@@ -405,40 +425,50 @@ function validateGrantMatch(label: string, m: Record<string, unknown>): GrantMat
 
   const out: GrantMatch = { trustClass: m.trustClass };
 
-  if (m.minTrustLevel !== undefined) {
-    // `null`, `NaN` and any non-numeric string pass `!== undefined` and then make the comparison
-    // in `evaluate()` unconditionally false — `4 < null`, `4 < NaN` and `4 < "high"` are all
-    // `false` — so the floor loads and denies nothing. JSON can express `null` and `"high"`.
-    if (typeof m.minTrustLevel !== 'number' || !Number.isInteger(m.minTrustLevel) || m.minTrustLevel < 0) {
+  // Read ONCE into a local, then validate and store THAT. Reading `m.minTrustLevel` again to
+  // store it would validate one value and load another whenever the source object defines an
+  // accessor rather than a data property: measured, a getter returning 9 four times and then
+  // `NaN` passed validation and loaded `NaN`, which orders below nothing and grants every trust
+  // level. Not reachable from JSON, but the constructor is written for a config loader that does
+  // not exist yet, and "the field is read twice" is not a property a future caller can see.
+  const minTrustLevel = m.minTrustLevel;
+  if (minTrustLevel !== undefined) {
+    // Two distinct failures, refused together. `null`, `NaN` and any non-numeric string pass
+    // `!== undefined` and then make the comparison in `evaluate()` unconditionally false —
+    // `4 < null`, `4 < NaN` and `4 < "high"` are all `false` — so the floor loads and denies
+    // nothing. JSON can express `null` and `"high"`. A negative floor orders correctly but sits
+    // below every trust level a verifier emits, so it is a floor that admits everyone.
+    if (typeof minTrustLevel !== 'number' || !Number.isFinite(minTrustLevel) || minTrustLevel < 0) {
       throw new Error(
-        `${label}: match.minTrustLevel must be a non-negative integer, not ` +
-        `${describe(m.minTrustLevel)}. A value the comparison cannot order is not a low ` +
+        `${label}: match.minTrustLevel must be a number of zero or more, not ` +
+        `${describe(minTrustLevel)}. A value the comparison cannot order is not a low ` +
         `minimum — it is no minimum, and the binding would grant every trust level.`,
       );
     }
-    out.minTrustLevel = m.minTrustLevel;
+    out.minTrustLevel = minTrustLevel;
   }
 
-  if (m.oasbLevel !== undefined) {
-    if (!isNonEmptyString(m.oasbLevel)) {
+  const oasbLevel = m.oasbLevel; // Read once. See the note on minTrustLevel above.
+  if (oasbLevel !== undefined) {
+    if (!isNonEmptyString(oasbLevel)) {
       throw new Error(
         `${label}: match.oasbLevel must be a non-empty string like ">=L2", not ` +
-        `${describe(m.oasbLevel)}. An empty floor is not a floor everything satisfies — it ` +
+        `${describe(oasbLevel)}. An empty floor is not a floor everything satisfies — it ` +
         `removes the check. Omit oasbLevel to require no OASB level.`,
       );
     }
-    if (parseOasbFloor(m.oasbLevel) === undefined) {
-      const bare = m.oasbLevel.replace(/^>=\s*/, '').trim();
+    if (parseOasbFloor(oasbLevel) === undefined) {
+      const bare = oasbLevel.replace(/^>=\s*/, '').trim();
       const cased = caseOnlyMatch(bare);
       throw new Error(
-        `${label}: match.oasbLevel "${m.oasbLevel}" names a level this build cannot rank` +
+        `${label}: match.oasbLevel "${oasbLevel}" names a level this build cannot rank` +
         `${cased ? ` (did you mean "${cased}"? levels are case-sensitive)` : ''}. ` +
         `This build ranks: ${rankableLevels()}. ` +
         `A floor it cannot rank is refused rather than ignored, because ignoring it would ` +
         `leave the binding with no OASB floor at all while reporting it loaded.`,
       );
     }
-    out.oasbLevel = m.oasbLevel;
+    out.oasbLevel = oasbLevel;
   }
 
   // Federation predicates. AAP §7.1 requires a v1 broker to PARSE the full clause, so these are
@@ -482,35 +512,43 @@ function validateGrantMatch(label: string, m: Record<string, unknown>): GrantMat
 function validateResourceBinding(label: string, r: Record<string, unknown>): ResourceBinding {
   checkKeys(`${label}: resolve`, r, KNOWN_RESOLVE_KEYS, OVERWRITTEN_RESOLVE_KEYS);
 
-  if (!isNonEmptyString(r.mode) || !CPI_MODES.has(r.mode)) {
-    const near = typeof r.mode === 'string' ? nearestMatch(r.mode, [...CPI_MODES]) : undefined;
+  const mode = r.mode;
+  if (!isNonEmptyString(mode) || !CPI_MODES.has(mode)) {
+    const near = typeof mode === 'string' ? nearestMatch(mode, [...CPI_MODES]) : undefined;
     throw new Error(
       `${label}: resolve.mode must be one of ${[...CPI_MODES].join(', ')}, not ` +
-      `${describe(r.mode)}${near ? ` (did you mean "${near}"?)` : ''}.`,
+      `${describe(mode)}${near ? ` (did you mean "${near}"?)` : ''}.`,
     );
   }
-  for (const key of ['providerId', 'scope', 'audience'] as const) {
-    if (!isNonEmptyString(r[key])) {
-      throw new Error(`${label}: resolve.${key} must be a non-empty string, not ${describe(r[key])}`);
+  const [providerId, scope, audience] = (['providerId', 'scope', 'audience'] as const).map((key) => {
+    const value = r[key];
+    if (!isNonEmptyString(value)) {
+      throw new Error(`${label}: resolve.${key} must be a non-empty string, not ${describe(value)}`);
     }
-  }
+    return value;
+  });
+  // Read once. See the note on minTrustLevel in validateGrantMatch.
+  //
   // An absent or non-numeric TTL reaches the assertion builder as `nowSeconds + undefined`, which
   // is NaN, which `JSON.stringify` emits as `"exp": null` — a broker assertion a downstream
-  // verifier may read as carrying no expiry at all.
-  if (typeof r.ttlSeconds !== 'number' || !Number.isInteger(r.ttlSeconds) || r.ttlSeconds <= 0) {
+  // verifier may read as carrying no expiry at all. An integer is required separately from that:
+  // `exp` is a NumericDate (RFC 7519 §2), so a fractional TTL mints a claim whose type the spec
+  // does not admit, and a non-positive one mints a credential already expired at issue.
+  const ttlSeconds = r.ttlSeconds;
+  if (typeof ttlSeconds !== 'number' || !Number.isInteger(ttlSeconds) || ttlSeconds <= 0) {
     throw new Error(
-      `${label}: resolve.ttlSeconds must be a positive integer number of seconds, not ` +
-      `${describe(r.ttlSeconds)}. A TTL this build cannot add to a timestamp mints a credential ` +
-      `whose expiry serialises to null.`,
+      `${label}: resolve.ttlSeconds must be a whole number of seconds greater than zero, not ` +
+      `${describe(ttlSeconds)}. A TTL this build cannot add to a timestamp mints a credential ` +
+      `whose expiry serialises to null, and \`exp\` is a whole number of seconds (RFC 7519 §2).`,
     );
   }
 
   return {
-    mode: r.mode as CpiMode,
-    providerId: r.providerId as string,
-    scope: r.scope as string,
-    audience: r.audience as string,
-    ttlSeconds: r.ttlSeconds,
+    mode: mode as CpiMode,
+    providerId: providerId as string,
+    scope: scope as string,
+    audience: audience as string,
+    ttlSeconds,
   };
 }
 


### PR DESCRIPTION
A grant binding that cannot be applied as written is now refused when the policy loads, and a
credential whose signature does not cover the fields a binding matches on is denied.

## What was wrong

`GrantPolicy` accepted every binding handed to it and compared predicates against fields it had no
reason to trust.

**An `oasbLevel` outside `{L1, L2, L3}` required rank 0.** Nothing is below 0, so the strictest
floor an operator could write was the one that admitted an agent presenting no OASB level at all.
`"L4"`, `"l3"`, `"high"`, `"none"`, `"> L2"`, `"L2+"` and `""` all behaved this way, as did a
misspelled key such as `oasbLevl`, which left the field undefined so the branch reading it never
ran. `minTrustLevel: null` had the same shape: `4 < null` is `false`, so the floor loaded and denied
nothing.

**`OASB_RANK` was an object literal indexed by a string from the agent's own credential.** A lookup
of `constructor`, `__proto__`, `toString` or `valueOf` resolved up the prototype chain to a
function, so the `?? 0` meant to catch an unknown level never fired and `function < 3` is `false`.
Measured against a `>=L3` floor: ten of ten prototype keys were allowed, while `L1`, `L2`, an absent
level, `"L4"` and `""` were all correctly denied.

**Two of the three predicates read fields the ATX v1.0 signature does not cover.** `trustClass`
reads `capabilities` and `oasbLevel` reads `scanSummary.oasbLevel`, and `@opena2a/atx-verify`
documents that a v1.0 holder can edit both after signing without invalidating the signature. It
publishes `ResolutionContext.signedCapabilities` for exactly this decision. Nothing in this package
read it. Proved end to end with a real Ed25519 key: a holder raising their own level from L2 to L3
after signing was granted by a `>=L3` binding, and a capability that was never issued was accepted
— while the control, tampering with the signature-covered `trustLevel`, correctly failed
verification, and every equivalent tamper on a v1.1 credential also failed.

## What changed

Validation now happens in the constructor, which is the only write path to the bindings, so a
future config loader inherits one accept-set instead of creating a second. It covers the whole
binding — `match`, `resolve`, and the duplicate-grant case — because the unvalidated half of a
partly validated authorization unit is where the problem moves to rather than disappears: an
unvalidated `ttlSeconds` mints an assertion whose `exp` serialises to `null`.

`OASB_RANK` is a `Map` on both sides. The accepted vocabulary is L1-L3, matching the AAP broker
profile's own glossary, and a level outside it is refused when an operator writes it and denied when
an agent presents it — never treated as zero. Case is not normalised in either direction: on the
operator side that would guess which security bar they meant, and on the wire side it would widen
what an agent can present. The near-miss hint is restricted to a pure case difference, because
`nearestMatch` returns `L1` for `L4`, `L0` and `L9` on a tie broken by array order, which would
point an operator at the weakest floor in the vocabulary while they believed they were correcting a
typo.

Denial reasons now distinguish an absent level, an unrankable one, and one genuinely below the
floor. The single string they replace reported an unrankable level as "below required" — a
comparison that never happened, written into an audit record.

`evaluate()` requires `signedCapabilities`, before any predicate that reads a field the signature
does not cover. The ordering is asserted rather than incidental: placed later the verdict is
identical, but the record then reads "ATX lacks trust class", a conclusion drawn from the very list
the check exists to distrust.

## Scope, stated precisely

This binds an operator's configuration in every case. Against a credential **holder** it binds only
on v1.1, and on v1.0 it now refuses rather than comparing. No surface should describe an OASB level
presented by an agent as one this build imposes on a v1.0 credential — the refusal is the guarantee,
not the comparison.

The published type declarations are corrected in the same change. `dist/broker/grant-policy.d.ts`
described `trustClass`, `minTrustLevel` and `oasbLevel` as "Enforced in v1.", and drew the
not-enforced line explicitly for `jurisdiction` — so it was specific, and two of those three were
wrong. A declaration is what a consumer reads at the moment they use a field.

## A fourth commit, after adversarial review

The review found that the third commit had legalised a privilege escalation, and that a comment it
added asserted the opposite of what is true.

Both canonical ATX payloads project `trustLevel` through `Math.trunc` while the resolution context
carries the raw value, so the fractional digits of a signed integer sit outside the signature on
every credential version. Measured with a real key against a `>=3.5` floor: a credential signed at
`3` and edited to `3.999999` afterwards still verifies and is served, while the honest `3` is
denied. An integer rewrite to `4` fails verification, and against a floor of `4` the same forgery is
denied — so the gap is inert while floors are whole numbers, because truncation preserves the
integer part and the most a holder can add is just under 1.0.

Relaxing `minTrustLevel` to any finite number is what made it reachable. That is reverted; the
field documentation now states what the signature actually covers; and the test that blessed
fractional floors, on the reasoning that refusing them was "a break with no security argument", now
asserts the refusal and names the reason.

The same pass found four more sites of the read-once class the third commit claimed to have swept:
`match.trustClass` (which travels into the assertion's `trust_class` claim), the binding's own
`grant` key (read six times, so the reference check, the duplicate check and the stored key could
each see a different value), the bindings **array** — frozen only in its elements, so `push`
admitted a binding that never passed validation — and the nested federation predicates. Two
lower-severity items closed with them: `evaluate()` interpolated the grant name, so a hostile
`toString` threw from inside the decision function, and the capability check used
`Array.prototype.includes`, which an `Array` subclass or a `Proxy` can override while still
satisfying `Array.isArray`.

## A fifth commit, after an independent re-review

The fourth commit replaced `Array.prototype.includes` with a `for…of` to stop a capability list
that lies about its contents. `for…of` consults `Symbol.iterator`, which an `Array` subclass or a
`Proxy` overrides exactly as easily as `includes` — so it swapped which lie works, and two of the
four shapes went from denied in the released build to served. The comment claimed a loop "cannot be
redirected that way", and the only test covered the direction the change survives because it no
longer calls `includes`.

Reading by index is redirected by neither, and all four shapes are now covered. A `Proxy` that
traps every property read is still not defended against — it can lie about `length` and about each
element, and nothing that reads it in place can prevent that. That is asserted as a known limit
rather than left as a surprise.

## Compatibility

`GrantPolicy` is a published value export and the constructor now throws on a binding it cannot
apply, which is observable to a library consumer. There is no in-package construction site outside
tests. `minTrustLevel` requires a whole number. A fractional floor orders perfectly well, which is why it
was briefly allowed, but only the integer part of `trustLevel` is inside the signature, so a
fractional floor is crossable by an edit the signature does not cover. `ttlSeconds` is likewise a
whole number, because `exp` is a whole number of seconds (RFC 7519 §2).

## Verification

Suite 1560 → 1833. Of the new assertions, 76 of 107 fail against the pre-change commit, and the 31
that pass there are exactly the absence-direction controls — well-formed bindings still load, ranked
floors still discriminate, existing denials still deny. Thirty-five targeted mutations, each removing one
guard, are all caught by the test written for that guard.

Three of those mutations survived a first pass and one went inert when a later change moved its
anchor; both were visible only because the harness distinguishes a surviving mutant from one that
never applied. The AAP conformance test added here was initially vacuous — its v1.0 fixture was
signed with a key the server did not trust, so the asserted 403 came from signature verification
and would have passed against a build with no gate at all. It now signs with the trusted key,
asserts the credential verifies before asserting the refusal, and pairs it with the same agent on
v1.1 receiving 200.


One finding is recorded and deliberately not fixed here: `resolve.ttlSeconds` has a lower bound but
no upper one, so `1e21` loads and mints an `exp` far enough out that a verifier reads it as no
expiry. The released build validates `ttlSeconds` not at all, so this is strictly better than what
ships today; a maximum credential lifetime is a policy number that wants a defensible basis, and it
interacts with the unclamped provider `expires_in` on the exchange path.

Separately, the `Math.trunc` projection is worth raising with `@opena2a/atx-verify`: the fractional
bits of a signed numeric field are attacker-controlled on every credential version, and this change
only makes one consumer immune to it.


## What this PR does not fix, and what bounds it

An independent re-review of the whole branch found a defect **upstream in `@opena2a/atx-verify`**
that bounds what the `signedCapabilities` gate here can promise. Key eligibility is seeded from the
credential's own claimed `issuerDid` and `issuerChain` **before** the signature is checked, so on
v1.1 any key already in the anchor set can mint a credential under any trusted issuer by naming its
own DID in the chain. Reproduced with a control:

```
CONTROL  other-issuer key, issuerChain=[]            REJECTED  SIGNATURE_INVALID
ATTACK   other-issuer key, issuerChain=[own-did]     VERIFIES  trustLevel=9, caps=["admin:*"],
                                                               signedCapabilities=true
```

That yields attacker-chosen values for every predicate this file enforces, plus the flag that is
supposed to make them trustworthy. It is pre-existing, it is not caused by this change, and this
change does not fix it — but the gate added here is bypassable through it until it is. Filed
separately; the precondition is a multi-issuer anchor set, and a single-key anchor set is unaffected.

Also filed and deliberately not fixed here: `resolve.ttlSeconds` has a lower bound but no upper one.
