### PR TITLE
The near-miss work bound was read off a clock, so it failed under load and passed on the regression

### DIFF
--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -16,7 +16,22 @@ function cleanup(dir: string): void {
   fs.rmSync(dir, { recursive: true, force: true });
 }
 
-describe('init', () => {
+// Every assertion below is about a DECISION the generated hook reaches — block
+// or allow — and none of them is about how fast it reaches it. But each command
+// checked costs a `bash` process, and the hook starts `python3` inside it to
+// parse the tool payload, so a test that checks 26 commands pays for roughly 52
+// process starts. `echo/printenv of a PREFIXED secret variable is blocked`
+// measures 2.8s idle against vitest's 5s default, and it was seen timing out at
+// ~5.8s on a loaded machine. That leaves 1.7x of headroom on a shared laptop,
+// which is not enough, and the failure it produces is a timeout on a security
+// guard test — indistinguishable at a glance from the hook having broken.
+//
+// The commands are the coverage, so thinning them to save time would be paying
+// for speed with the thing the test exists to check. Raise the bound instead:
+// at 30s the slowest test has ~10x headroom, while a genuinely hung `execSync`
+// still fails the run rather than hanging it. This is a timeout, not an
+// assertion — nothing here starts passing because the number went up.
+describe('init', { timeout: 30_000 }, () => {
   let dir: string;
 
   beforeEach(() => { dir = tmpDir(); });

--- a/src/near-miss.ts
+++ b/src/near-miss.ts
@@ -35,6 +35,12 @@ export const OVER = NEAR_MISS_MAX + 1;
  * flow is a degradation path whose trigger a caller sets by growing the store.
  * Not exported from `src/index.ts`; present in the published types only because
  * the package ships `dist/`.
+ *
+ * Being module state, a reader must reset it and read it back without another
+ * test running in between, so the assertions on it need tests to run in order.
+ * That is vitest's default and this repo does not change it. It is also not a
+ * new constraint: forcing `--sequence.concurrent` on `secret-store.test.ts`
+ * fails three tests that predate this counter, alongside the ones reading it.
  */
 let cellsEvaluated = 0;
 

--- a/src/near-miss.ts
+++ b/src/near-miss.ts
@@ -20,6 +20,35 @@ export const NEAR_MISS_MAX = 2;
 export const OVER = NEAR_MISS_MAX + 1;
 
 /**
+ * Table cells evaluated since the last reset, summed across every call.
+ *
+ * The band and the row cutoff below are pure optimisations: they change what
+ * gets computed, never what gets returned. Cost is therefore their ONLY
+ * observable, and reading that cost off a clock measures the machine at least
+ * as much as the code — the assertion this replaced went red on source it could
+ * not have been affected by, while staying green on a build with the band taken
+ * out entirely. This counts the work instead. The count is an exact integer,
+ * identical on every machine.
+ *
+ * @internal Observation only. Nothing outside `*.test.ts` may read it, and no
+ * behaviour depends on its value — a work counter that feeds back into control
+ * flow is a degradation path whose trigger a caller sets by growing the store.
+ * Not exported from `src/index.ts`; present in the published types only because
+ * the package ships `dist/`.
+ */
+let cellsEvaluated = 0;
+
+/** @internal Test observation only — see {@link cellsEvaluated}. */
+export function nearMissCellsEvaluated(): number {
+  return cellsEvaluated;
+}
+
+/** @internal Test observation only — see {@link cellsEvaluated}. */
+export function resetNearMissCellsEvaluated(): void {
+  cellsEvaluated = 0;
+}
+
+/**
  * Case-insensitive edit distance, only ever used to suggest a typo fix.
  * Any result above NEAR_MISS_MAX is returned as OVER, not computed exactly.
  *
@@ -27,15 +56,25 @@ export const OVER = NEAR_MISS_MAX + 1;
  * comparison costs O(n * k) rather than O(n^2) — bounded whether the two names
  * are similar or not.
  *
- * A row-minimum cutoff alone is not enough, and the measurement that suggested
- * it was misleading: it used maximally DIFFERENT names, which exit on the first
- * row. For names sharing a long prefix and differing only near the end — the
- * realistic shape, since stored names look alike — the band around the diagonal
- * stays under the threshold and the full table gets computed. Measured at 5000
- * stored names sharing a 60-char prefix, against 100 unmatched: 7814ms
- * unbounded, 840ms with the cutoff alone, 378ms banded. (The same shape with
- * maximally different names is 33ms — which is why benchmarking that shape hid
- * the problem.)
+ * A row-minimum cutoff alone is not enough. It exits early only when EVERY
+ * reachable cell in a row is already over the threshold, which maximally
+ * different names reach on the third row but names sharing a long prefix never
+ * reach at all — and a long shared prefix is the realistic shape, since stored
+ * secret names look alike. So the two optimisations cover different shapes and
+ * neither substitutes for the other:
+ *
+ *   5000 stored names, 100 requested, MAX_HINTED = 10, cells evaluated:
+ *
+ *                              60-char shared prefix   differing from char 1
+ *     band + cutoff (shipped)             15,603,880                 600,000
+ *     cutoff alone, no band              202,749,440               9,600,000
+ *     band alone, no cutoff                15,700,000              15,700,000
+ *
+ * Read the columns, not the rows: the shared-prefix column is what the BAND
+ * holds down (13x), and the differing-from-char-1 column is the only one that
+ * moves when the CUTOFF goes (26x). Each column is pinned by its own test in
+ * `secret-store.test.ts`; deleting the second as redundant would leave the row
+ * cutoff with no regression test at all.
  */
 export function editDistance(a: string, b: string): number {
   const s = a.toUpperCase();
@@ -52,6 +91,9 @@ export function editDistance(a: string, b: string): number {
     cur[0] = i <= NEAR_MISS_MAX ? i : OVER;
     const lo = Math.max(1, i - NEAR_MISS_MAX);
     const hi = Math.min(t.length, i + NEAR_MISS_MAX);
+    // Derived from lo/hi rather than restated as a constant, so the count
+    // cannot disagree with the loop it measures. Once per ROW, never per cell.
+    cellsEvaluated += hi >= lo ? hi - lo + 1 : 0;
     let rowMin = cur[0];
     for (let j = lo; j <= hi; j++) {
       const v = Math.min(

--- a/src/secret-store.test.ts
+++ b/src/secret-store.test.ts
@@ -320,8 +320,15 @@ describe('near-miss hint work is bounded (CI review finding, measured)', () => {
     for (let i = 0; i < 5000; i++) names.push('A'.repeat(60) + String(i).padStart(4, '0'));
     const requested = requestedLike('A'.repeat(60));
 
+    // The bound is the band's own ceiling, not a round number with room in it:
+    // at most (2 * NEAR_MISS_MAX + 1) = 5 cells per row, at most 64 rows because
+    // of the length cap, over MAX_HINTED * 5000 = 50,000 comparisons. A looser
+    // bound is not free — at 20,000,000 a band widened by a single cell scores
+    // 18.7M and slips through. Written as a literal on purpose: raising
+    // NEAR_MISS_MAX must fail here and be re-measured, not silently re-derive
+    // a wider bound from the value it just changed.
     const cells = await cellsFor(names, requested);
-    expect(cells).toBeLessThan(20_000_000);
+    expect(cells).toBeLessThanOrEqual(5 * 64 * 50_000);
     // Same input, same count — no clock, no tolerance, no flake.
     expect(await cellsFor(names, requested)).toBe(cells);
   });
@@ -338,8 +345,12 @@ describe('near-miss hint work is bounded (CI review finding, measured)', () => {
     }
     const requested = requestedLike('A'.repeat(60));
 
+    // Same reasoning: the cutoff's own ceiling. Every reachable cell is over the
+    // threshold by row 3, and rows 1-3 are 3, 4 and 5 cells wide, so 12 per
+    // comparison over 50,000 of them. Allowing the walk even one row further
+    // scores well above this.
     const cells = await cellsFor(names, requested);
-    expect(cells).toBeLessThan(2_000_000);
+    expect(cells).toBeLessThanOrEqual(12 * 50_000);
     expect(await cellsFor(names, requested)).toBe(cells);
   });
 

--- a/src/secret-store.test.ts
+++ b/src/secret-store.test.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { SecretStore } from './secret-store';
 import { LocalBackend } from './backends/local';
+import { editDistance, nearMissCellsEvaluated, resetNearMissCellsEvaluated } from './near-miss';
 
 describe('SecretStore', () => {
   let tmpDir: string;
@@ -275,20 +276,132 @@ describe('near-miss hint work is bounded (CI review finding, measured)', () => {
     });
   }
 
-  it('stays fast when stored names SHARE A LONG PREFIX', async () => {
-    // This is the shape that matters, and the one an earlier benchmark missed.
-    // Maximally-different names exit on the first row of the table, so they
-    // never exercise the expensive path; names that look alike — which stored
-    // secret names do — keep the band under the threshold the whole way.
-    // Measured: 7814ms unbounded, 840ms with a row cutoff alone, 378ms banded.
+  // These assertions used to read a stopwatch: `expect(Date.now() - started)
+  // .toBeLessThan(1500)` on the shared-prefix workload. Two measurements
+  // retired it.
+  //
+  // It measured the machine rather than the code. The workload takes ~270ms on
+  // an idle laptop; on a busy one it was seen at 1868ms, failing a full suite
+  // run on a branch whose diff could not reach this file. Re-run on an idle
+  // machine it was green 8 times out of 8 — so the failure rate tracks the load,
+  // and no bound stated in milliseconds separates the two.
+  //
+  // And it never had the power it appeared to have. Rebuilt with the band
+  // removed altogether, the same workload came in at 805ms and the assertion
+  // still PASSED — green on the exact regression it was written to catch. A
+  // gate that is red on unchanged code and green on a real regression trains
+  // people to re-run until green, which is how a gate that matters gets ignored.
+  //
+  // The band and the row cutoff change what editDistance computes, never what
+  // it returns, so cost is the only thing that can be asserted about them. So
+  // count the work rather than timing it. The numbers below are exact integers
+  // and are identical on every machine; none of these tests reads a clock.
+
+  /** Cells the store's hint pass evaluates for one workload. */
+  async function cellsFor(names: string[], requested: string[]): Promise<number> {
+    resetNearMissCellsEvaluated();
+    await expect(storeOf(names).loadSecrets(requested)).rejects.toThrow();
+    return nearMissCellsEvaluated();
+  }
+
+  /** 100 requested names, none stored, against a store of `count` names. */
+  function requestedLike(prefix: string) {
+    const out: string[] = [];
+    for (let i = 0; i < 100; i++) out.push(prefix + String(9000 + i).padStart(4, '0'));
+    return out;
+  }
+
+  it('the BAND bounds a store whose names share a long prefix', async () => {
+    // The realistic shape: stored secret names look alike. The row cutoff is no
+    // help here — every row stays under the threshold, so the cutoff never
+    // fires and the whole name is walked. Only the band bounds this.
+    // Measured: 15,603,880 cells banded; 202,749,440 with the band removed.
     const names: string[] = [];
     for (let i = 0; i < 5000; i++) names.push('A'.repeat(60) + String(i).padStart(4, '0'));
-    const requested: string[] = [];
-    for (let i = 0; i < 100; i++) requested.push('A'.repeat(60) + String(9000 + i).padStart(4, '0'));
+    const requested = requestedLike('A'.repeat(60));
 
-    const started = Date.now();
-    await expect(storeOf(names).loadSecrets(requested)).rejects.toThrow();
-    expect(Date.now() - started).toBeLessThan(1500);
+    const cells = await cellsFor(names, requested);
+    expect(cells).toBeLessThan(20_000_000);
+    // Same input, same count — no clock, no tolerance, no flake.
+    expect(await cellsFor(names, requested)).toBe(cells);
+  });
+
+  it('the ROW CUTOFF bounds a store whose names differ from the first character', async () => {
+    // The other shape, and the only one that moves when the cutoff goes: every
+    // reachable cell is over the threshold by the third row, so the walk stops
+    // there instead of running the full name.
+    // Measured: 600,000 cells with the cutoff; 15,700,000 with it removed.
+    const alphabet = 'BCDEFGHIJKLMNOPQRSTUVWXYZ';
+    const names: string[] = [];
+    for (let i = 0; i < 5000; i++) {
+      names.push(alphabet[i % alphabet.length].repeat(60) + String(i).padStart(4, '0'));
+    }
+    const requested = requestedLike('A'.repeat(60));
+
+    const cells = await cellsFor(names, requested);
+    expect(cells).toBeLessThan(2_000_000);
+    expect(await cellsFor(names, requested)).toBe(cells);
+  });
+
+  it('a length gap wider than the threshold builds no table at all', async () => {
+    const names: string[] = [];
+    for (let i = 0; i < 5000; i++) names.push('A'.repeat(50) + String(i).padStart(5, '0'));
+    expect(await cellsFor(names, requestedLike('A'.repeat(60)))).toBe(0);
+  });
+
+  it('a name over the length cap builds no table at all', async () => {
+    const names: string[] = [];
+    for (let i = 0; i < 5000; i++) names.push('A'.repeat(80) + String(i).padStart(4, '0'));
+    expect(await cellsFor(names, requestedLike('A'.repeat(80)))).toBe(0);
+  });
+
+  it('only the first MAX_HINTED unmatched names are given a hint', async () => {
+    // The caller's bound, and the one that multiplies against store size. Every
+    // requested name here has a real near miss stored, so an unbounded caller
+    // would hint all 40.
+    const stored: string[] = [];
+    const requested: string[] = [];
+    for (let i = 0; i < 40; i++) {
+      stored.push(`SERVICE_${String(i).padStart(3, '0')}_TOKEN`);
+      requested.push(`SERVICE_${String(i).padStart(3, '0')}_TOKN`);
+    }
+    let message = '';
+    try {
+      await storeOf(stored).loadSecrets(requested);
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toContain('Did you mean:');
+    expect((message.match(/ -> /g) ?? []).length).toBe(10);
+  });
+
+  it('the counter reports the row the loop actually walked', async () => {
+    // Pins the counter to the loop it measures. Two 5-char names one edit
+    // apart: the band gives rows of 3, 4, 5, 4, 3 cells, so 19. Restating the
+    // increment as a constant — `+= 5` per row, which is the band's WIDEST row
+    // — would report 25 here, and would go on reporting a banded figure for a
+    // loop with the band removed, leaving every bound above green on a
+    // regression. Without this, the seam can be made vacuous by a tidy-up.
+    resetNearMissCellsEvaluated();
+    expect(editDistance('ABCDE', 'ABCDX')).toBe(1);
+    expect(nearMissCellsEvaluated()).toBe(19);
+  });
+
+  it('nothing outside the tests reads the work counter', () => {
+    // The counter is an observation. If production code ever branched on it,
+    // the store's own size would become the trigger for a degraded path.
+    const walk = (dir: string, out: string[] = []): string[] => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(full, out);
+        else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) out.push(full);
+      }
+      return out;
+    };
+    const offenders = walk(__dirname)
+      .filter((f) => path.basename(f) !== 'near-miss.ts')
+      .filter((f) => /cellsEvaluated/.test(fs.readFileSync(f, 'utf-8')));
+    expect(offenders).toEqual([]);
   });
 
   it('CONTROL: a real near miss is still suggested', async () => {


### PR DESCRIPTION
`stays fast when stored names SHARE A LONG PREFIX` asserted `Date.now() - started < 1500`
over a 5000-name store. Two measurements retire it.

**It measured the machine.** The workload takes ~270 ms idle and was seen at 1868 ms on a
busy one, failing a suite run on a branch whose diff could not reach the file. Re-run idle
it was green 8 of 8, so the rate tracks load and no bound stated in milliseconds separates
the two cases.

**It also had no detection power.** Rebuilt with the diagonal band removed the same
workload runs in 805 ms, and with the band and the row cutoff both removed, 791 ms — under
the bound in each case. It passed on the regression it was written to catch.

A gate that is red on unchanged code and green on a real regression trains people to re-run
until green, which is how a gate that matters gets ignored.

## Counting the work instead of timing it

The band and the row cutoff change what `editDistance` computes and never what it returns,
so cost is the only thing assertable about them — but cost can be counted exactly rather
than timed. `cellsEvaluated` sums table cells **once per row**, derived from the loop's own
`lo`/`hi` so it cannot disagree with the loop it measures. Counts are exact integers,
identical on every machine. Measured overhead: -2.1%, i.e. below the noise floor.

The two optimisations cover different shapes and neither substitutes for the other, so each
gets its own bound:

| workload | shipped | band removed | cutoff removed |
|---|---|---|---|
| 60-char shared prefix | 15,603,880 | 202,749,440 | 15,700,000 |
| differing from char 1 | 600,000 | 9,600,000 | 15,700,000 |

Removing the band leaves the second bound green; removing the cutoff leaves the first green.
Both are here for that reason, and the source comment says so, because the previous comment
claimed the opposite and would have led a reader to delete the load-bearing one.

Each bound is the ceiling its own optimisation permits — 5 cells per row over at most 64
rows across 50,000 comparisons, and 12 cells per comparison respectively — not a round
number with slack in it. At a looser 20,000,000 a band widened by a single cell scored
18,714,000 and slipped through. Tight headroom costs nothing here because the measurement
has no run-to-run variance; the margin was only ever hiding regressions.

The length-gap guard, the 64-character cap and the caller-side `MAX_HINTED` cap get bounds
too, and a guard asserts nothing outside the tests reads the counter — a work count feeding
back into control flow would be a degraded path whose trigger a caller sets by growing the
store.

**Mutation-checked: the removed assertion caught 0 of 10 mutants; these catch 10 of 10**,
including one that restates the per-row increment as a constant, which would otherwise
report a bounded figure for an unbounded loop.

## Also: the guard-hook tests had 1.7x of headroom

`echo/printenv of a PREFIXED secret variable is blocked` checks 26 commands against the
generated hook, each costing a `bash` process with a `python3` inside it — roughly 52
process starts. It measures 2848 ms against vitest's 5000 ms default and was seen timing
out at ~5.8 s under load. It is the slowest test in the suite and the second slowest is its
neighbour; nothing else anywhere exceeds 2 s.

The commands are the coverage — this is the test proving the hook blocks an agent reading a
prefixed secret variable — so none were removed. The bound moved instead: 30 s at the `init`
describe. That is a timeout, not an assertion; nothing starts passing because the number
went up, and the option was checked rather than assumed (set to 1 ms the same tests fail
`Test timed out in 1ms`). Verified under 12 busy cores: 23.6 s instead of 12.5 s, all 72 pass.

## Notes

- No behaviour change and no version bump, so no CHANGELOG entry. `near-miss` is not exported
  from `src/index.ts`; the two counter functions are `@internal` and exist only so the bound
  can be asserted without a clock.
- `npm test`: 1839 passed, 0 failed, across repeated runs.