### PR TITLE
Rename review check to 'Automated code review'

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,5 +1,5 @@
 name: PR Review
-# Runs on every PR to main — calls the Claude API for a security-focused code review.
+# Runs on every PR to main — an automated code review (calls the Claude API).
 #
 # The gate fails CLOSED. There are three verdicts: APPROVE passes,
 # REQUEST_CHANGES fails, INCONCLUSIVE fails. Inconclusive covers a missing key,
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   review:
-    name: Claude Code Review
+    name: Automated code review
     runs-on: ubuntu-latest
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -154,12 +154,14 @@ jobs:
           # standalone because gh rejects --slurp combined with --jq.
           #
           # The login filter is the security half: any commenter who quotes
-          # "Claude Code Review" would otherwise be fed back to the model under
+          # "Automated code review" (or the pre-rename header) would otherwise
+          # be fed back to the model under
           # a PREVIOUS REVIEW heading the system prompt instructs it to trust,
           # as the gate's own prior verdict.
           gh api --paginate --slurp "repos/${{ github.repository }}/issues/$PR_NUMBER/comments?per_page=100" 2>/dev/null \
-            | jq -r '[.[][] | select(.user.login == "github-actions[bot]") | select(.body | test("Claude Code Review")) | .body] | last // ""' \
+            | jq -r '[.[][] | select(.user.login == "github-actions[bot]") | select(.body | test("Claude Code Review|Automated code review")) | .body] | last // ""' \
             | sed -e '/^## Claude Code Review/d' \
+                  -e '/^## Automated code review/d' \
                   -e '/^\*\*Verdict:.*\*\*[[:space:]]*$/d' \
                   -e '/^\*Reviewed .*\*[[:space:]]*$/d' \
                   -e '/^\*No review was produced\..*\*[[:space:]]*$/d' \
@@ -287,7 +289,7 @@ jobs:
             cat /tmp/previous_review.txt >> /tmp/user_msg.txt
           fi
 
-      - name: Run Claude review
+      - name: Run automated review
         id: review
         # The model call is shared across the org. It held three defects at once
         # — an anthropic-version the API rejected, an extraction that read only
@@ -402,7 +404,7 @@ jobs:
           esac
 
           {
-            echo "## Claude Code Review — $VERDICT"
+            echo "## Automated code review — $VERDICT"
             echo ""
             cat "$REVIEW_FILE"
             echo ""


### PR DESCRIPTION
Renames the PR review check from `Claude Code Review` to `Automated code review` — one string for the job name (which is the required status-check context) and the posted comment header (`## Automated code review — VERDICT`).

The name states what the green tick is: a machine-produced review. It is "code review", not "security review", because the check blocks on correctness and quality defects too.

**Transition mechanics** (so prior reviews are still recognized while both names exist):

- The previous-review matcher now matches either header: `test("Claude Code Review|Automated code review")`.
- The strip pipeline gains one expression, `-e '/^## Automated code review/d'`, rather than switching to `sed -E`: two sibling expressions (`\{8,\}` interval, literal `(s)`) are BRE and would silently go dead under `-E` — verified by executing the pipeline both ways.
- Both transitional branches should be removed once no open PR carries an old-name comment.

**Merge coordination — read before merging.** The job name is the required status-check context, so this PR's run reports under the NEW context and the OLD required context `Claude Code Review` will never report here. Merging requires a repo admin to update branch protection in one atomic call that replaces the contexts array — dropping the old name and adding `Automated code review` together. Never drop the old context without adding the new one in the same call: a check that is not required does not block, and the gate would silently become advisory.

The behavior of the gate is otherwise unchanged: verdict handling (APPROVE / REQUEST_CHANGES / INCONCLUSIVE, fail-closed) is untouched.
