### PR TITLE
The review's primary API request used a version the server rejects, so every review ran the fallback

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -215,10 +215,11 @@ jobs:
             -X POST "https://api.anthropic.com/v1/messages" \
             -H "Content-Type: application/json" \
             -H "x-api-key: ${ANTHROPIC_API_KEY}" \
-            -H "anthropic-version: 2025-04-15" \
+            -H "anthropic-version: 2023-06-01" \
             -d @/tmp/request.json)
 
           echo "API response HTTP code: $HTTP_CODE"
+          echo "primary" > /tmp/review_path.txt
 
           # Extract response text (skip thinking blocks)
           REVIEW_TEXT=""
@@ -229,6 +230,7 @@ jobs:
           # Fallback: retry without extended thinking if first attempt failed
           if [ -z "$REVIEW_TEXT" ]; then
             echo "First attempt failed (HTTP $HTTP_CODE), retrying without extended thinking..."
+            echo "fallback" > /tmp/review_path.txt
 
             jq -n \
               --rawfile system /tmp/system_prompt.txt \
@@ -250,7 +252,7 @@ jobs:
             echo "Fallback API response HTTP code: $HTTP_CODE"
 
             if [ "$HTTP_CODE" = "200" ]; then
-              REVIEW_TEXT=$(jq -r '.content[0].text // empty' /tmp/api_response.json)
+              REVIEW_TEXT=$(jq -r '[.content[] | select(.type == "text") | .text] | join("\n") // empty' /tmp/api_response.json)
             fi
           fi
 
@@ -315,7 +317,12 @@ jobs:
             cat /tmp/review_body.txt
             echo ""
             echo "---"
-            echo "*Reviewed ${FILE_COUNT} files changed (${DIFF_SIZE} bytes)*"
+            REVIEW_PATH=$(cat /tmp/review_path.txt 2>/dev/null || echo "unknown")
+            if [ "$REVIEW_PATH" = "fallback" ]; then
+              echo "*Reviewed ${FILE_COUNT} files changed (${DIFF_SIZE} bytes) — produced by the FALLBACK request, without extended thinking. The primary request failed; see the run log.*"
+            else
+              echo "*Reviewed ${FILE_COUNT} files changed (${DIFF_SIZE} bytes)*"
+            fi
           } > /tmp/full_review.txt
 
           BODY=$(cat /tmp/full_review.txt)


### PR DESCRIPTION
Closes #152.

The review's primary API request has never succeeded. Every automated review this repo has ever produced came from the fallback, and nothing said so.

`pr-review.yml` sent `anthropic-version: 2025-04-15` on the first request. That is not a valid version, so the call returned 400 on every run, `REVIEW_TEXT` came back empty, and the workflow took its documented retry:

```
API response HTTP code: 400
First attempt failed (HTTP 400), retrying without extended thinking...
Fallback API response HTTP code: 200
```

Probed directly, both ways:

```
anthropic-version: 2025-04-15   HTTP 400  "2025-04-15" is not a valid version
anthropic-version: 2023-06-01   HTTP 200
```

The same fallback line appears in `hackmyagent` and `nanomind` runs, so this is the shared workflow rather than one repo's misconfiguration. Older runs elsewhere are past log retention.

## What it cost

The two requests are not equivalent, which is the whole reason the primary exists:

| | primary (never ran) | fallback (always ran) |
|---|---|---|
| `max_tokens` | 16000 | 8192 |
| extended thinking | enabled, 10000 budget | none |

Every review that has gated a merge here ran without extended thinking and at half the output budget. The reviews were real and the verdicts were real — but the configuration this file describes has never been the one that ran.

## The three changes

1. **`anthropic-version` on the primary request → `2023-06-01`**, the value the fallback already uses successfully on every run. This is the defect.

2. **The fallback's response extraction moves to the primary's filtered form.** `.content[0].text` is correct only while nothing returns a leading `thinking` block. Measured against a live response with thinking enabled, that field is `null` — which would empty `REVIEW_TEXT` and block every pull request in the repo. Fixing the header without this would move that landmine rather than remove it, because the primary path is now the one that runs.

3. **The posted review names the fallback when the fallback produced it.** A retry that fires on 100% of runs is indistinguishable from a primary that works, which is exactly how this survived unnoticed across eight repositories. The run log already said so; nobody reads a green run's log.

## Verification

The corrected primary request was POSTed to the live API **before this change was written**, using the workflow's exact request shape and this repo's real over-cap diff (PR #149, 149,315 bytes):

```
HTTP 200
content block types : ['thinking', 'text']
first line          : VERDICT-<nonce>: APPROVE
parses as a verdict : YES
usage               : 47,377 input tokens, 1,117 thinking tokens
fallback .content[0].text would be: null
```

That last line is change 2's justification, measured rather than reasoned.

Also checked: the primary path's extraction has never executed in production, so this PR enables a code path that has only ever been exercised by hand — which is why it was exercised by hand first, and why this PR is the end-to-end proof. `pull_request` runs the workflow from the merge ref, so **this PR is reviewed by its own fixed code.** If the check below reports a verdict without a fallback notice in the footer, the fix works.

Suite is unaffected and provably so: no test reads `.github/workflows/pr-review.yml`. Every `.github` reference in `src/**/*.test.ts` is a fixture the test creates in a temp directory, a synthetic path string, or a github.com URL. YAML parses and all four `run` blocks pass `bash -n`.

Scoped to this file alone, per the `[CHIEF-CISO]` ruling that any `pr-review.yml` change lands in its own PR and never on the PR it unblocks. The 120,000-byte diff cap (#150) is a separate defect and is deliberately **not** touched here.

Noted in passing, not fixed here: two wall-clock assertions (`secret-store` near-miss timing, `init` guard-hook echo/printenv) fail under machine load and pass 5/5 in isolation. Filed separately rather than absorbed into this change.
