### PR TITLE
fix: report rules-file lines the parser does not read instead of silently dropping them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [Unreleased]
+
+**A `.secretless-rules.yaml` line the parser cannot read is now reported, and
+`rules list` and `init` exit 1 over it.** Previously a top-level key the parser
+did not recognise — `file:` instead of `files:`, `Files:`, `envs:` — silently
+discarded every pattern under it, flow syntax (`env: [ACME_*]`) and zero-indent
+list items vanished the same way, and the loader still reported the file as
+loaded (or empty) with no diagnostic. The deny rules were generated without
+those patterns and `init` exited 0: a restriction you wrote, reported as
+loaded, that did not restrict. Unknown keys now get a nearest-match hint
+("did you mean \"files\"?") but are never auto-corrected, every dropped pattern
+is named with its line number, and the sections that were read still load. Two
+adjacent holes closed with it: a section line carrying inline content no longer
+lets the items below it attach to the previous section (a file pattern misread
+as an env pattern generated deny rules you did not write), and a rules file
+refused for unsafe pattern characters no longer configures nothing while
+`init` exits 0.
+
 ## [0.23.0] - 2026-08-19
 
 The tool does what it says. Every change here is a case where a command accepted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ those patterns and `init` exited 0: a restriction you wrote, reported as
 loaded, that did not restrict. Unknown keys now get a nearest-match hint
 ("did you mean \"files\"?") but are never auto-corrected, every dropped pattern
 is named with its line number, and the sections that were read still load. Two
-adjacent holes closed with it: a section line carrying inline content no longer
-lets the items below it attach to the previous section (a file pattern misread
-as an env pattern generated deny rules you did not write), and a rules file
-refused for unsafe pattern characters no longer configures nothing while
-`init` exits 0.
+adjacent holes closed with it: a section line the parser cannot read — inline
+content, stray spacing like `files :`, an invisible character — no longer lets
+the items below it attach to the previous section (a file pattern misread as an
+env pattern generated deny rules you did not write), a rules file refused for
+unsafe pattern characters no longer configures nothing while `init` exits 0,
+and the problem is reported even when Claude Code is not among the configured
+tools.
 
 ## [0.23.0] - 2026-08-19
 

--- a/src/commands/core.ts
+++ b/src/commands/core.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import { init } from '../init';
+import { RULES_FILENAME } from '../custom-rules';
 import { scan, emptySkips } from '../scan';
 import { status } from '../status';
 import { verify } from '../verify';
@@ -167,6 +168,36 @@ export function runInit(projectDir: string): number {
   console.log('    Scan:   secretless-ai scan');
   console.log('    Status: secretless-ai status');
   console.log();
+
+  // A rules file the operator wrote that is not fully in force fails the run:
+  // part of what they asked for was not installed, and exiting 0 over that is
+  // the accepted-but-narrower defect this block exists to close. Rendered last
+  // so the problem and its fix are the bottom lines of the output.
+  if (result.rulesFileProblem) {
+    if (result.rulesFileProblem.kind === 'unrecognised-content') {
+      const { issues } = result.rulesFileProblem;
+      console.log(`  ${c.yellow('Warning:')} ${RULES_FILENAME} has ${issues.length} line${issues.length === 1 ? '' : 's'} this build does not read`);
+      console.log();
+      for (const issue of issues) {
+        console.log(`    line ${issue.line}: ${issue.text}`);
+        console.log(`      ${issue.message}`);
+      }
+      console.log();
+      console.log('    The flagged lines generated no deny rules, so the protections they');
+      console.log('    describe are not installed. Lines that were read were applied.');
+    } else {
+      console.log(`  ${c.yellow('Warning:')} ${RULES_FILENAME} was refused — none of its patterns were applied`);
+      console.log();
+      for (const l of result.rulesFileProblem.reason.split('\n')) {
+        console.log(`    ${l}`);
+      }
+    }
+    console.log();
+    console.log(`  ${c.cyan('Verify:')} secretless-ai rules list`);
+    console.log(`  ${c.cyan('Fix:')}    edit ${RULES_FILENAME}, then re-run: secretless-ai init`);
+    console.log();
+    return 1;
+  }
 
   return 0;
 }

--- a/src/commands/core.ts
+++ b/src/commands/core.ts
@@ -184,7 +184,16 @@ export function runInit(projectDir: string): number {
       }
       console.log();
       console.log('    The flagged lines generated no deny rules, so the protections they');
-      console.log('    describe are not installed. Lines that were read were applied.');
+      console.log('    describe are not installed.');
+      // "were applied" is only true when a Claude Code configuration was
+      // actually written this run — custom rules generate Claude Code deny
+      // rules and nothing for the other tools.
+      if (result.toolsConfigured.includes('claude-code')) {
+        console.log('    Lines that were read were applied.');
+      } else {
+        console.log('    Custom rules generate Claude Code deny rules, and Claude Code was');
+        console.log('    not configured in this run, so none of this file is in force here.');
+      }
     } else {
       console.log(`  ${c.yellow('Warning:')} ${RULES_FILENAME} was refused — none of its patterns were applied`);
       console.log();

--- a/src/commands/rules-file-diagnostics.test.ts
+++ b/src/commands/rules-file-diagnostics.test.ts
@@ -98,3 +98,30 @@ describe('runInit with a rules file that cannot be fully honoured', () => {
     expect(code).toBe(0);
   });
 });
+
+describe('runInit with a broken rules file and no Claude Code among detected tools', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('exits 1 and says the file is not in force here', () => {
+    const dir = tmpProject({
+      '.cursorrules': '',
+      '.secretless-rules.yaml': 'file:\n  - "*.corp-secret"\n',
+    });
+    const lines: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => { lines.push(a.map(String).join(' ')); });
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'rules-diag-home-'));
+    const prev = process.env.HOME;
+    process.env.HOME = home;
+    let code: number;
+    try {
+      code = runInit(dir);
+    } finally {
+      process.env.HOME = prev;
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+    expect(code).toBe(1);
+    const out = lines.join('\n');
+    expect(out).toContain('not configured in this run');
+    expect(out).not.toContain('Lines that were read were applied');
+  });
+});

--- a/src/commands/rules-file-diagnostics.test.ts
+++ b/src/commands/rules-file-diagnostics.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { runRules } from './rules';
+import { runInit } from './core';
+
+function tmpProject(files: Record<string, string> = {}): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rules-diag-'));
+  for (const [rel, content] of Object.entries(files)) {
+    const full = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+  return dir;
+}
+
+function captureLog(): string[] {
+  const lines: string[] = [];
+  vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => { lines.push(a.map(String).join(' ')); });
+  return lines;
+}
+
+// A rules file the parser could not fully read must fail `rules list` and
+// `init` audibly. Exit 0 over dropped patterns is the defect these pin.
+describe('rules list with unrecognised content', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('exits 0 on a clean rules file', () => {
+    const dir = tmpProject({ '.secretless-rules.yaml': 'env:\n  - ACME_*\n' });
+    const lines = captureLog();
+    expect(runRules(['list'], dir)).toBe(0);
+    expect(lines.join('\n')).toContain('ACME_*');
+  });
+
+  it('exits 1 and names the unread lines when a key is misspelled', () => {
+    const dir = tmpProject({ '.secretless-rules.yaml': 'file:\n  - "*.corp-secret"\n' });
+    const lines = captureLog();
+    expect(runRules(['list'], dir)).toBe(1);
+    const out = lines.join('\n');
+    expect(out).toContain('not read');
+    expect(out).toContain('did you mean "files"?');
+    expect(out).toContain('The flagged lines generate no deny rules');
+  });
+
+  it('still lists what WAS read, marked as partial, and exits 1', () => {
+    const dir = tmpProject({
+      '.secretless-rules.yaml': 'env:\n  - ACME_*\nfile:\n  - "*.corp-secret"\n',
+    });
+    const lines = captureLog();
+    expect(runRules(['list'], dir)).toBe(1);
+    const out = lines.join('\n');
+    expect(out).toContain('ACME_*');
+    expect(out).toContain('from the lines that were read');
+  });
+});
+
+describe('runInit with a rules file that cannot be fully honoured', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  // HOME is redirected so runInit's shell-profile fixer and backend-config
+  // reads touch a throwaway home, never the real one.
+  function withTmpHome<T>(fn: () => T): T {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'rules-diag-home-'));
+    const prev = process.env.HOME;
+    process.env.HOME = home;
+    try {
+      return fn();
+    } finally {
+      process.env.HOME = prev;
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  }
+
+  it('exits 1 and renders the unread lines with a fix path', () => {
+    const dir = tmpProject({ '.secretless-rules.yaml': 'file:\n  - "*.corp-secret"\n' });
+    const lines = captureLog();
+    const code = withTmpHome(() => runInit(dir));
+    expect(code).toBe(1);
+    const out = lines.join('\n');
+    expect(out).toContain('does not read');
+    expect(out).toContain('did you mean "files"?');
+    expect(out).toContain('secretless-ai rules list');
+  });
+
+  it('exits 1 when the rules file is refused outright', () => {
+    const dir = tmpProject({ '.secretless-rules.yaml': 'env:\n  - "$(whoami)"\n' });
+    const lines = captureLog();
+    const code = withTmpHome(() => runInit(dir));
+    expect(code).toBe(1);
+    expect(lines.join('\n')).toContain('refused');
+  });
+
+  it('exits 0 on a clean rules file', () => {
+    const dir = tmpProject({ '.secretless-rules.yaml': 'env:\n  - CORP_*\n' });
+    captureLog();
+    const code = withTmpHome(() => runInit(dir));
+    expect(code).toBe(0);
+  });
+});

--- a/src/commands/rules.ts
+++ b/src/commands/rules.ts
@@ -1,15 +1,18 @@
 import * as path from 'path';
+import * as fs from 'fs';
+import {
+  loadCustomRulesDetailed,
+  customRulesToDenyRules,
+  generateTemplate,
+  envPatternToDenyRules,
+  filePatternToDenyRules,
+  validatePattern,
+  globToShellRegex,
+  RULES_FILENAME,
+} from '../custom-rules';
 
-export function runRules(args: string[]): number {
-  const {
-    loadCustomRulesDetailed,
-    customRulesToDenyRules,
-    generateTemplate,
-    RULES_FILENAME,
-  } = require('../custom-rules') as typeof import('../custom-rules');
-
+export function runRules(args: string[], projectDir: string = process.cwd()): number {
   const subcommand = args[0] ?? 'list';
-  const projectDir = process.cwd();
 
   switch (subcommand) {
     case 'list': {
@@ -24,44 +27,62 @@ export function runRules(args: string[]): number {
         console.log('  Uncomment or add patterns, then run: npx secretless-ai init\n');
         return 0;
       }
-      const rules = result.rules!;
 
-      console.log(`\n  Custom Rules (${RULES_FILENAME})\n`);
-
-      if (rules.env.length > 0) {
-        console.log('  Environment variables:');
-        for (const p of rules.env) {
-          console.log(`    ${p}`);
-        }
-      }
-      if (rules.files.length > 0) {
-        console.log('  File patterns:');
-        for (const p of rules.files) {
-          console.log(`    ${p}`);
-        }
-      }
-      if (rules.bash.length > 0) {
-        console.log('  Bash commands:');
-        for (const p of rules.bash) {
-          console.log(`    ${p}`);
+      const issues = result.status === 'unrecognised-content' ? (result.issues ?? []) : [];
+      if (issues.length > 0) {
+        console.log(`\n  ${RULES_FILENAME}: ${issues.length} line${issues.length === 1 ? '' : 's'} not read\n`);
+        for (const issue of issues) {
+          console.log(`    line ${issue.line}: ${issue.text}`);
+          console.log(`      ${issue.message}`);
         }
       }
 
-      const denyRules = customRulesToDenyRules(rules);
-      console.log(`\n  Generates ${denyRules.length} deny rules.`);
-      console.log('  Run: npx secretless-ai init  (to apply)\n');
+      const rules = result.rules;
+      if (rules) {
+        console.log(`\n  Custom Rules (${RULES_FILENAME})\n`);
+
+        if (rules.env.length > 0) {
+          console.log('  Environment variables:');
+          for (const p of rules.env) {
+            console.log(`    ${p}`);
+          }
+        }
+        if (rules.files.length > 0) {
+          console.log('  File patterns:');
+          for (const p of rules.files) {
+            console.log(`    ${p}`);
+          }
+        }
+        if (rules.bash.length > 0) {
+          console.log('  Bash commands:');
+          for (const p of rules.bash) {
+            console.log(`    ${p}`);
+          }
+        }
+
+        const denyRules = customRulesToDenyRules(rules);
+        console.log(`\n  Generates ${denyRules.length} deny rules${issues.length > 0 ? ' from the lines that were read' : ''}.`);
+        console.log('  Run: npx secretless-ai init  (to apply)\n');
+      }
+
+      if (issues.length > 0) {
+        if (!rules) {
+          console.log(`\n  No deny rules are generated from this file — nothing in it was read as a pattern.`);
+        }
+        console.log(`  The flagged lines generate no deny rules. Fix them, then run: npx secretless-ai rules list  (to re-check)\n`);
+        return 1;
+      }
       return 0;
     }
 
     case 'init': {
-      const nodeFs = require('fs') as typeof import('fs');
       const rulesPath = path.join(projectDir, RULES_FILENAME);
-      if (nodeFs.existsSync(rulesPath)) {
+      if (fs.existsSync(rulesPath)) {
         console.log(`\n  ${RULES_FILENAME} already exists.`);
         console.log('  Edit it directly or use: npx secretless-ai rules list\n');
         return 0;
       }
-      nodeFs.writeFileSync(rulesPath, generateTemplate());
+      fs.writeFileSync(rulesPath, generateTemplate());
       console.log(`\n  Created ${RULES_FILENAME}`);
       console.log('  Edit it to add your organization-specific patterns.');
       console.log('  Then run: npx secretless-ai init  (to apply)\n');
@@ -81,9 +102,6 @@ export function runRules(args: string[]): number {
         console.error('    secretless-ai rules test "curl*corp*" --bash   (force bash type)\n');
         return 1;
       }
-
-      const { envPatternToDenyRules, filePatternToDenyRules, validatePattern, globToShellRegex } =
-        require('../custom-rules') as typeof import('../custom-rules');
 
       if (!validatePattern(pattern)) {
         console.error(`\n  Invalid pattern: ${pattern}`);

--- a/src/custom-rules.test.ts
+++ b/src/custom-rules.test.ts
@@ -5,6 +5,7 @@ import * as os from 'os';
 
 import {
   parseRulesYaml,
+  parseRulesYamlDetailed,
   validatePattern,
   validateRules,
   globToShellRegex,
@@ -362,5 +363,159 @@ describe('generateTemplate', () => {
     // Template should parse without error (all items are commented out)
     const parsed = parseRulesYaml(template);
     expect(parsed.env).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Detailed parser — every unread line is an issue, never a silent drop
+// ---------------------------------------------------------------------------
+
+describe('parseRulesYamlDetailed', () => {
+  it('reports an unknown top-level key with a nearest-match hint', () => {
+    const { rules, issues } = parseRulesYamlDetailed(`
+file:
+  - "*.corp-secret"
+`);
+    expect(rules).toEqual({ env: [], files: [], bash: [] });
+    const keyIssue = issues.find(i => i.message.includes('Unknown top-level key "file"'));
+    expect(keyIssue).toBeDefined();
+    expect(keyIssue!.message).toContain('did you mean "files"?');
+    expect(keyIssue!.message).toContain('env, files, bash');
+  });
+
+  it('hints on a case variant of a known key', () => {
+    const { issues } = parseRulesYamlDetailed('Files:\n  - "*.a"\n');
+    expect(issues[0].message).toContain('Unknown top-level key "Files"');
+    expect(issues[0].message).toContain('did you mean "files"?');
+  });
+
+  it('reports every pattern dropped under an unknown key, naming the key', () => {
+    const { rules, issues } = parseRulesYamlDetailed(`
+envs:
+  - ACME_*
+  - CORP_*
+`);
+    expect(rules.env).toEqual([]);
+    const dropped = issues.filter(i => i.message.includes('sits under "envs"'));
+    expect(dropped.map(d => d.text)).toEqual(['- ACME_*', '- CORP_*']);
+    expect(dropped.map(d => d.line)).toEqual([3, 4]);
+  });
+
+  it('does not auto-correct: a hinted near-miss key still binds nothing', () => {
+    const { rules } = parseRulesYamlDetailed('file:\n  - "*.corp-secret"\n');
+    expect(rules.files).toEqual([]);
+    expect(rules.env).toEqual([]);
+    expect(rules.bash).toEqual([]);
+  });
+
+  it('reports flow syntax instead of silently dropping it', () => {
+    const { rules, issues } = parseRulesYamlDetailed('env: [ACME_*]\n');
+    expect(rules.env).toEqual([]);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].line).toBe(1);
+    expect(issues[0].message).toContain('flow syntax');
+  });
+
+  it('a failed section line does not bind following items to the previous section', () => {
+    const { rules, issues } = parseRulesYamlDetailed(`env:
+  - FOO_*
+files: [inline]
+  - "*.key-material"
+`);
+    // The shipped parser bound *.key-material to env, generating echo/printenv
+    // deny rules for a file pattern. It must be dropped and reported instead.
+    expect(rules.env).toEqual(['FOO_*']);
+    expect(rules.files).toEqual([]);
+    const dropped = issues.find(i => i.text.includes('key-material'));
+    expect(dropped).toBeDefined();
+    expect(dropped!.message).toContain('section never opened');
+  });
+
+  it('reports a comment on a section line as unsupported', () => {
+    const { rules, issues } = parseRulesYamlDetailed('env: # main envs\n  - ACME_*\n');
+    expect(rules.env).toEqual([]);
+    expect(issues).toHaveLength(2);
+    expect(issues[0].message).toContain('comment on the same line');
+    expect(issues[1].message).toContain('section never opened');
+  });
+
+  it('reports a zero-indent list item instead of silently dropping it', () => {
+    const { rules, issues } = parseRulesYamlDetailed('env:\n- ACME_*\n');
+    expect(rules.env).toEqual([]);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].line).toBe(2);
+  });
+
+  it('reports a pattern with no section at all', () => {
+    const { issues } = parseRulesYamlDetailed('  - ORPHAN_*\n');
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain('does not sit under any recognised section');
+  });
+
+  it('returns no issues for a clean file or the generated template', () => {
+    const clean = parseRulesYamlDetailed('env:\n  - ACME_*\nfiles:\n  - "*.a"\n');
+    expect(clean.issues).toEqual([]);
+    expect(parseRulesYamlDetailed(generateTemplate()).issues).toEqual([]);
+  });
+
+  it('issue line numbers are 1-based file positions', () => {
+    const { issues } = parseRulesYamlDetailed('\n# comment\nbogus:\n');
+    expect(issues).toHaveLength(1);
+    expect(issues[0].line).toBe(3);
+  });
+
+  it('parseRulesYaml still returns the same rules object shape', () => {
+    const content = 'env:\n  - A_*\nbogus:\n  - dropped\n';
+    expect(parseRulesYaml(content)).toEqual(parseRulesYamlDetailed(content).rules);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Load status — a file with unread lines must not report 'loaded' or 'empty'
+// ---------------------------------------------------------------------------
+
+describe('loadCustomRulesDetailed with unrecognised content', () => {
+  let dir: string;
+  beforeEach(() => { dir = tmpDir(); });
+  afterEach(() => { cleanup(dir); });
+
+  it('reports unrecognised-content, not empty, when everything sat under a misspelled key', () => {
+    fs.writeFileSync(path.join(dir, RULES_FILENAME), `
+file:
+  - "*.corp-secret"
+`);
+    const result = loadCustomRulesDetailed(dir);
+    expect(result.status).toBe('unrecognised-content');
+    expect(result.rules).toBeNull();
+    expect(result.issues!.length).toBeGreaterThan(0);
+    expect(result.issues![0].message).toContain('did you mean "files"?');
+  });
+
+  it('reports unrecognised-content, not loaded, when only part of the file was read', () => {
+    fs.writeFileSync(path.join(dir, RULES_FILENAME), `
+env:
+  - ACME_*
+file:
+  - "*.corp-secret"
+`);
+    const result = loadCustomRulesDetailed(dir);
+    expect(result.status).toBe('unrecognised-content');
+    expect(result.rules).not.toBeNull();
+    expect(result.rules!.env).toEqual(['ACME_*']);
+    expect(result.rules!.files).toEqual([]);
+  });
+
+  it('carries no issues field on loaded and empty files', () => {
+    fs.writeFileSync(path.join(dir, RULES_FILENAME), 'env:\n  - CORP_*\n');
+    expect(loadCustomRulesDetailed(dir).issues).toBeUndefined();
+    fs.writeFileSync(path.join(dir, RULES_FILENAME), '# nothing\n');
+    expect(loadCustomRulesDetailed(dir).issues).toBeUndefined();
+  });
+
+  it('does not throw on unsafe characters under an unknown key — nothing binds, so it reports instead', () => {
+    fs.writeFileSync(path.join(dir, RULES_FILENAME), 'bogus:\n  - "$(whoami)"\n');
+    const result = loadCustomRulesDetailed(dir);
+    expect(result.status).toBe('unrecognised-content');
+    expect(result.rules).toBeNull();
   });
 });

--- a/src/custom-rules.test.ts
+++ b/src/custom-rules.test.ts
@@ -519,3 +519,60 @@ file:
     expect(result.rules).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Unreadable headers close the open section (adversarial-review finding:
+// "files :" left the previous section open and mis-bound the items below it)
+// ---------------------------------------------------------------------------
+
+describe('parseRulesYamlDetailed — unreadable headers close the section', () => {
+  it('a header with a space before the colon does not bind following items to the previous section', () => {
+    const { rules, issues } = parseRulesYamlDetailed('env:\n  - FOO_*\nfiles :\n  - "*.key-material"\n');
+    expect(rules.env).toEqual(['FOO_*']);
+    expect(rules.files).toEqual([]);
+    const dropped = issues.find(i => i.text.includes('key-material'));
+    expect(dropped).toBeDefined();
+    expect(dropped!.message).toContain('does not sit under any recognised section');
+  });
+
+  it('a tab-indented header closes the section the same way', () => {
+    const { rules, issues } = parseRulesYamlDetailed('env:\n  - FOO_*\n\tfiles:\n  - "*.key-material"\n');
+    expect(rules.env).toEqual(['FOO_*']);
+    expect(rules.files).toEqual([]);
+    expect(issues.some(i => i.text.includes('key-material'))).toBe(true);
+  });
+
+  it('a dropped item after an unreadable header does not blame an earlier unknown key', () => {
+    const { issues } = parseRulesYamlDetailed('envs:\n  - A_*\nfiles :\n  - B_*\n');
+    const b = issues.find(i => i.text === '- B_*');
+    expect(b).toBeDefined();
+    expect(b!.message).not.toContain('envs');
+    expect(b!.message).toContain('does not sit under any recognised section');
+  });
+
+  it('strips a leading BOM so the first key parses', () => {
+    const { rules, issues } = parseRulesYamlDetailed('\uFEFFenv:\n  - ACME_*\n');
+    expect(rules.env).toEqual(['ACME_*']);
+    expect(issues).toEqual([]);
+  });
+
+  it('points at invisible characters when a correct-looking line is not read', () => {
+    const { issues } = parseRulesYamlDetailed('env\u00A0:\n');
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain('invisible');
+  });
+
+  it('reports an empty quoted item instead of silently skipping it', () => {
+    const { rules, issues } = parseRulesYamlDetailed("env:\n  - \"\"\n  - ''\n");
+    expect(rules.env).toEqual([]);
+    expect(issues).toHaveLength(2);
+    expect(issues[0].message).toContain('no pattern left');
+  });
+
+  it('advises on the key, not on indentation, for an unknown key with an inline value', () => {
+    const { issues } = parseRulesYamlDetailed('version: 1\n');
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain('is not a section this build reads');
+    expect(issues[0].message).not.toContain('indented');
+  });
+});

--- a/src/custom-rules.ts
+++ b/src/custom-rules.ts
@@ -7,6 +7,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { nearestMatch } from './near-miss';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -19,6 +20,30 @@ export interface CustomRules {
   files: string[];
   /** Bash command patterns to block (glob, e.g. acme-vault*get*) */
   bash: string[];
+}
+
+/** The top-level section keys this build reads. Everything else is reported, never bound. */
+export const KNOWN_RULES_KEYS: readonly string[] = ['env', 'files', 'bash'];
+
+/**
+ * A non-empty line of the rules file the parser did not read. Every issue means
+ * a line the operator wrote that produced no deny rule — the file "loaded"
+ * while restricting less than it says, which is exactly the failure the status
+ * value below exists to make visible.
+ */
+export interface RulesFileIssue {
+  /** 1-based line number in the rules file. */
+  line: number;
+  /** The offending line, trimmed. */
+  text: string;
+  /** What the parser could not do with the line, and what to write instead. */
+  message: string;
+}
+
+export interface RulesParseResult {
+  rules: CustomRules;
+  /** Non-empty, non-comment lines that were not read. Empty when every line was understood. */
+  issues: RulesFileIssue[];
 }
 
 export const RULES_FILENAME = '.secretless-rules.yaml';
@@ -34,13 +59,25 @@ const SAFE_PATTERN = /^[a-zA-Z0-9_*.\-/\[\]{}?]+$/;
  * Parse a minimal YAML subset: top-level keys mapping to lists of strings.
  * Supports: comments (#), quoted strings, blank lines.
  * Does NOT support: anchors, multiline strings, nested objects, flow syntax.
+ *
+ * Every non-empty, non-comment line the parser does not read comes back as an
+ * issue. An unknown key is reported with a nearest-match hint but never
+ * auto-corrected, and a pattern is never bound to a section the operator did
+ * not put it under — the same rule the policy envelope check enforces
+ * (`KNOWN_ENVELOPE_KEYS` in broker/policy.ts).
  */
-export function parseRulesYaml(content: string): CustomRules {
+export function parseRulesYamlDetailed(content: string): RulesParseResult {
   const result: CustomRules = { env: [], files: [], bash: [] };
+  const issues: RulesFileIssue[] = [];
   let currentKey: keyof CustomRules | null = null;
+  // The unknown key whose section is open, so dropped patterns under it can
+  // name the key that killed them rather than reporting context-free.
+  let currentUnknownKey: string | null = null;
 
-  for (const rawLine of content.split('\n')) {
-    const line = rawLine.trimEnd();
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const lineNo = i + 1;
+    const line = lines[i].trimEnd();
 
     // Skip empty lines and comment-only lines
     if (!line.trim() || line.trim().startsWith('#')) continue;
@@ -51,37 +88,108 @@ export function parseRulesYaml(content: string): CustomRules {
       const key = keyMatch[1] as string;
       if (key === 'env' || key === 'files' || key === 'bash') {
         currentKey = key;
+        currentUnknownKey = null;
       } else {
-        currentKey = null; // Unknown key — skip its items
+        currentKey = null;
+        currentUnknownKey = key;
+        const near = nearestMatch(key, KNOWN_RULES_KEYS);
+        issues.push({
+          line: lineNo,
+          text: line.trim(),
+          message:
+            `Unknown top-level key "${key}"${near ? ` (did you mean "${near}"?)` : ''}. ` +
+            `A rules file may carry: ${KNOWN_RULES_KEYS.join(', ')}. Patterns under a key this ` +
+            `build does not read are never loaded, and nothing downstream can tell that from a ` +
+            `file that declared no such patterns.`,
+        });
       }
       continue;
     }
 
     // List item (e.g., "  - ACME_*" or '  - "*.acme-credentials"')
     const itemMatch = line.match(/^\s+-\s+(.+)$/);
-    if (itemMatch && currentKey) {
-      let value = itemMatch[1].trim();
+    if (itemMatch) {
+      if (currentKey) {
+        let value = itemMatch[1].trim();
 
-      // Strip inline comments
-      const commentIdx = value.indexOf(' #');
-      if (commentIdx >= 0) {
-        value = value.slice(0, commentIdx).trim();
-      }
+        // Strip inline comments
+        const commentIdx = value.indexOf(' #');
+        if (commentIdx >= 0) {
+          value = value.slice(0, commentIdx).trim();
+        }
 
-      // Strip surrounding quotes
-      if ((value.startsWith('"') && value.endsWith('"')) ||
-          (value.startsWith("'") && value.endsWith("'"))) {
-        value = value.slice(1, -1);
-      }
+        // Strip surrounding quotes
+        if ((value.startsWith('"') && value.endsWith('"')) ||
+            (value.startsWith("'") && value.endsWith("'"))) {
+          value = value.slice(1, -1);
+        }
 
-      if (value) {
-        result[currentKey].push(value);
+        if (value) {
+          result[currentKey].push(value);
+        }
+      } else {
+        issues.push({
+          line: lineNo,
+          text: line.trim(),
+          message: currentUnknownKey
+            ? KNOWN_RULES_KEYS.includes(currentUnknownKey)
+              ? `Pattern not loaded: the "${currentUnknownKey}:" line above it was not read, so the section never opened.`
+              : `Pattern not loaded: it sits under "${currentUnknownKey}", which this build does not read.`
+            : `Pattern not loaded: it does not sit under any recognised section (${KNOWN_RULES_KEYS.join(', ')}).`,
+        });
       }
       continue;
     }
+
+    // Neither a section line nor a list item. A key with content on the same
+    // line closes any open section: binding the items that follow to the
+    // PREVIOUS section would attach patterns to a section the operator did not
+    // put them under, and an env pattern misread as a file pattern (or vice
+    // versa) generates the wrong deny rules entirely.
+    const inlineKey = line.match(/^([a-zA-Z0-9_-]+):\s*(\S.*)$/);
+    if (inlineKey) {
+      const key = inlineKey[1] as string;
+      const trailing = inlineKey[2];
+      currentKey = null;
+      currentUnknownKey = key;
+      const known = KNOWN_RULES_KEYS.includes(key);
+      const near = known ? undefined : nearestMatch(key, KNOWN_RULES_KEYS);
+      issues.push({
+        line: lineNo,
+        text: line.trim(),
+        message: trailing.startsWith('#')
+          ? `A comment on the same line as "${key}:" is not supported by this parser, so the ` +
+            `section never opens and the patterns beneath it are not read. Put the comment on ` +
+            `its own line.`
+          : `Content on the same line as "${key}:" is not read (this parser does not support ` +
+            `flow syntax or inline values)` +
+            `${known ? '' : `, and "${key}" is not a section this build reads` +
+              `${near ? ` (did you mean "${near}"?)` : ''}`}. ` +
+            `Put each pattern on its own indented "- pattern" line below the key.`,
+      });
+      continue;
+    }
+
+    issues.push({
+      line: lineNo,
+      text: line.trim(),
+      message:
+        `Unrecognised line: not a "key:" section line or an indented "- pattern" item, ` +
+        `so it was not read.`,
+    });
   }
 
-  return result;
+  return { rules: result, issues };
+}
+
+/**
+ * Rules-only form of `parseRulesYamlDetailed`, discarding the issue list.
+ * Callers that report to an operator must use the detailed form — this one
+ * cannot distinguish a file that parsed clean from one that silently lost
+ * patterns.
+ */
+export function parseRulesYaml(content: string): CustomRules {
+  return parseRulesYamlDetailed(content).rules;
 }
 
 // ---------------------------------------------------------------------------
@@ -252,8 +360,17 @@ export function customRulesToFilePatterns(rules: CustomRules): string[] {
  */
 export interface LoadResult {
   rules: CustomRules | null;
-  /** 'missing' = no file, 'empty' = file exists but no active rules, 'loaded' = has rules */
-  status: 'missing' | 'empty' | 'loaded';
+  /**
+   * 'missing' = no file, 'empty' = file exists but no active rules, 'loaded' =
+   * has rules and every line was read. 'unrecognised-content' = the file has
+   * lines the parser did not read; `rules` still carries what WAS read (null
+   * when nothing was). It takes precedence over 'empty' and 'loaded' because
+   * both would report the file as fully honoured when part of what the
+   * operator wrote produced no deny rules.
+   */
+  status: 'missing' | 'empty' | 'loaded' | 'unrecognised-content';
+  /** The unread lines. Present exactly when status is 'unrecognised-content'. */
+  issues?: RulesFileIssue[];
 }
 
 export function loadCustomRules(dir: string): CustomRules | null {
@@ -265,7 +382,7 @@ export function loadCustomRulesDetailed(dir: string): LoadResult {
   if (!fs.existsSync(rulesPath)) return { rules: null, status: 'missing' };
 
   const content = fs.readFileSync(rulesPath, 'utf-8');
-  const rules = parseRulesYaml(content);
+  const { rules, issues } = parseRulesYamlDetailed(content);
 
   // Validate all patterns are safe
   const invalid = validateRules(rules);
@@ -276,8 +393,14 @@ export function loadCustomRulesDetailed(dir: string): LoadResult {
     );
   }
 
+  const empty = rules.env.length === 0 && rules.files.length === 0 && rules.bash.length === 0;
+
+  if (issues.length > 0) {
+    return { rules: empty ? null : rules, status: 'unrecognised-content', issues };
+  }
+
   // Return empty status if all sections are empty
-  if (rules.env.length === 0 && rules.files.length === 0 && rules.bash.length === 0) {
+  if (empty) {
     return { rules: null, status: 'empty' };
   }
 

--- a/src/custom-rules.ts
+++ b/src/custom-rules.ts
@@ -67,6 +67,13 @@ const SAFE_PATTERN = /^[a-zA-Z0-9_*.\-/\[\]{}?]+$/;
  * (`KNOWN_ENVELOPE_KEYS` in broker/policy.ts).
  */
 export function parseRulesYamlDetailed(content: string): RulesParseResult {
+  // A UTF-8 byte-order mark is an encoding artifact, not operator content —
+  // without this, a BOM'd file's first key line fails every pattern below and
+  // the issue shows a line that LOOKS like a valid key (trim strips the BOM
+  // from the displayed text too).
+  if (content.charCodeAt(0) === 0xfeff) {
+    content = content.slice(1);
+  }
   const result: CustomRules = { env: [], files: [], bash: [] };
   const issues: RulesFileIssue[] = [];
   let currentKey: keyof CustomRules | null = null;
@@ -126,6 +133,12 @@ export function parseRulesYamlDetailed(content: string): RulesParseResult {
 
         if (value) {
           result[currentKey].push(value);
+        } else {
+          issues.push({
+            line: lineNo,
+            text: line.trim(),
+            message: `Pattern not loaded: the item has no pattern left after removing quotes and comments.`,
+          });
         }
       } else {
         issues.push({
@@ -154,28 +167,41 @@ export function parseRulesYamlDetailed(content: string): RulesParseResult {
       currentUnknownKey = key;
       const known = KNOWN_RULES_KEYS.includes(key);
       const near = known ? undefined : nearestMatch(key, KNOWN_RULES_KEYS);
+      // The fix advice must match the actual defect: telling the operator to
+      // indent patterns under a key this build does not read sends them in a
+      // circle — the re-indented file fails on the key instead.
       issues.push({
         line: lineNo,
         text: line.trim(),
-        message: trailing.startsWith('#')
-          ? `A comment on the same line as "${key}:" is not supported by this parser, so the ` +
-            `section never opens and the patterns beneath it are not read. Put the comment on ` +
-            `its own line.`
-          : `Content on the same line as "${key}:" is not read (this parser does not support ` +
-            `flow syntax or inline values)` +
-            `${known ? '' : `, and "${key}" is not a section this build reads` +
-              `${near ? ` (did you mean "${near}"?)` : ''}`}. ` +
-            `Put each pattern on its own indented "- pattern" line below the key.`,
+        message: !known
+          ? `The key "${key}" is not a section this build reads` +
+            `${near ? ` (did you mean "${near}"?)` : ''}, and content on the same line as a ` +
+            `key is not read either. A rules file may carry: ${KNOWN_RULES_KEYS.join(', ')}.`
+          : trailing.startsWith('#')
+            ? `A comment on the same line as "${key}:" is not supported by this parser, so the ` +
+              `section never opens and the patterns beneath it are not read. Put the comment on ` +
+              `its own line.`
+            : `Content on the same line as "${key}:" is not read (this parser does not support ` +
+              `flow syntax or inline values). Put each pattern on its own indented ` +
+              `"- pattern" line below the key.`,
       });
       continue;
     }
 
+    // A line that matches nothing above ALSO closes any open section, exactly
+    // as the inline-content branch does: an unreadable header ("files :", a
+    // tab-indented or invisible-character-prefixed key) would otherwise leave
+    // the previous section open and bind the patterns below it there —
+    // installing deny rules of the wrong kind, which is worse than absence.
+    currentKey = null;
+    currentUnknownKey = null;
     issues.push({
       line: lineNo,
       text: line.trim(),
       message:
         `Unrecognised line: not a "key:" section line or an indented "- pattern" item, ` +
-        `so it was not read.`,
+        `so it was not read. If it looks correct, check for stray spacing or invisible ` +
+        `characters (a non-breaking space, a byte-order mark).`,
     });
   }
 

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -1241,3 +1241,17 @@ file:
     }
   });
 });
+
+describe('init surfaces the rules file regardless of detected tools', () => {
+  let dir: string;
+  beforeEach(() => { dir = tmpDir(); });
+  afterEach(() => { cleanup(dir); });
+
+  it('reports a broken rules file even when Claude Code is not among the detected tools', () => {
+    fs.writeFileSync(path.join(dir, '.cursorrules'), '');
+    fs.writeFileSync(path.join(dir, '.secretless-rules.yaml'), 'file:\n  - "*.corp-secret"\n');
+    const result = init(dir);
+    expect(result.toolsConfigured).not.toContain('claude-code');
+    expect(result.rulesFileProblem?.kind).toBe('unrecognised-content');
+  });
+});

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -1181,3 +1181,63 @@ describe('README sample output matches the build', () => {
     expect(claimed![1]).toBe(pkg.version);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Rules file that cannot be fully honoured — init must say so, not exit clean
+// ---------------------------------------------------------------------------
+
+describe('init with a rules file that cannot be fully honoured', () => {
+  let dir: string;
+  beforeEach(() => { dir = tmpDir(); });
+  afterEach(() => { cleanup(dir); });
+
+  function settings(): { permissions: { deny: string[] } } {
+    return JSON.parse(fs.readFileSync(path.join(dir, '.claude', 'settings.json'), 'utf-8'));
+  }
+
+  it('surfaces unread lines on the result and still applies the lines that were read', () => {
+    fs.writeFileSync(path.join(dir, '.secretless-rules.yaml'), `
+env:
+  - ACME_*
+file:
+  - "*.corp-secret"
+`);
+    const result = init(dir);
+
+    expect(result.rulesFileProblem?.kind).toBe('unrecognised-content');
+    const problem = result.rulesFileProblem!;
+    if (problem.kind !== 'unrecognised-content') throw new Error('unreachable');
+    // The misspelled key and its dropped pattern are both named.
+    expect(problem.issues.some(i => i.message.includes('did you mean "files"?'))).toBe(true);
+    expect(problem.issues.some(i => i.text.includes('corp-secret'))).toBe(true);
+
+    // The section that WAS read is applied...
+    expect(settings().permissions.deny).toContain('Bash(echo $*ACME_*)');
+    // ...and the dropped file pattern generates nothing.
+    expect(settings().permissions.deny).not.toContain('Read(*.corp-secret)');
+  });
+
+  it('reports a refused rules file instead of silently ignoring it', () => {
+    fs.writeFileSync(path.join(dir, '.secretless-rules.yaml'), 'env:\n  - "$(whoami)"\n');
+    const result = init(dir);
+
+    expect(result.rulesFileProblem?.kind).toBe('load-error');
+    const problem = result.rulesFileProblem!;
+    if (problem.kind !== 'load-error') throw new Error('unreachable');
+    expect(problem.reason).toContain('Invalid patterns');
+    // Nothing from the refused file was applied.
+    expect(settings().permissions.deny.some(r => r.includes('whoami'))).toBe(false);
+  });
+
+  it('sets no problem for a clean rules file or no rules file', () => {
+    expect(init(dir).rulesFileProblem).toBeUndefined();
+
+    const dir2 = tmpDir();
+    try {
+      fs.writeFileSync(path.join(dir2, '.secretless-rules.yaml'), 'env:\n  - CORP_*\n');
+      expect(init(dir2).rulesFileProblem).toBeUndefined();
+    } finally {
+      cleanup(dir2);
+    }
+  });
+});

--- a/src/init.ts
+++ b/src/init.ts
@@ -155,11 +155,31 @@ export function init(projectDir: string): InitResult {
   // Quick scan for existing secrets
   result.secretsFound = quickScan(projectDir);
 
+  // Load custom rules HERE, not inside configureClaudeCode: a rules file that
+  // cannot be honoured must reach the result even when Claude Code is not
+  // among the configured tools — otherwise an operator with only .cursorrules
+  // and a broken rules file gets exit 0 and no mention of it. The previous
+  // bare catch inside configureClaudeCode was worse still: a file refused for
+  // unsafe patterns configured nothing and `init` exited 0.
+  let projectCustomRules: CustomRules | null = null;
+  try {
+    const loaded = loadCustomRulesDetailed(projectDir);
+    projectCustomRules = loaded.rules;
+    if (loaded.status === 'unrecognised-content') {
+      result.rulesFileProblem = { kind: 'unrecognised-content', issues: loaded.issues ?? [] };
+    }
+  } catch (err) {
+    result.rulesFileProblem = {
+      kind: 'load-error',
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+
   // Configure each detected tool
   for (const tool of detected) {
     switch (tool.tool) {
       case 'claude-code':
-        configureClaudeCode(projectDir, result);
+        configureClaudeCode(projectDir, result, projectCustomRules);
         break;
       case 'cursor':
         configureCursor(projectDir, result);
@@ -191,30 +211,16 @@ export function init(projectDir: string): InitResult {
 // Claude Code Configuration
 // ============================================================================
 
-function configureClaudeCode(projectDir: string, result: InitResult): void {
+function configureClaudeCode(
+  projectDir: string,
+  result: InitResult,
+  projectCustomRules: CustomRules | null,
+): void {
   const claudeDir = path.join(projectDir, '.claude');
   const hooksDir = path.join(claudeDir, 'hooks');
 
   // Ensure directories exist
   fs.mkdirSync(hooksDir, { recursive: true });
-
-  // Load custom rules early (needed for both hook script and deny rules).
-  // A rules file that cannot be fully honoured is surfaced on the result, not
-  // swallowed: the previous bare catch here meant a file refused for unsafe
-  // patterns configured nothing and `init` still exited 0.
-  let projectCustomRules: CustomRules | null = null;
-  try {
-    const loaded = loadCustomRulesDetailed(projectDir);
-    projectCustomRules = loaded.rules;
-    if (loaded.status === 'unrecognised-content') {
-      result.rulesFileProblem = { kind: 'unrecognised-content', issues: loaded.issues ?? [] };
-    }
-  } catch (err) {
-    result.rulesFileProblem = {
-      kind: 'load-error',
-      reason: err instanceof Error ? err.message : String(err),
-    };
-  }
 
   // 1. Install (or refresh) the PreToolUse guard hook. The hook is a managed
   // file we own — older `init` only wrote it when absent, so an outdated hook

--- a/src/init.ts
+++ b/src/init.ts
@@ -7,8 +7,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { detectAITools, toolDisplayName, type AITool } from './detect';
 import { SECRET_FILE_PATTERNS, CREDENTIAL_PATTERNS, CONFIG_FILES } from './patterns';
-import { loadCustomRules, customRulesToDenyRules, customRulesToHookBlocks, customRulesToFilePatterns, mergeRules } from './custom-rules';
-import type { CustomRules } from './custom-rules';
+import { loadCustomRulesDetailed, customRulesToDenyRules, customRulesToHookBlocks, customRulesToFilePatterns, mergeRules } from './custom-rules';
+import type { CustomRules, RulesFileIssue } from './custom-rules';
 import { loadSecretlessIgnore } from './secretlessignore';
 
 /** Known API services with their auth header formats */
@@ -92,6 +92,18 @@ interface InitResult {
    * nothing is not a pass.
    */
   settingsUnusable?: { path: string; kind: SettingsUnusableKind; reason: string };
+  /**
+   * Set when `.secretless-rules.yaml` exists but part or all of it could not
+   * be honoured. 'unrecognised-content': the parser did not read some lines,
+   * so the patterns on them generate no deny rules (any lines that WERE read
+   * are still applied). 'load-error': the file was refused outright (e.g.
+   * unsafe pattern characters) and none of it was applied. Either way the
+   * operator wrote restrictions that are not in force, so `runInit` reports
+   * it and exits non-zero — silence here is the defect this field closes.
+   */
+  rulesFileProblem?:
+    | { kind: 'unrecognised-content'; issues: RulesFileIssue[] }
+    | { kind: 'load-error'; reason: string };
 }
 
 /**
@@ -186,11 +198,23 @@ function configureClaudeCode(projectDir: string, result: InitResult): void {
   // Ensure directories exist
   fs.mkdirSync(hooksDir, { recursive: true });
 
-  // Load custom rules early (needed for both hook script and deny rules)
+  // Load custom rules early (needed for both hook script and deny rules).
+  // A rules file that cannot be fully honoured is surfaced on the result, not
+  // swallowed: the previous bare catch here meant a file refused for unsafe
+  // patterns configured nothing and `init` still exited 0.
   let projectCustomRules: CustomRules | null = null;
   try {
-    projectCustomRules = loadCustomRules(projectDir);
-  } catch { /* handled later in deny rules section */ }
+    const loaded = loadCustomRulesDetailed(projectDir);
+    projectCustomRules = loaded.rules;
+    if (loaded.status === 'unrecognised-content') {
+      result.rulesFileProblem = { kind: 'unrecognised-content', issues: loaded.issues ?? [] };
+    }
+  } catch (err) {
+    result.rulesFileProblem = {
+      kind: 'load-error',
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
 
   // 1. Install (or refresh) the PreToolUse guard hook. The hook is a managed
   // file we own — older `init` only wrote it when absent, so an outdated hook


### PR DESCRIPTION
A `.secretless-rules.yaml` top-level key the parser did not recognise set `currentKey = null` and every pattern under it was silently discarded, while `loadCustomRulesDetailed` reported `status: 'loaded'` (or `'empty'`) with no diagnostic. A file written with `file:` instead of `files:`, or `Files:`, or `env: [ACME_*]` flow syntax, lost all of its deny patterns; `init` generated the agent's rules without them and exited 0. The restriction the operator wrote was reported as loaded and did not restrict — the exact class 0.23.0's release notes exist to close, live in the release's primary user-facing path.

## What changed

- `parseRulesYamlDetailed` returns every non-empty, non-comment line it did not read as a per-line issue: unknown keys get a `nearestMatch` hint (never an auto-correction — a pattern is never bound to a key or section the operator did not write), dropped patterns name the key that killed them, and flow syntax, zero-indent items, and section lines carrying comments are called out individually with line numbers.
- `LoadResult` gains `status: 'unrecognised-content'` + `issues`; rules that WERE read still load.
- `rules list` prints the unread lines and exits 1.
- `init` surfaces `rulesFileProblem` on the result, still applies what was read, renders the issues with a Verify/Fix path, and exits 1 — including the previously-swallowed path where a rules file refused for unsafe pattern characters configured nothing while `init` exited 0.
- Two adjacent holes closed: a section line with inline content now closes the open section, so the items below it can no longer attach to the previous section (shipped 0.23.0 bound `- "*.key-material"` after `files: [inline]` into `env:`, generating 5 deny rules the operator never wrote while the 8 they did write were absent); and the bare catch around the rules-file load in `init` no longer swallows refusals.
- `runRules` takes an optional `projectDir` (defaults to `process.cwd()`), and the lazy `require('../custom-rules')` calls in `src/commands/rules.ts` are now top-level imports — `cli.ts` imports the module statically, so they deferred nothing, and they do not resolve under vitest.

## Verification

- Red-proof against the shipped npm artifact `secretless-ai@0.23.0`: all 8 drop shapes reproduce — status `empty`/`loaded`, no diagnostic surface exists.
- Measurement (what the discarded rules would have blocked): per drop shape, 5–16 deny rules silently absent per file (`Read`/`Grep` + 6 Bash readers per file pattern; echo/printenv/os.environ/process.env/eval per env pattern), plus the 5 mis-bound rules above. Sweep of every reachable real install on the development machine found zero `.secretless-rules.yaml` files, so zero reachable installs were affected — bounded to that population; no telemetry exists for the wider install base.
- Full suite 1873/1873. 11 targeted mutations (issue push removed, status suppressed, hint removed, mis-binding restored, dropped-item issues silenced, init field dropped, both exit codes reverted to 0, fallthrough section-close removed, BOM strip removed, empty-item issue removed) — all killed by named tests.
- Two independent adversarial review rounds. Round 1 found 6 real defects in the first cut — the worst: an unreadable header (`files :`, tab indent, invisible-character prefix) fell through without closing the open section, so patterns below it bound to the previous section and were installed as the wrong kind of deny rule. All six fixed; round 2 re-verified each closed by execution (including an exhaustive new-shape attack that could not construct any remaining silent drop or wrong binding) with a clean regression sweep.
- CLI verified on the built artifact: `rules list` and `init` exit 1 with line-numbered diagnostics and a Verify/Fix path on affected files; clean and missing files unchanged (exit 0).

Leads 0.24.0 per the CISO release-blocker ruling of 2026-08-19 (COUNCIL_LEDGER). No version bump here — publish batching applies and other secretless work is in review.
