### PR TITLE
Make the build a precondition of the test run

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "pretest": "npm run build",
     "test": "vitest run",
     "dev": "tsc --watch",
     "clean": "rm -rf dist",


### PR DESCRIPTION
In a fresh clone, `npm ci && npm test` exits 1 with 16 failures whose message is a build
instruction, not a test failure:

```
install-wrapper: Compiled wrapper not found at .../dist/mcp-wrapper.js. Run "npm run build" first.
```

`test` was bare `vitest run` with no build step, `dist/` is gitignored, and four test files
drive the compiled wrapper (`src/argv.test.ts`, `src/mcp/e2e.test.ts`,
`src/mcp/install-wrapper.test.ts`, `src/mcp/wrapper.test.ts`). So the suite's exit code carried
no information unless the reader already knew to build first, and a contributor's first command
after `npm ci` failed on a repository whose CI is green.

A `pretest` hook makes the build a precondition. The diff is one line.

## Red first, then green — same tree, `dist/` absent in both

```
$ git checkout origin/main -- package.json && rm -rf dist && npm test
  Failed Tests 16
  Error: install-wrapper: Compiled wrapper not found at .../dist/mcp-wrapper.js.
         Run "npm run build" first.
  exit 1

$ git checkout HEAD -- package.json && rm -rf dist && npm test
  Test Files  86 passed (86)
  Tests  1891 passed (1891)
  exit 0
```

The first attempt at this proof was vacuous and is reported here rather than quietly
re-run: `dist/` still existed from an earlier build, so reverting the line still passed.
The proof above deletes `dist/` on both sides, which is the state a fresh clone is in.

## No test is hidden by this

`git diff --name-only origin/main..HEAD` is `package.json` alone — no test file is deleted,
skipped, renamed, or edited. Running the suite twice in a row succeeds both times, so the
added step is idempotent and does not depend on a clean `dist/`.

Worth knowing for anyone reading the counts: without a build the run reports
`16 failed | 1823 passed | 52 skipped`, and with one it reports `1891 passed`. The 52 skips
were conditional on the missing artifact, so they were not being exercised either.

## CI

`.github/workflows/ci.yml` already ran `npm ci` -> `npm run build` -> `npm test` in both the
gate job and the version matrix job, and runs on `main` are green. This changes CI's results in
no way; it does mean CI now runs the build twice, once explicitly and once through the hook.
Nothing in `.github/` is touched by this PR.

## Checks run

Sensitive-file scan clean; LICENSE within one line of canonical Apache-2.0; no references to
private planning artifacts in the diff or the commit message (pattern verified against a
positive control). Build exits 0. `hackmyagent secure --ci` reports 100/100 with no findings,
having analyzed 122 artifacts and read 210 files across 61 of 61 check groups. The packaged
artifact is unchanged apart from the added line (427 files both sides), and both bins run.