### PR TITLE
Drop the previous-review replay from the review gate

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -145,49 +145,23 @@ jobs:
             nl -ba < "$file" >> /tmp/full_files.txt
           done 3< /tmp/changed_files.txt
 
-          # Previous review comments (for re-review awareness on synchronize).
+          # NO previous-review replay. Removed 2026-08-29. The fetch
+          # selected issue comments by
+          # `user.login == "github-actions[bot]"` plus a body substring and
+          # replayed the newest match to the model under a PREVIOUS REVIEW
+          # heading the system prompt told it to trust. That login is not a
+          # provenance guarantee: it belongs to the default workflow token, so
+          # every workflow in the repository that can comment posts under the
+          # same name. No sibling workflow here posts today, but the filter
+          # would not have told the difference, so a body built from
+          # pull-request content could arrive as the gate's own prior verdict.
           #
-          # --paginate is load-bearing: without it only the OLDEST 30 comments
-          # come back, so `last` selects the newest match within the oldest
-          # page — a superseded review replayed as if it were current. --slurp
-          # yields one array of page-arrays, hence `.[][]`, and jq runs
-          # standalone because gh rejects --slurp combined with --jq.
-          #
-          # The login filter is the security half: any commenter who quotes
-          # "Automated code review" (or the pre-rename header) would otherwise
-          # be fed back to the model under
-          # a PREVIOUS REVIEW heading the system prompt instructs it to trust,
-          # as the gate's own prior verdict.
-          gh api --paginate --slurp "repos/${{ github.repository }}/issues/$PR_NUMBER/comments?per_page=100" 2>/dev/null \
-            | jq -r '[.[][] | select(.user.login == "github-actions[bot]") | select(.body | test("Claude Code Review|Automated code review")) | .body] | last // ""' \
-            | sed -e '/^## Claude Code Review/d' \
-                  -e '/^## Automated code review/d' \
-                  -e '/^\*\*Verdict:.*\*\*[[:space:]]*$/d' \
-                  -e '/^\*Reviewed .*\*[[:space:]]*$/d' \
-                  -e '/^\*No review was produced\..*\*[[:space:]]*$/d' \
-            | head -c 4000 > /tmp/previous_review.txt || echo "" > /tmp/previous_review.txt
-
-          # The gate's OWN heading and footer are removed from what gets replayed.
-          # The comment a human reads states the verdict in its heading; that same
-          # comment is what this fetch selects, and the system prompt tells the
-          # model to trust the PREVIOUS REVIEW block and not re-raise against it.
-          # Feeding back a heading reading "— APPROVE" therefore hands the next
-          # review its own prior approval as trusted context: open a clean pull
-          # request, collect an APPROVE, then push the real change. What the model
-          # needs from a previous review is the FINDINGS, not the verdict word or
-          # the byte counts. The verdict is carried by the check conclusion, which
-          # is what actually gates the merge.
-          #
-          # The PRE-ADOPTION comment format is covered too, and that is not
-          # belt-and-braces: `pull_request` runs this workflow from the merge ref,
-          # so the moment adoption lands on main every already-open pull request
-          # runs the NEW workflow against a comment history that is still OLD. This
-          # repo's previous format emitted `**Verdict: $VERDICT**` on its own line
-          # and a footer without the `review path:` phrase, so a rule written only
-          # for the new shape would replay a legacy APPROVE on exactly the first
-          # re-review after adoption. The trailing `[[:space:]]*` before `$` is for
-          # the same reason a parser cannot govern transport: a CRLF body would
-          # otherwise slip past a bare `$` anchor.
+          # A body predicate cannot fix this — the body is entirely
+          # author-controlled, so any string rule is reproducible by the
+          # author. Signing the body would work and was rejected on value:
+          # the feature only saved the model from repeating findings across
+          # rounds, and it was paying for that by feeding attacker-influenced
+          # text to the only merge gate. Each review now stands alone.
 
       - name: Build review prompt
         # Kept local on purpose: Secretless's tech stack and review focus are its
@@ -235,9 +209,6 @@ jobs:
           - SSRF when URLs are validated against an allowlist before fetch
           - Unhandled rejections when .catch() or try/catch wraps the async call
 
-          === RE-REVIEW AWARENESS ===
-          If a PREVIOUS REVIEW section is included below, check whether each previously flagged issue has been FIXED in the current code. Do NOT re-raise issues that now have adequate mitigations. Briefly note which previous findings were addressed.
-
           === LINE NUMBERS ===
           Use line numbers from the FULL SOURCE FILES section (these are accurate). Do NOT estimate line numbers from diff hunk headers.
 
@@ -283,11 +254,6 @@ jobs:
             cat /tmp/pr_diff.txt
           } > /tmp/user_msg.txt
 
-          # Append previous review if exists
-          if [ -s /tmp/previous_review.txt ] && [ "$(wc -c < /tmp/previous_review.txt | tr -d ' ')" -gt 10 ]; then
-            printf '\n\nPREVIOUS REVIEW (check if issues were fixed — do not re-raise mitigated findings):\n' >> /tmp/user_msg.txt
-            cat /tmp/previous_review.txt >> /tmp/user_msg.txt
-          fi
 
       - name: Run automated review
         id: review


### PR DESCRIPTION
## What this changes

The review gate fetched its own past comments and replayed the newest match to the model under a
`PREVIOUS REVIEW` heading the system prompt told it to trust, selecting them by
`user.login == "github-actions[bot]"` plus a body substring.

That login is not a provenance guarantee. It belongs to the default workflow token, so every
workflow in the repository that can comment posts under the same name, and the body substring is
entirely author-controlled.

**No sibling workflow in this repository posts today** — verified: `pr-review.yml` is the only
PR-triggered workflow here holding `pull-requests: write` or calling `createComment`; every other
one is read-only. But the filter would not have told the difference. Any workflow added later that
comments with pull-request-derived content would have been replayed to the gate as its own prior
verdict, and that is exactly what happened in a sibling repository, which is why this is being
removed everywhere rather than only where it was reachable.

A body predicate cannot close it: any string rule is reproducible by the author. Signing the body
would work and was rejected on value — the feature only saved the model from repeating findings
across rounds, and it paid for that by feeding attacker-influenced text into the only merge gate.
**Each review now stands alone.**

## The trade, stated plainly

The model no longer carries findings between rounds. It cannot say which prior findings were
addressed, and an author who draws `REQUEST_CHANGES` can push no-op commits to draw fresh samples
until one approves. The verdict is still carried by the check conclusion, which is what gates the
merge.

## Verification

- **The required check still reports.** The job name is unchanged (`Automated code review`),
  verified explicitly — a changed name would permanently block every pull request in this
  repository.
- The workflow parses, and every `run:` block still passes `bash -n` after the removal.
- No step references the deleted file, and the system prompt no longer carries a dangling
  instruction to act on a section that no longer exists.

## Note on how this was reviewed

`pr-review.yml` runs from the pull request head on same-repo branches, so **this pull request is
reviewed by the gate version it introduces.** That is the self-modification gap this work exists to
close, and it cannot be escaped from inside the change. What limits it here: the change only
removes a context-gathering feature and does not touch verdict logic — `REQUEST_CHANGES → exit 1`
is untouched. The equivalent change in the sibling repository carrying the reachable instance went
through an independent adversarial review; this one is the same removal applied to a repository
where the primitive was latent rather than live.
